### PR TITLE
feat: 添加扫描文件大小过滤

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1003,13 +1003,14 @@ func (a *App) runScan(ctx context.Context, driveID string) {
 		return
 	}
 	sc := scanner.New(a.cat, drv, a.cfg.Scanner.VideoExtensions, d.SkipDirIDs, onNew)
+	sc.MinFileSizeBytes = d.MinScanFileSizeBytes
 
 	startID := d.ScanRootID
 	if startID == "" {
 		startID = d.RootID
 	}
 
-	log.Printf("[scan] drive=%s start=%s skip_dirs=%d", driveID, startID, len(d.SkipDirIDs))
+	log.Printf("[scan] drive=%s start=%s skip_dirs=%d min_size=%d", driveID, startID, len(d.SkipDirIDs), d.MinScanFileSizeBytes)
 	stats, err := sc.Run(ctx, startID)
 	if err != nil {
 		log.Printf("[scan] drive=%s error: %v", driveID, err)

--- a/backend/internal/api/admin.go
+++ b/backend/internal/api/admin.go
@@ -103,6 +103,7 @@ func (a *AdminServer) Register(r chi.Router) {
 			r.Post("/drives/{id}/rescan", a.handleRescan)
 			r.Post("/drives/{id}/teaser-enabled", a.handleSetDriveTeaserEnabled)
 			r.Post("/drives/{id}/skip-dirs", a.handleSetDriveSkipDirs)
+			r.Post("/drives/{id}/scan-filter", a.handleSetDriveScanFilter)
 			r.Get("/drives/{id}/dirtree", a.handleListDriveDirTree)
 			r.Post("/drives/{id}/previews/failed/regenerate", a.handleRegenFailedPreviews)
 			r.Post("/drives/{id}/thumbnails/failed/regenerate", a.handleRegenFailedThumbnails)
@@ -366,6 +367,8 @@ func (a *AdminServer) handleListDrives(w http.ResponseWriter, r *http.Request) {
 		// 前端用它在"设置跳过目录"弹窗里回显已选项；JSON 字段名 camelCase 与
 		// catalog.Drive 保持一致。
 		SkipDirIDs []string `json:"skipDirIds"`
+		// MinScanFileSizeBytes 是扫描入库的最小文件大小阈值；0 表示关闭大小过滤。
+		MinScanFileSizeBytes int64 `json:"minScanFileSizeBytes"`
 		// LastCrawlAt 是 spider91 上次成功爬取的 unix 秒（来自 credentials.last_crawl_at）。
 		// 其它 kind 留 0；前端用它显示"上次抓取: N 小时前"。
 		LastCrawlAt               int64            `json:"lastCrawlAt,omitempty"`
@@ -417,6 +420,7 @@ func (a *AdminServer) handleListDrives(w http.ResponseWriter, r *http.Request) {
 			HasCredential:             hasCred,
 			TeaserEnabled:             d.TeaserEnabled,
 			SkipDirIDs:                append([]string{}, d.SkipDirIDs...),
+			MinScanFileSizeBytes:      d.MinScanFileSizeBytes,
 			LastCrawlAt:               lastCrawlAt,
 			ThumbnailGenerationStatus: generation.Thumbnail,
 			PreviewGenerationStatus:   generation.Preview,
@@ -446,6 +450,8 @@ type upsertDriveReq struct {
 	// 推荐前端"设置跳过目录"走专用 POST /drives/{id}/skip-dirs；
 	// 这里支持是为了允许批量编辑场景一次性提交。
 	SkipDirIDs *[]string `json:"skipDirIds,omitempty"`
+	// MinScanFileSizeBytes 同样支持"未传 = 沿用旧值"；新建时默认 0。
+	MinScanFileSizeBytes *int64 `json:"minScanFileSizeBytes,omitempty"`
 }
 
 func (a *AdminServer) handleUpsertDrive(w http.ResponseWriter, r *http.Request) {
@@ -491,13 +497,26 @@ func (a *AdminServer) handleUpsertDrive(w http.ResponseWriter, r *http.Request) 
 		skipDirIDs = existing.SkipDirIDs
 	}
 
+	minScanFileSizeBytes := int64(0)
+	switch {
+	case body.MinScanFileSizeBytes != nil:
+		minScanFileSizeBytes = *body.MinScanFileSizeBytes
+	case existing != nil:
+		minScanFileSizeBytes = existing.MinScanFileSizeBytes
+	}
+	if minScanFileSizeBytes < 0 {
+		http.Error(w, "minScanFileSizeBytes must be >= 0", http.StatusBadRequest)
+		return
+	}
+
 	d := &catalog.Drive{
 		ID: body.ID, Kind: body.Kind, Name: body.Name,
 		RootID: body.RootID, ScanRootID: body.ScanRootID,
-		Credentials:   body.Credentials,
-		Status:        "disconnected",
-		TeaserEnabled: teaserEnabled,
-		SkipDirIDs:    skipDirIDs,
+		Credentials:          body.Credentials,
+		Status:               "disconnected",
+		TeaserEnabled:        teaserEnabled,
+		SkipDirIDs:           skipDirIDs,
+		MinScanFileSizeBytes: minScanFileSizeBytes,
 	}
 	if err := a.Catalog.UpsertDrive(r.Context(), d); err != nil {
 		writeErr(w, http.StatusInternalServerError, err)
@@ -632,6 +651,44 @@ func (a *AdminServer) handleSetDriveSkipDirs(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "skipDirIds": cleaned})
+}
+
+// scanFilterReq 是 POST /admin/api/drives/{id}/scan-filter 的入参。
+type scanFilterReq struct {
+	MinFileSizeBytes int64 `json:"minFileSizeBytes"`
+}
+
+// handleSetDriveScanFilter 更新某盘的扫描过滤阈值。
+//
+// minFileSizeBytes=0 表示关闭大小过滤。设置后不会立即触发扫描；下次扫描时，小于
+// 阈值的视频文件不会入库，也不会进入 SeenFileIDs，完整扫描会顺带清理既有小文件记录。
+func (a *AdminServer) handleSetDriveScanFilter(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+	var body scanFilterReq
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if body.MinFileSizeBytes < 0 {
+		http.Error(w, "minFileSizeBytes must be >= 0", http.StatusBadRequest)
+		return
+	}
+	if err := a.Catalog.SetDriveMinScanFileSizeBytes(r.Context(), id, body.MinFileSizeBytes); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "drive not found", http.StatusNotFound)
+			return
+		}
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":               true,
+		"minFileSizeBytes": body.MinFileSizeBytes,
+	})
 }
 
 // handleListDriveDirTree 列出某 drive 在指定父目录下的直接子目录。

