### PR TITLE
fix: remove extra margin-right on logout button icon

### DIFF
--- a/src/admin/AdminLayout.tsx
+++ b/src/admin/AdminLayout.tsx
@@ -110,7 +110,7 @@ export function AdminLayout() {
             {checkingUpdate ? "检查中" : "检查更新"}
           </button>
           <button className="admin-sidebar__logout" onClick={handleLogout}>
-            <LogOut size={14} style={{ verticalAlign: -2, marginRight: 4 }} />
+            <LogOut size={14} />
             退出登录
           </button>
         </div>


### PR DESCRIPTION
## Summary

移除"退出登录"按钮 `<LogOut>` icon 上的内联 `marginRight: 4` 样式。

## Root Cause

`AdminLayout.tsx` 中退出登录按钮的 `<LogOut>` 有内联 `style={{ verticalAlign: -2, marginRight: 4 }}`，而 CSS `.admin-sidebar__logout` 已通过 `display: inline-flex` + `gap: 6px` 统一控制 icon 与文字间距。内联 `marginRight` 叠加在 `gap` 之上，导致实际间距变为 10px，icon 起点被向右推移，无法与上方"检查更新"按钮左对齐。

## Fix

移除内联 style，两个按钮统一由 CSS flex gap 控制间距。

```diff
- <LogOut size={14} style={{ verticalAlign: -2, marginRight: 4 }} />
+ <LogOut size={14} />
```

## Verification

- ✅ TypeScript 编译（`tsc --noEmit`）无错误
- ✅ 22/22 测试全部通过
- ✅ Vite 生产构建成功

Closes #11