### PR TITLE
feat: add google drive openlist api url field

### DIFF
--- a/backend/internal/api/admin.go
+++ b/backend/internal/api/admin.go
@@ -479,9 +479,10 @@ func (a *AdminServer) handleListDrives(w http.ResponseWriter, r *http.Request) {
 		SkipDirIDs []string `json:"skipDirIds"`
 		// LastCrawlAt 是 spider91 上次成功爬取的 unix 秒（来自 credentials.last_crawl_at）。
 		// 其它 kind 留 0；前端用它显示"上次抓取: N 小时前"。
-		Spider91Proxy           string `json:"spider91Proxy,omitempty"`
-		LastCrawlAt             int64  `json:"lastCrawlAt,omitempty"`
-		GoogleDriveUseOnlineAPI *bool  `json:"googleDriveUseOnlineAPI,omitempty"`
+		Spider91Proxy             string `json:"spider91Proxy,omitempty"`
+		LastCrawlAt               int64  `json:"lastCrawlAt,omitempty"`
+		GoogleDriveUseOnlineAPI   *bool  `json:"googleDriveUseOnlineAPI,omitempty"`
+		GoogleDriveOpenListAPIURL string `json:"googleDriveOpenListApiUrl,omitempty"`
 		// STRMAllowOutsideRoot 是 localstorage 的 .strm 越root开关；其它 kind 省略。
 		STRMAllowOutsideRoot          *bool            `json:"strmAllowOutsideRoot,omitempty"`
 		ScanGenerationStatus          GenerationStatus `json:"scanGenerationStatus"`
@@ -560,6 +561,7 @@ func (a *AdminServer) handleListDrives(w http.ResponseWriter, r *http.Request) {
 			Spider91Proxy:                 spider91ProxyForDrive(d),
 			LastCrawlAt:                   lastCrawlAt,
 			GoogleDriveUseOnlineAPI:       googleDriveUseOnlineAPIForDrive(d),
+			GoogleDriveOpenListAPIURL:     googleDriveOpenListAPIURLForDrive(d),
 			STRMAllowOutsideRoot:          strmAllowOutsideRootForDrive(d),
 			ScanGenerationStatus:          generation.Scan,
 			ThumbnailGenerationStatus:     generation.Thumbnail,
@@ -628,7 +630,9 @@ func (a *AdminServer) handleUpsertDrive(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		body.Credentials = credentials
-	} else if body.Kind == "googledrive" || body.Kind == "localstorage" || body.Kind == "guangyapan" {
+	} else if body.Kind == "googledrive" {
+		body.Credentials = mergeGoogleDriveCredentials(existing, body.Credentials)
+	} else if body.Kind == "localstorage" || body.Kind == "guangyapan" {
 		// 按键合并、空值沿用旧值：这些网盘的编辑表单允许只改某几个字段，
 		// 其它 token / 路径 / 开关字段应保留旧值。
 		body.Credentials = mergeNonEmptyCredentials(existing, body.Credentials)
@@ -1410,6 +1414,21 @@ func googleDriveUseOnlineAPIForDrive(d *catalog.Drive) *bool {
 	}
 	result = v
 	return &result
+}
+
+func googleDriveOpenListAPIURLForDrive(d *catalog.Drive) string {
+	if d == nil || d.Kind != "googledrive" || d.Credentials == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Credentials["api_url_address"])
+}
+
+func mergeGoogleDriveCredentials(existing *catalog.Drive, incoming map[string]string) map[string]string {
+	merged := mergeNonEmptyCredentials(existing, incoming)
+	if _, ok := incoming["api_url_address"]; ok && strings.TrimSpace(incoming["api_url_address"]) == "" {
+		delete(merged, "api_url_address")
+	}
+	return merged
 }
 
 // mergeNonEmptyCredentials 逐键合并凭证：incoming 里非空的键覆盖旧值，

--- a/backend/internal/api/admin_test.go
+++ b/backend/internal/api/admin_test.go
@@ -732,6 +732,31 @@ func TestHandleUpsertGoogleDriveMergesOAuthCredentials(t *testing.T) {
 	if got.Credentials["client_id"] != "google-client-id" || got.Credentials["client_secret"] != "google-client-secret" {
 		t.Fatalf("oauth client credentials = %#v, want saved", got.Credentials)
 	}
+	if got.Credentials["api_url_address"] != "https://api.oplist.org/googleui/renewapi" {
+		t.Fatalf("api_url_address = %q, want preserved", got.Credentials["api_url_address"])
+	}
+
+	clearReq := httptest.NewRequest(http.MethodPost, "/admin/api/drives", bytes.NewBufferString(`{
+		"id": "google-main",
+		"kind": "googledrive",
+		"name": "Google Drive",
+		"rootId": "root",
+		"credentials": {
+			"api_url_address": ""
+		}
+	}`))
+	clearRR := httptest.NewRecorder()
+	(&AdminServer{Catalog: cat}).handleUpsertDrive(clearRR, clearReq)
+	if clearRR.Code != http.StatusOK {
+		t.Fatalf("clear status = %d, body = %s", clearRR.Code, clearRR.Body.String())
+	}
+	cleared, err := cat.GetDrive(ctx, "google-main")
+	if err != nil {
+		t.Fatalf("get cleared drive: %v", err)
+	}
+	if _, ok := cleared.Credentials["api_url_address"]; ok {
+		t.Fatalf("api_url_address was not cleared: %#v", cleared.Credentials)
+	}
 }
 
 func TestHandleUpsertSpider91DriveIsRejected(t *testing.T) {
@@ -1948,7 +1973,8 @@ func TestHandleListDrivesIncludesGoogleDriveOnlineAPIMode(t *testing.T) {
 			Name:   "Google Legacy",
 			RootID: "root",
 			Credentials: map[string]string{
-				"refresh_token": "legacy-refresh",
+				"refresh_token":   "legacy-refresh",
+				"api_url_address": "https://openlist-api.example/googleui/renewapi",
 			},
 			Status: "ok",
 		},
@@ -1979,21 +2005,27 @@ func TestHandleListDrivesIncludesGoogleDriveOnlineAPIMode(t *testing.T) {
 	}
 
 	var got []struct {
-		ID                      string `json:"id"`
-		GoogleDriveUseOnlineAPI bool   `json:"googleDriveUseOnlineAPI"`
+		ID                        string `json:"id"`
+		GoogleDriveUseOnlineAPI   bool   `json:"googleDriveUseOnlineAPI"`
+		GoogleDriveOpenListAPIURL string `json:"googleDriveOpenListApiUrl"`
 	}
 	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	byID := map[string]bool{}
+	byAPIURL := map[string]string{}
 	for _, d := range got {
 		byID[d.ID] = d.GoogleDriveUseOnlineAPI
+		byAPIURL[d.ID] = d.GoogleDriveOpenListAPIURL
 	}
 	if !byID["google-legacy"] {
 		t.Fatalf("legacy google drive use_online_api = false, want true")
 	}
 	if byID["google-oauth"] {
 		t.Fatalf("oauth google drive use_online_api = true, want false")
+	}
+	if byAPIURL["google-legacy"] != "https://openlist-api.example/googleui/renewapi" {
+		t.Fatalf("legacy google drive openlist api url = %q, want custom URL", byAPIURL["google-legacy"])
 	}
 }
 

--- a/src/admin/DrivesPage.tsx
+++ b/src/admin/DrivesPage.tsx
@@ -217,7 +217,10 @@ export function DrivesPage() {
         d.kind === "spider91"
           ? { proxy: d.spider91Proxy ?? "" }
           : d.kind === "googledrive"
-          ? { use_online_api: (d.googleDriveUseOnlineAPI ?? true) ? "true" : "false" }
+          ? {
+              use_online_api: (d.googleDriveUseOnlineAPI ?? true) ? "true" : "false",
+              api_url_address: d.googleDriveOpenListApiUrl ?? "",
+            }
           : d.kind === "localstorage"
           ? { strm_allow_outside_root: (d.strmAllowOutsideRoot ?? false) ? "true" : "false" }
           : {},

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -98,6 +98,8 @@ export type AdminDrive = {
   spider91Proxy?: string;
   // Google Drive 是否使用 OpenList 在线续期 API；未配置时后端按 true 返回。
   googleDriveUseOnlineAPI?: boolean;
+  // Google Drive OpenList 在线续期 API 地址；为空时后端使用驱动默认值。
+  googleDriveOpenListApiUrl?: string;
   // localstorage 的 .strm 是否允许指向存储根目录之外；未配置时后端按 false 返回。
   strmAllowOutsideRoot?: boolean;
   scanGenerationStatus?: DriveGenerationStatus;

--- a/src/admin/drive/constants.ts
+++ b/src/admin/drive/constants.ts
@@ -323,15 +323,15 @@ export function credentialFields(kind: Kind, creds: Record<string, string> = {})
             { value: "false", label: "自建 Google OAuth 客户端" },
           ],
         },
-        {
-          key: "refresh_token",
-          label: "refresh_token",
-          placeholder: "OpenList Google Drive refresh_token",
-          multiline: true,
-          required: true,
-        },
         ...(googleDriveUsesOnlineAPI(creds)
-          ? []
+          ? [
+              {
+                key: "api_url_address",
+                label: "OpenList 在线 API URL",
+                placeholder: "默认：https://api.oplist.org/googleui/renewapi",
+                help: "留空时使用 OpenList 官方在线 API，填写后会使用自定义续期 API。",
+              },
+            ]
           : [
               {
                 key: "client_id",
@@ -348,6 +348,13 @@ export function credentialFields(kind: Kind, creds: Record<string, string> = {})
                 help: "Google Cloud Console 中同一个 OAuth 客户端的 Client Secret",
               },
             ]),
+        {
+          key: "refresh_token",
+          label: "refresh_token",
+          placeholder: "OpenList Google Drive refresh_token",
+          multiline: true,
+          required: true,
+        },
       ];
     case "localstorage":
       return [


### PR DESCRIPTION
## 背景

对于 Google Drive，OpenList 在线 API 默认使用官方实例，但是也支持用户自部署的私有实例（OpenListTeam/OpenList-APIPages 项目已开源）。

考虑到部分用户不希望依赖官方实例，或出于安全原因希望自行托管续期 API，因此有必要支持配置自定义 OpenList 在线 API URL。

## 修改内容

在 Google Drive 使用 OpenList 在线 API 认证方式时，UI 中新增可选的 `OpenList 在线 API URL` 配置项，可以将自定义 URL 保存到 `api_url_address`。

留空时仍然使用默认地址：`https://api.oplist.org/googleui/renewapi`。

## 预览

<img width="1062" height="781" alt="image" src="https://github.com/user-attachments/assets/f5fcc81c-b9f6-423a-85f1-3bde35149acd" />