--- a/backend/internal/api/admin_test.go
+++ b/backend/internal/api/admin_test.go
@@ -250,6 +250,49 @@ func TestHandleUpsertDrivePreservesExistingCredentialsWhenRequestCredentialsEmpt
 	}
 }
 
+func TestHandleUpsertDrivePreservesExistingMinScanFileSizeWhenOmitted(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cat.Close(); err != nil {
+			t.Fatalf("close catalog: %v", err)
+		}
+	})
+
+	if err := cat.UpsertDrive(ctx, &catalog.Drive{
+		ID: "p115-main", Kind: "p115", Name: "115", RootID: "0", Status: "ok",
+		MinScanFileSizeBytes: 150 * 1024 * 1024,
+	}); err != nil {
+		t.Fatalf("seed drive: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/drives", strings.NewReader(`{
+		"id": "p115-main",
+		"kind": "p115",
+		"name": "115 renamed",
+		"rootId": "0",
+		"scanRootId": "0",
+		"credentials": {}
+	}`))
+	rr := httptest.NewRecorder()
+
+	(&AdminServer{Catalog: cat}).handleUpsertDrive(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	got, err := cat.GetDrive(ctx, "p115-main")
+	if err != nil {
+		t.Fatalf("get drive: %v", err)
+	}
+	if got.MinScanFileSizeBytes != 150*1024*1024 {
+		t.Fatalf("min scan size = %d, want 150MiB", got.MinScanFileSizeBytes)
+	}
+}
+
 func TestHandleUpsertDriveReplacesExistingCredentialsWhenProvided(t *testing.T) {
 	ctx := context.Background()
 	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
@@ -297,6 +340,41 @@ func TestHandleUpsertDriveReplacesExistingCredentialsWhenProvided(t *testing.T) 
 	}
 	if got.Credentials["cookie"] != "new-cookie" {
 		t.Fatalf("cookie credential = %q, want new-cookie", got.Credentials["cookie"])
+	}
+}
+
+func TestHandleSetDriveScanFilter(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cat.Close(); err != nil {
+			t.Fatalf("close catalog: %v", err)
+		}
+	})
+	if err := cat.UpsertDrive(ctx, &catalog.Drive{ID: "p115-main", Kind: "p115", Name: "115", RootID: "0"}); err != nil {
+		t.Fatalf("seed drive: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/drives/p115-main/scan-filter", strings.NewReader(`{"minFileSizeBytes":104857600}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "p115-main")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+
+	(&AdminServer{Catalog: cat}).handleSetDriveScanFilter(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	got, err := cat.GetDrive(ctx, "p115-main")
+	if err != nil {
+		t.Fatalf("get drive: %v", err)
+	}
+	if got.MinScanFileSizeBytes != 104857600 {
+		t.Fatalf("min scan size = %d, want 104857600", got.MinScanFileSizeBytes)
 	}
 }
 

--- a/backend/internal/catalog/catalog.go
+++ b/backend/internal/catalog/catalog.go
@@ -1151,9 +1151,11 @@ type Drive struct {
 	// scanner 在 walk 时命中其中任意一个就直接 continue —— 不递归、不收集文件，也
 	// 不参与 stats 统计。替代旧版硬编码"影视"目录的特例分支。
 	// 含义按"目录 ID 自身"匹配，所以同名目录在不同父级下需要分别选定。
-	SkipDirIDs []string  `json:"skipDirIds,omitempty"`
-	CreatedAt  time.Time `json:"createdAt"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	SkipDirIDs []string `json:"skipDirIds,omitempty"`
+	// MinScanFileSizeBytes 是扫描入库的最小文件大小阈值；0 表示关闭大小过滤。
+	MinScanFileSizeBytes int64     `json:"minScanFileSizeBytes"`
+	CreatedAt            time.Time `json:"createdAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
 }
 
 func (c *Catalog) UpsertDrive(ctx context.Context, d *Drive) error {
@@ -1162,6 +1164,9 @@ func (c *Catalog) UpsertDrive(ctx context.Context, d *Drive) error {
 	if skipDirs == nil {
 		skipDirs = []string{}
 	}
+	if d.MinScanFileSizeBytes < 0 {
+		d.MinScanFileSizeBytes = 0
+	}
 	skipDirsJSON, _ := json.Marshal(skipDirs)
 	now := time.Now().UnixMilli()
 	if d.CreatedAt.IsZero() {
@@ -1169,26 +1174,27 @@ func (c *Catalog) UpsertDrive(ctx context.Context, d *Drive) error {
 	}
 	d.UpdatedAt = time.UnixMilli(now)
 	_, err := c.db.ExecContext(ctx, `
-INSERT INTO drives (id, kind, name, root_id, scan_root_id, credentials, status, last_error, teaser_enabled, skip_dir_ids, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO drives (id, kind, name, root_id, scan_root_id, credentials, status, last_error, teaser_enabled, skip_dir_ids, min_scan_file_size_bytes, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
-  kind           = excluded.kind,
-  name           = excluded.name,
-  root_id        = excluded.root_id,
-  scan_root_id   = excluded.scan_root_id,
-  credentials    = excluded.credentials,
-  status         = excluded.status,
-  last_error     = excluded.last_error,
-  teaser_enabled = excluded.teaser_enabled,
-  skip_dir_ids   = excluded.skip_dir_ids,
-  updated_at     = excluded.updated_at
-`, d.ID, d.Kind, d.Name, d.RootID, d.ScanRootID, string(cred), d.Status, d.LastError, boolToInt(d.TeaserEnabled), string(skipDirsJSON),
+  kind                     = excluded.kind,
+  name                     = excluded.name,
+  root_id                  = excluded.root_id,
+  scan_root_id             = excluded.scan_root_id,
+  credentials              = excluded.credentials,
+  status                   = excluded.status,
+  last_error               = excluded.last_error,
+  teaser_enabled           = excluded.teaser_enabled,
+  skip_dir_ids             = excluded.skip_dir_ids,
+  min_scan_file_size_bytes = excluded.min_scan_file_size_bytes,
+  updated_at               = excluded.updated_at
+`, d.ID, d.Kind, d.Name, d.RootID, d.ScanRootID, string(cred), d.Status, d.LastError, boolToInt(d.TeaserEnabled), string(skipDirsJSON), d.MinScanFileSizeBytes,
 		d.CreatedAt.UnixMilli(), d.UpdatedAt.UnixMilli())
 	return err
 }
 
 func (c *Catalog) ListDrives(ctx context.Context) ([]*Drive, error) {
-	rows, err := c.db.QueryContext(ctx, `SELECT id, kind, name, root_id, COALESCE(scan_root_id, ''), COALESCE(credentials, '{}'), status, COALESCE(last_error, ''), COALESCE(teaser_enabled, 1), COALESCE(skip_dir_ids, '[]'), created_at, updated_at FROM drives ORDER BY created_at ASC`)
+	rows, err := c.db.QueryContext(ctx, `SELECT id, kind, name, root_id, COALESCE(scan_root_id, ''), COALESCE(credentials, '{}'), status, COALESCE(last_error, ''), COALESCE(teaser_enabled, 1), COALESCE(skip_dir_ids, '[]'), COALESCE(min_scan_file_size_bytes, 0), created_at, updated_at FROM drives ORDER BY created_at ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -1199,7 +1205,7 @@ func (c *Catalog) ListDrives(ctx context.Context) ([]*Drive, error) {
 		var credsStr, skipDirsStr string
 		var teaserEnabled int
 		var createdAt, updatedAt int64
-		if err := rows.Scan(&d.ID, &d.Kind, &d.Name, &d.RootID, &d.ScanRootID, &credsStr, &d.Status, &d.LastError, &teaserEnabled, &skipDirsStr, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&d.ID, &d.Kind, &d.Name, &d.RootID, &d.ScanRootID, &credsStr, &d.Status, &d.LastError, &teaserEnabled, &skipDirsStr, &d.MinScanFileSizeBytes, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
 		_ = json.Unmarshal([]byte(credsStr), &d.Credentials)
@@ -1213,12 +1219,12 @@ func (c *Catalog) ListDrives(ctx context.Context) ([]*Drive, error) {
 }
 
 func (c *Catalog) GetDrive(ctx context.Context, id string) (*Drive, error) {
-	row := c.db.QueryRowContext(ctx, `SELECT id, kind, name, root_id, COALESCE(scan_root_id, ''), COALESCE(credentials, '{}'), status, COALESCE(last_error, ''), COALESCE(teaser_enabled, 1), COALESCE(skip_dir_ids, '[]'), created_at, updated_at FROM drives WHERE id = ?`, id)
+	row := c.db.QueryRowContext(ctx, `SELECT id, kind, name, root_id, COALESCE(scan_root_id, ''), COALESCE(credentials, '{}'), status, COALESCE(last_error, ''), COALESCE(teaser_enabled, 1), COALESCE(skip_dir_ids, '[]'), COALESCE(min_scan_file_size_bytes, 0), created_at, updated_at FROM drives WHERE id = ?`, id)
 	d := &Drive{}
 	var credsStr, skipDirsStr string
 	var teaserEnabled int
 	var createdAt, updatedAt int64
-	if err := row.Scan(&d.ID, &d.Kind, &d.Name, &d.RootID, &d.ScanRootID, &credsStr, &d.Status, &d.LastError, &teaserEnabled, &skipDirsStr, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(&d.ID, &d.Kind, &d.Name, &d.RootID, &d.ScanRootID, &credsStr, &d.Status, &d.LastError, &teaserEnabled, &skipDirsStr, &d.MinScanFileSizeBytes, &createdAt, &updatedAt); err != nil {
 		return nil, err
 	}
 	_ = json.Unmarshal([]byte(credsStr), &d.Credentials)
@@ -1279,6 +1285,28 @@ func (c *Catalog) SetDriveSkipDirIDs(ctx context.Context, id string, ids []strin
 	res, err := c.db.ExecContext(ctx,
 		`UPDATE drives SET skip_dir_ids = ?, updated_at = ? WHERE id = ?`,
 		string(payload), time.Now().UnixMilli(), id)
+	if err != nil {
+		return err
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// SetDriveMinScanFileSizeBytes 重写某盘的最小扫描文件大小阈值。
+//
+// bytes <= 0 等价于关闭大小过滤。drive 不存在时返回 sql.ErrNoRows。
+func (c *Catalog) SetDriveMinScanFileSizeBytes(ctx context.Context, id string, bytes int64) error {
+	if id == "" {
+		return fmt.Errorf("catalog: set drive min_scan_file_size_bytes: empty id")
+	}
+	if bytes < 0 {
+		bytes = 0
+	}
+	res, err := c.db.ExecContext(ctx,
+		`UPDATE drives SET min_scan_file_size_bytes = ?, updated_at = ? WHERE id = ?`,
+		bytes, time.Now().UnixMilli(), id)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/catalog/schema.sql
+++ b/backend/internal/catalog/schema.sql
@@ -78,6 +78,9 @@ CREATE TABLE IF NOT EXISTS drives (
     -- 全部子目录都不会被递归扫描，也不会进入 SeenFileIDs / VisitedDirIDs 统计。
     -- 替代了早期硬编码"影视"目录的特例分支。
     skip_dir_ids  TEXT NOT NULL DEFAULT '[]',
+    -- 扫描入库的最小视频文件大小；0 表示不按大小过滤。
+    -- 小于该值的文件不会入库，用来过滤下载目录里夹带的广告小视频。
+    min_scan_file_size_bytes INTEGER NOT NULL DEFAULT 0,
     created_at    INTEGER NOT NULL,
     updated_at    INTEGER NOT NULL
 );

--- a/backend/internal/catalog/tags.go
+++ b/backend/internal/catalog/tags.go
@@ -74,6 +74,11 @@ func (c *Catalog) migrate(ctx context.Context) error {
 	if err := c.addColumnIfMissing(ctx, "drives", "skip_dir_ids", "TEXT NOT NULL DEFAULT '[]'"); err != nil {
 		return err
 	}
+	// drives.min_scan_file_size_bytes：每盘扫描入库的最小文件大小阈值。默认 0
+	// 保持旧行为；用户可设为如 100MB，用来过滤下载目录里的广告小视频。
+	if err := c.addColumnIfMissing(ctx, "drives", "min_scan_file_size_bytes", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
 	// 一次性修正：早期版本（短暂存在过）会把现存 drive 的 teaser_enabled 同步成
 	// 旧的全局 preview.enabled 值，导致升级后所有 drive 都是关。"默认开启"约定下，
 	// 这里一次性把所有 drive 强制重置为 1，并用 marker setting 记号，避免之后

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -23,6 +23,10 @@ type Scanner struct {
 	//
 	// nil / 空集合 → 行为等同于不跳过任何目录。
 	SkipDirIDs map[string]struct{}
+	// MinFileSizeBytes 是扫描入库的最小文件大小阈值。0 表示关闭大小过滤。
+	// 小于该值的视频文件不会进入 SeenFileIDs，因此下一次完整扫描会把既有小文件
+	// 元数据当作不再可见并清理掉。
+	MinFileSizeBytes int64
 	// 回调：新视频被加入后触发 teaser 生成
 	OnNewVideo func(v *catalog.Video)
 	// ProgressInterval 控制扫描内部 heartbeat 的最小输出间隔。
@@ -149,6 +153,9 @@ func (s *Scanner) walk(ctx context.Context, dirID, dirName string, stats *Stats,
 			continue
 		}
 		if e.Size <= 0 {
+			continue
+		}
+		if s.MinFileSizeBytes > 0 && e.Size < s.MinFileSizeBytes {
 			continue
 		}
 		stats.SeenFileIDs[e.ID] = struct{}{}

--- a/backend/internal/scanner/scanner_test.go
+++ b/backend/internal/scanner/scanner_test.go
@@ -90,6 +90,48 @@ func TestRunIgnoresZeroSizeVideoFiles(t *testing.T) {
 	}
 }
 
+func TestRunSkipsVideoFilesBelowMinSize(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cat.Close(); err != nil {
+			t.Fatalf("close catalog: %v", err)
+		}
+	})
+
+	drv := &scannerFakeDrive{
+		entries: []drives.Entry{
+			{ID: "ad-file", Name: "ad.mp4", Size: 99},
+			{ID: "movie-file", Name: "movie.mp4", Size: 100},
+		},
+	}
+	sc := New(cat, drv, []string{".mp4"}, nil, nil)
+	sc.MinFileSizeBytes = 100
+
+	stats, err := sc.Run(ctx, "")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if stats.Added != 1 {
+		t.Fatalf("added = %d, want only file meeting min size", stats.Added)
+	}
+	if _, ok := stats.SeenFileIDs["ad-file"]; ok {
+		t.Fatalf("seen file ids = %#v, want small file excluded", stats.SeenFileIDs)
+	}
+	if _, ok := stats.SeenFileIDs["movie-file"]; !ok {
+		t.Fatalf("seen file ids = %#v, want movie-file", stats.SeenFileIDs)
+	}
+	if _, err := cat.GetVideo(ctx, "fake-drive-ad-file"); err != sql.ErrNoRows {
+		t.Fatalf("small video lookup error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := cat.GetVideo(ctx, "fake-drive-movie-file"); err != nil {
+		t.Fatalf("movie video was not added: %v", err)
+	}
+}
+
 func TestRunBackfillsRemoteThumbnailForExistingVideo(t *testing.T) {
 	ctx := context.Background()
 	cat, err := catalog.Open(t.TempDir() + "/catalog.db")

--- a/src/admin/DrivesPage.tsx
+++ b/src/admin/DrivesPage.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ChevronRight,
   Download,
+  Filter,
   FolderTree,
   HardDrive,
   PlayCircle,
@@ -411,19 +412,34 @@ export function DrivesPage() {
 
             {/* 如果不是爬虫网盘，内嵌显示跳过目录设置 */}
             {d.kind !== "spider91" && (
-              <SkipDirsPanel
-                drive={d}
-                onSaved={(saved) => {
-                  setList((prev) =>
-                    prev.map((item) =>
-                      item.id === saved.id
-                        ? { ...item, skipDirIds: saved.skipDirIds }
-                        : item
-                    )
-                  );
-                  refreshDriveList();
-                }}
-              />
+              <>
+                <ScanSizeFilterPanel
+                  drive={d}
+                  onSaved={(saved) => {
+                    setList((prev) =>
+                      prev.map((item) =>
+                        item.id === saved.id
+                          ? { ...item, minScanFileSizeBytes: saved.minScanFileSizeBytes }
+                          : item
+                      )
+                    );
+                    refreshDriveList();
+                  }}
+                />
+                <SkipDirsPanel
+                  drive={d}
+                  onSaved={(saved) => {
+                    setList((prev) =>
+                      prev.map((item) =>
+                        item.id === saved.id
+                          ? { ...item, skipDirIds: saved.skipDirIds }
+                          : item
+                      )
+                    );
+                    refreshDriveList();
+                  }}
+                />
+              </>
             )}
           </div>
 
@@ -1118,6 +1134,86 @@ function defaultRootId(kind: Kind): string {
   if (kind === "onedrive") return "root";
   if (kind === "spider91") return "/";
   return "0";
+}
+
+function bytesToMBInput(bytes: number | undefined): string {
+  const n = bytes ?? 0;
+  if (n <= 0) return "";
+  return (n / 1024 / 1024).toFixed(2).replace(/\.?0+$/, "");
+}
+
+type ScanSizeFilterPanelProps = {
+  drive: api.AdminDrive;
+  onSaved: (saved: { id: string; minScanFileSizeBytes: number }) => void;
+};
+
+function ScanSizeFilterPanel({ drive, onSaved }: ScanSizeFilterPanelProps) {
+  const { show } = useToast();
+  const [input, setInput] = useState(() => bytesToMBInput(drive.minScanFileSizeBytes));
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setInput(bytesToMBInput(drive.minScanFileSizeBytes));
+  }, [drive.id, drive.minScanFileSizeBytes]);
+
+  async function handleSave() {
+    const raw = input.trim();
+    const mb = raw === "" ? 0 : Number(raw);
+    if (!Number.isFinite(mb) || mb < 0) {
+      show("最小文件大小必须是大于等于 0 的数字", "error");
+      return;
+    }
+    const minFileSizeBytes = Math.round(mb * 1024 * 1024);
+    setSaving(true);
+    try {
+      const resp = await api.setDriveScanFilter(drive.id, minFileSizeBytes);
+      onSaved({ id: drive.id, minScanFileSizeBytes: resp.minFileSizeBytes });
+      show("扫描过滤已保存", "success");
+    } catch (e) {
+      show(e instanceof Error ? e.message : "保存失败", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const current = drive.minScanFileSizeBytes ?? 0;
+
+  return (
+    <div className="admin-detail-card">
+      <header className="admin-detail-card__title">
+        <div className="admin-detail-card__title-left">
+          <Filter size={16} />
+          <span>扫描文件大小过滤</span>
+        </div>
+        <button
+          className="admin-btn is-primary"
+          onClick={handleSave}
+          disabled={saving}
+          style={{ padding: "4px 10px", fontSize: "12px", height: "auto" }}
+        >
+          {saving ? "保存中..." : "保存更改"}
+        </button>
+      </header>
+
+      <div className="admin-form" style={{ maxWidth: "none" }}>
+        <div className="admin-form__row">
+          <label>最小文件大小 (MB)</label>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="0"
+          />
+          <div className="admin-form__help">
+            0 表示不过滤；小于该大小的视频文件会在下次扫描时跳过。当前值：
+            {current > 0 ? formatBytes(current) : "未启用"}。
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -92,6 +92,8 @@ export type AdminDrive = {
    * 替代旧版硬编码 p115 "影视" 目录例外分支。
    */
   skipDirIds: string[];
+  /** 扫描入库的最小文件大小阈值。0 表示不按大小过滤。 */
+  minScanFileSizeBytes: number;
   // spider91 上次成功爬取时间（unix 秒）；其它 kind 留空。
   lastCrawlAt?: number;
   thumbnailGenerationStatus?: DriveGenerationStatus;
@@ -144,6 +146,8 @@ export type UpsertDriveInput = {
    * 这里允许同时上传是为了批量编辑场景。
    */
   skipDirIds?: string[];
+  /** 可选：最小扫描文件大小阈值，单位 bytes。undefined 表示不变。 */
+  minScanFileSizeBytes?: number;
 };
 
 export function upsertDrive(body: UpsertDriveInput) {
@@ -215,6 +219,19 @@ export function setDriveSkipDirIds(id: string, dirIds: string[]) {
     {
       method: "POST",
       body: JSON.stringify({ dirIds }),
+    }
+  );
+}
+
+/**
+ * 设置扫描入库的最小文件大小阈值。0 表示关闭大小过滤。
+ */
+export function setDriveScanFilter(id: string, minFileSizeBytes: number) {
+  return request<{ ok: boolean; minFileSizeBytes: number }>(
+    `/drives/${encodeURIComponent(id)}/scan-filter`,
+    {
+      method: "POST",
+      body: JSON.stringify({ minFileSizeBytes }),
     }
   );
 }


### PR DESCRIPTION
## 变更内容

新增按驱动配置的扫描最小文件大小过滤，用于自动跳过广告小视频等无效文件。

### 功能说明

- 后台驱动详情页新增“最小文件大小 (MB)”配置，0 表示不过滤
- 扫描时小于阈值的视频文件不会入库
- 已入库但再次完整扫描时不满足阈值的视频记录会自动从媒体库移除
- 只清理数据库记录和本地生成的预览/缩略图缓存，不删除网盘或源目录里的视频文件

### 后端变更

- 为 drives 增加 min_scan_file_size_bytes 字段和迁移
- scanner 支持 MinFileSizeBytes 过滤
- 新增/扩展管理 API 读写扫描大小过滤配置

### 测试

- npm run lint
- npm test
- go test ./internal/scanner ./internal/catalog ./internal/api ./cmd/server