### PR TITLE
fix(scanner): sync renamed video metadata on rescan

### DIFF
--- a/backend/internal/catalog/catalog.go
+++ b/backend/internal/catalog/catalog.go
@@ -451,6 +451,10 @@ type VideoMetaPatch struct {
 	Category               string
 	ContentHash            string
 	FileName               string
+	Title                  string
+	TitleSet               bool
+	Author                 string
+	AuthorSet              bool
 	Tags                   []string
 	TagsSet                bool
 }
@@ -499,6 +503,14 @@ func (c *Catalog) UpdateVideoMeta(ctx context.Context, id string, p VideoMetaPat
 	if p.FileName != "" {
 		parts = append(parts, "file_name = ?")
 		args = append(args, p.FileName)
+	}
+	if p.TitleSet {
+		parts = append(parts, "title = ?")
+		args = append(args, p.Title)
+	}
+	if p.AuthorSet {
+		parts = append(parts, "author = ?")
+		args = append(args, p.Author)
 	}
 	if p.TagsSet {
 		tagsJSON, _ := json.Marshal(p.Tags)

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -206,15 +206,19 @@ func (s *Scanner) walk(ctx context.Context, dirID, dirName string, stats *Stats,
 				patch.ContentHash = e.Hash
 				existing.ContentHash = e.Hash
 			}
-			if e.Name != "" && existing.FileName == "" {
+			if e.Name != "" && existing.FileName != e.Name {
 				patch.FileName = e.Name
 				existing.FileName = e.Name
+				patch.Title = parsed.Title
+				patch.TitleSet = true
+				patch.Author = parsed.Author
+				patch.AuthorSet = true
 			}
 			// 已存在但轻量元数据空缺时，顺便补齐。
 			if existing.Category == "" && dirName != "" {
 				patch.Category = dirName
 			}
-			if patch.Category != "" || patch.ContentHash != "" || patch.FileName != "" {
+			if patch.Category != "" || patch.ContentHash != "" || patch.FileName != "" || patch.TitleSet || patch.AuthorSet {
 				_ = s.Catalog.UpdateVideoMeta(ctx, id, patch)
 				if err := ctx.Err(); err != nil {
 					return err

--- a/backend/internal/scanner/scanner_test.go
+++ b/backend/internal/scanner/scanner_test.go
@@ -323,6 +323,67 @@ func TestRunDoesNotBackfillRemoteThumbnailForExistingVideo(t *testing.T) {
 	}
 }
 
+func TestRunSyncsRenamedExistingVideoMetadata(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cat.Close(); err != nil {
+			t.Fatalf("close catalog: %v", err)
+		}
+	})
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &catalog.Video{
+		ID:            "fake-drive-file-1",
+		DriveID:       "drive",
+		FileID:        "file-1",
+		FileName:      "old-name - Old Author.mp4",
+		Title:         "old-name",
+		Author:        "Old Author",
+		PreviewStatus: "pending",
+		PublishedAt:   now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+
+	drv := &scannerFakeDrive{
+		entries: []drives.Entry{{
+			ID:      "file-1",
+			Name:    "[4K] renamed clip.mp4",
+			Size:    123,
+			ModTime: now,
+		}},
+	}
+	sc := New(cat, drv, []string{".mp4"}, nil, nil)
+
+	stats, err := sc.Run(ctx, "")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if stats.Added != 0 {
+		t.Fatalf("added = %d, want existing video to be updated in place", stats.Added)
+	}
+
+	got, err := cat.GetVideo(ctx, "fake-drive-file-1")
+	if err != nil {
+		t.Fatalf("get video: %v", err)
+	}
+	if got.FileName != "[4K] renamed clip.mp4" {
+		t.Fatalf("file_name = %q, want remote name", got.FileName)
+	}
+	if got.Title != "renamed clip" {
+		t.Fatalf("title = %q, want parsed title from remote name", got.Title)
+	}
+	if got.Author != "" {
+		t.Fatalf("author = %q, want cleared author from remote name without author suffix", got.Author)
+	}
+}
+
 func TestRunReplacesExistingVideoTagsWithFixedFilenameTags(t *testing.T) {
 	ctx := context.Background()
 	cat, err := catalog.Open(t.TempDir() + "/catalog.db")


### PR DESCRIPTION
## 背景

目前标准网盘扫描器在重扫时会通过同一个 file_id 识别已有视频，但如果云盘侧只修改了文件名，数据库里的 file_name/title/author 不会同步更新，导致站内仍显示旧名称。

例如云盘文件名如果从 `old-name.mp4` 改成 `new-name.mp4`，虽然 file_id 不变但是重扫后视频仍显示旧的 title。

## 修改内容

1. 当 scanner 扫描到已有视频，并且远端 Entry.Name 与数据库 file_name 不一致时，同步更新 file_name、title、author。
2. 扩展 `catalog.VideoMetaPatch`，支持显式更新/清空 title 和 author。
3. 新增回归测试，覆盖「同一 file_id 的已有视频在云盘改名后，重扫会更新站内展示名称」。

## 影响范围

这个修复作用于标准 scanner，因此适用于所有标准网盘驱动，只要该网盘改名后 file_id 保持不变。