### PR TITLE
Fix rescan syncing renamed video metadata

### DIFF
--- a/backend/internal/catalog/catalog.go
+++ b/backend/internal/catalog/catalog.go
@@ -451,6 +451,10 @@ type VideoMetaPatch struct {
 	Category               string
 	ContentHash            string
 	FileName               string
+	Title                  string
+	TitleSet               bool
+	Author                 string
+	AuthorSet              bool
 	Tags                   []string
 	TagsSet                bool
 }
@@ -499,6 +503,14 @@ func (c *Catalog) UpdateVideoMeta(ctx context.Context, id string, p VideoMetaPat
 	if p.FileName != "" {
 		parts = append(parts, "file_name = ?")
 		args = append(args, p.FileName)
+	}
+	if p.TitleSet {
+		parts = append(parts, "title = ?")
+		args = append(args, p.Title)
+	}
+	if p.AuthorSet {
+		parts = append(parts, "author = ?")
+		args = append(args, p.Author)
 	}
 	if p.TagsSet {
 		tagsJSON, _ := json.Marshal(p.Tags)

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -206,15 +206,19 @@ func (s *Scanner) walk(ctx context.Context, dirID, dirName string, stats *Stats,
 				patch.ContentHash = e.Hash
 				existing.ContentHash = e.Hash
 			}
-			if e.Name != "" && existing.FileName == "" {
+			if e.Name != "" && existing.FileName != e.Name {
 				patch.FileName = e.Name
 				existing.FileName = e.Name
+				patch.Title = parsed.Title
+				patch.TitleSet = true
+				patch.Author = parsed.Author
+				patch.AuthorSet = true
 			}
 			// 已存在但轻量元数据空缺时，顺便补齐。
 			if existing.Category == "" && dirName != "" {
 				patch.Category = dirName
 			}
-			if patch.Category != "" || patch.ContentHash != "" || patch.FileName != "" {
+			if patch.Category != "" || patch.ContentHash != "" || patch.FileName != "" || patch.TitleSet || patch.AuthorSet {
 				_ = s.Catalog.UpdateVideoMeta(ctx, id, patch)
 				if err := ctx.Err(); err != nil {
 					return err

--- a/backend/internal/scanner/scanner_test.go
+++ b/backend/internal/scanner/scanner_test.go
@@ -323,6 +323,67 @@ func TestRunDoesNotBackfillRemoteThumbnailForExistingVideo(t *testing.T) {
 	}
 }
 
+func TestRunSyncsRenamedExistingVideoMetadata(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cat.Close(); err != nil {
+			t.Fatalf("close catalog: %v", err)
+		}
+	})
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &catalog.Video{
+		ID:            "fake-drive-file-1",
+		DriveID:       "drive",
+		FileID:        "file-1",
+		FileName:      "old-name - Old Author.mp4",
+		Title:         "old-name",
+		Author:        "Old Author",
+		PreviewStatus: "pending",
+		PublishedAt:   now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+
+	drv := &scannerFakeDrive{
+		entries: []drives.Entry{{
+			ID:      "file-1",
+			Name:    "[4K] renamed clip.mp4",
+			Size:    123,
+			ModTime: now,
+		}},
+	}
+	sc := New(cat, drv, []string{".mp4"}, nil, nil)
+
+	stats, err := sc.Run(ctx, "")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if stats.Added != 0 {
+		t.Fatalf("added = %d, want existing video to be updated in place", stats.Added)
+	}
+
+	got, err := cat.GetVideo(ctx, "fake-drive-file-1")
+	if err != nil {
+		t.Fatalf("get video: %v", err)
+	}
+	if got.FileName != "[4K] renamed clip.mp4" {
+		t.Fatalf("file_name = %q, want remote name", got.FileName)
+	}
+	if got.Title != "renamed clip" {
+		t.Fatalf("title = %q, want parsed title from remote name", got.Title)
+	}
+	if got.Author != "" {
+		t.Fatalf("author = %q, want cleared author from remote name without author suffix", got.Author)
+	}
+}
+
 func TestRunReplacesExistingVideoTagsWithFixedFilenameTags(t *testing.T) {
 	ctx := context.Background()
 	cat, err := catalog.Open(t.TempDir() + "/catalog.db")


### PR DESCRIPTION
## Summary
- Sync existing video file_name/title/author when a rescan sees the same file ID with a different remote name
- Keep the update in the scanner metadata patch path instead of using full video upsert
- Add regression coverage for renamed existing videos

## Tests
- go test ./internal/scanner
- go test ./internal/catalog
- docker run --rm -v "${PWD}:/work" -w /work/backend golang:1.25-bookworm go test ./...

Note: the repository declares Go 1.23.4, but one existing test uses testing.T.Chdir, which is unavailable in Go 1.23; the full Linux Docker test suite passes with Go 1.25.
