### PR TITLE
fix: render short videos on iOS (black screen in short-video mode)

### DIFF
--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -2,8 +2,14 @@
    滚动靠原生 scroll-snap 实现 TikTok 式吸附切屏。 */
 
 .shorts-page {
-  position: fixed;
-  inset: 0;
+  /* 不能用 fixed 定位：iOS Safari/WebKit 不会合成（渲染）嵌套在 fixed
+     祖先里的内联 <video>，视频能解码播放但画面始终不显示（黑屏）。
+     桌面 Chrome 正常，所以只在 iOS 上表现为黑屏。
+     这里改用普通流里的满屏块（高度锁视口），沉浸态的滚动锁定已由组件在
+     mount 时给 html/body 设置 overflow:hidden 实现，效果等价。 */
+  position: relative;
+  width: 100%;
+  height: 100svh;
   background: #000;
   color: #fff;
   z-index: 50;
@@ -16,6 +22,17 @@
   user-select: none;
   /* 防止移动端在边缘滑动触发"上一页"导航 */
   overscroll-behavior: none;
+}
+
+@supports not (height: 100svh) {
+  .shorts-page {
+    height: 100dvh;
+  }
+}
+@supports not (height: 100dvh) {
+  .shorts-page {
+    height: 100vh;
+  }
 }
 
 /* ---------- 顶部条 (高阶毛玻璃渐变遮罩) ---------- */

--- a/tests/shortsIosVideoCompositing.test.ts
+++ b/tests/shortsIosVideoCompositing.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const shortsCss = readFileSync(
+  new URL("../src/styles/shorts.css", import.meta.url),
+  "utf8"
+);
+
+// iOS Safari/WebKit does not composite an inline <video> nested inside a
+// `position: fixed` ancestor — the video decodes and plays but never paints
+// (black screen on iOS only). The shorts page wrapper must therefore not be
+// position:fixed; it locks the viewport via html/body overflow + 100svh height.
+test("shorts page wrapper is not position:fixed (breaks iOS <video> compositing)", () => {
+  const pageRule = /\.shorts-page \{[\s\S]*?\}/.exec(shortsCss);
+  assert.ok(pageRule, ".shorts-page rule should exist");
+  assert.doesNotMatch(pageRule[0], /position:\s*fixed/);
+  assert.match(pageRule[0], /position:\s*relative/);
+  assert.match(pageRule[0], /height:\s*100svh/);
+});


### PR DESCRIPTION
Fixes #52

## Problem
Short-video mode shows a black screen on iOS (Safari/WebKit) while working fine on desktop. The video data loads, the element decodes and plays (currentTime advances, frames are drawable to a canvas), but the video never paints.

## Root cause
iOS WebKit does not composite an inline `<video>` nested inside a `position: fixed` ancestor — its hardware layer is decoded but never rendered. `.shorts-page` used `position: fixed; inset: 0`, which traps every shorts video. Desktop Chrome composites it regardless, hence desktop-only-working.

Narrowed on-device: server logs confirmed data loaded and detail-page playback worked on the same phone (rules out backend/codec); the DOM showed the video fully decoded/playing/visible-by-CSS (rules out data/layout); a canvas draw of the frames worked (frames are paintable); moving the element to `document.body` made it paint (ancestor context); bisecting ancestors isolated `position: fixed`.

## Fix
Make `.shorts-page` a normal-flow full-viewport block (`position: relative; height: 100svh` with `dvh`/`vh` fallbacks) instead of `position: fixed`. The immersive scroll lock is already provided by the component setting `html`/`body` `overflow: hidden` on mount, so layout and behavior are unchanged — the video is simply no longer inside a fixed ancestor.

Verified on an iPhone (iOS 18.7, Safari 27): video plays, full-screen, vertical swipe + scroll-snap intact. Includes a regression test asserting the shorts wrapper is not `position: fixed`.