### PR TITLE
feat: Docker 镜像构建 + GitHub Action 多架构自动打包

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+*.md
+!README.md
+tests
+release
+.gitignore
+.gitattributes

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,60 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# ---- Stage 1: Build frontend ----
+FROM node:20-slim AS frontend
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json vite.config.ts index.html ./
+COPY src/ src/
+COPY public/ public/
+RUN npm run build
+
+# ---- Stage 2: Build backend ----
+FROM golang:1.23-bookworm AS backend
+WORKDIR /app/backend
+COPY backend/ .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o server ./cmd/server
+
+# ---- Stage 3: Runtime ----
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl tar ffmpeg openssl iproute2 \
+    python3 python3-requests python3-bs4 python3-lxml \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/video-site-91
+
+# Copy built artifacts
+COPY --from=backend /app/backend/server ./server
+COPY --from=frontend /app/dist ./dist
+COPY backend/config.example.yaml ./config.example.yaml
+COPY 91VideoSpider/ ./91VideoSpider/
+COPY install.sh ./install.sh
+
+RUN chmod +x ./server
+
+# Config via env vars (see install.sh)
+ENV VIDEO_CONFIG=/opt/video-site-91/config.yaml
+ENV VIDEO_FRONTEND_DIR=/opt/video-site-91/dist
+ENV VIDEO_VERSION_FILE=/opt/video-site-91/.version
+ENV VIDEO_GITHUB_REPO=nianzhibai/91
+
+# Data volume
+VOLUME ["/opt/video-site-91/data"]
+
+EXPOSE 9191
+
+# Generate default config on first run if missing
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["./server"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+CONFIG="/opt/video-site-91/config.yaml"
+EXAMPLE="/opt/video-site-91/config.example.yaml"
+
+# Auto-generate config from example if missing
+if [ ! -f "$CONFIG" ] && [ -f "$EXAMPLE" ]; then
+    cp "$EXAMPLE" "$CONFIG"
+    # Generate random session secret
+    SECRET=$(openssl rand -hex 32)
+    sed -i "s/session_secret: \"change-me-to-a-random-string\"/session_secret: \"$SECRET\"/" "$CONFIG"
+    # Bind to 0.0.0.0 for Docker (use FRONTEND_PORT or default 9191)
+    PORT="${FRONTEND_PORT:-9191}"
+    sed -i -E "s#listen: \".*\"#listen: \"0.0.0.0:${PORT}\"#" "$CONFIG"
+    echo "[entrypoint] Generated config.yaml with random session_secret"
+fi
+
+# Write version file if missing
+if [ ! -f /opt/video-site-91/.version ]; then
+    echo "docker-${VERSION:-latest}" > /opt/video-site-91/.version
+fi
+
+exec "$@"


### PR DESCRIPTION
## 变更内容

添加 Docker 容器化支持和 GitHub Action 自动构建。

### 新增文件

- **`Dockerfile`** — 多阶段构建：
  - Stage 1: Node 20 构建前端 (React + Vite)
  - Stage 2: Go 1.23 构建后端 (vendored 离线构建)
  - Stage 3: debian-slim 运行时 (ffmpeg + python3 + spider 依赖)
- **`docker-entrypoint.sh`** — 首次启动自动生成 config.yaml（随机 session_secret，绑定 0.0.0.0）
- **`.github/workflows/docker-build.yml`** — 推送 main/tag 时自动构建 linux/amd64 + linux/arm64 并推送到 ghcr.io
- **`.dockerignore`** — 排除 node_modules、dist、.git 等

### 使用方式

```bash
# 拉取运行
docker run -d \
  -p 9191:9191 \
  -v video-data:/opt/video-site-91/data \
  ghcr.io/thazjswe42700/91:latest

# 自定义端口
docker run -d \
  -e FRONTEND_PORT=8080 \
  -p 8080:8080 \
  -v video-data:/opt/video-site-91/data \
  ghcr.io/thazjswe42700/91:latest
```

首次访问后台 `/admin` 时设置管理员账号。配置和数据通过 volume 持久化。