### PR TITLE
fix: debounce scan-all button and deduplicate toast notifications

### DIFF
--- a/src/admin/DrivesPage.tsx
+++ b/src/admin/DrivesPage.tsx
@@ -79,6 +79,7 @@ export function DrivesPage() {
   const [regenFailedThumbId, setRegenFailedThumbId] = useState("");
   // togglingTeaserId 在请求未返回前禁用按钮，避免连点导致两次切换互相覆盖。
   const [togglingTeaserId, setTogglingTeaserId] = useState("");
+  const [scanningAll, setScanningAll] = useState(false);
   const [selectedDriveId, setSelectedDriveId] = useState<string | null>(null);
   const { show } = useToast();
 
@@ -237,11 +238,14 @@ export function DrivesPage() {
    * 如果当前已有流水线在跑，后端最多保留一个待触发请求，当前轮结束后再跑一轮。
    */
   async function handleRunNightly() {
+    setScanningAll(true);
     try {
       await api.runNightlyJob();
       show("已触发扫描所有网盘，耗时较长，可在 backend 日志观察进度", "success");
     } catch (e) {
       show(e instanceof Error ? e.message : "触发失败", "error");
+    } finally {
+      setScanningAll(false);
     }
   }
 
@@ -588,9 +592,10 @@ export function DrivesPage() {
             type="button"
             className="admin-btn"
             onClick={handleRunNightly}
+            disabled={scanningAll}
             title="立即扫描所有网盘。耗时较长，期间不要重复触发。"
           >
-            <PlayCircle size={14} /> 扫描所有网盘
+            <PlayCircle size={14} /> {scanningAll ? "扫描中…" : "扫描所有网盘"}
           </button>
           <button className="admin-btn is-primary" onClick={openCreate}>
             <Plus size={14} /> 新建网盘

--- a/src/admin/ToastContext.tsx
+++ b/src/admin/ToastContext.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -18,13 +19,25 @@ const ToastCtx = createContext<Ctx | null>(null);
 
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<Toast[]>([]);
+  const timers = useRef<Record<string, ReturnType<typeof window.setTimeout>>>({});
 
+  // Deduplicate: same text won't stack, just resets the dismiss timer
   const show = useCallback((text: string, kind: ToastKind = "info") => {
+    // Reset timer if duplicate
+    if (timers.current[text]) {
+      window.clearTimeout(timers.current[text]);
+      timers.current[text] = window.setTimeout(() => {
+        setItems((list) => list.filter((t) => t.text !== text));
+        delete timers.current[text];
+      }, 2600);
+      return;
+    }
     const id = Date.now() + Math.random();
-    setItems((list) => [...list, { id, kind, text }]);
-    window.setTimeout(() => {
+    timers.current[text] = window.setTimeout(() => {
       setItems((list) => list.filter((t) => t.id !== id));
+      delete timers.current[text];
     }, 2600);
+    setItems((list) => [...list, { id, kind, text }]);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

修复"扫描所有网盘"按钮可被连击重复触发的问题，以及 Toast 通知无限叠加的问题。

## Changes

### 1. 按钮防重复触发（DrivesPage.tsx）
- 新增 `scanningAll` 状态，请求期间禁用按钮并显示"扫描中…"
- 请求结束后恢复，`finally` 块保证异常时也会解锁

### 2. Toast 去重（ToastContext.tsx）
- `show()` 用 `useRef<Map>` 按文本去重：相同文本的 toast 不会重复添加，只重置 dismiss timer
- 防止用户连击时右下角堆满重复提示导致页面卡顿

## Verification

- ✅ TypeScript 编译无错误
- ✅ 22/22 测试通过
- ✅ Vite 生产构建成功
- ✅ CSS 已有 `.admin-btn:disabled` 样式（opacity: 0.45 + cursor: not-allowed）

Closes #13