### PR TITLE
Fix localstorage stream failing on Windows drive paths

### DIFF
--- a/backend/internal/proxy/proxy.go
+++ b/backend/internal/proxy/proxy.go
@@ -229,6 +229,11 @@ func localFilePath(u *url.URL, raw string) (string, bool) {
 	if u == nil {
 		return "", false
 	}
+	// Windows 盘符绝对路径，如 E:\videos\file.mp4
+	// url.Parse 会把盘符当作 scheme（如 "e"），所以必须在 scheme 检查之前处理
+	if isWindowsDrivePath(raw) {
+		return raw, true
+	}
 	if u.Scheme == "file" && u.Path != "" {
 		return u.Path, true
 	}
@@ -236,6 +241,21 @@ func localFilePath(u *url.URL, raw string) (string, bool) {
 		return raw, true
 	}
 	return "", false
+}
+
+// isWindowsDrivePath 检查是否为 Windows 盘符绝对路径，如 C:\path 或 D:/path
+func isWindowsDrivePath(p string) bool {
+	if len(p) < 3 {
+		return false
+	}
+	c := p[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		return false
+	}
+	if p[1] != ':' {
+		return false
+	}
+	return p[2] == '\\' || p[2] == '/'
 }
 
 var errDriveNotFound = &httpError{Code: http.StatusNotFound, Msg: "drive not found"}

--- a/backend/internal/proxy/proxy_test.go
+++ b/backend/internal/proxy/proxy_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -278,6 +280,36 @@ func TestServeStreamServesLocalFilePath(t *testing.T) {
 	}
 	if drv.calls != 1 {
 		t.Fatalf("link calls = %d, want 1", drv.calls)
+	}
+}
+
+func TestLocalFilePathWindowsDrive(t *testing.T) {
+	// Unix 绝对路径在 Linux 上是合法本地文件，在 Windows 上不是
+	unixAbsWant := false
+	if runtime.GOOS != "windows" {
+		unixAbsWant = true
+	}
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"backslash", `E:\videos\file.mp4`, true},
+		{"forward_slash", `E:/videos/file.mp4`, true},
+		{"lowercase", `d:\file.mp4`, true},
+		{"unix_abs", `/mnt/videos/file.mp4`, unixAbsWant},
+		{"http_url", `http://example.com/file.mp4`, false},
+		{"too_short", `E:`, false},
+		{"no_separator", `E:file.mp4`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, _ := url.Parse(tc.raw)
+			_, got := localFilePath(u, tc.raw)
+			if got != tc.want {
+				t.Fatalf("localFilePath(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/proxy/proxy_test.go
+++ b/backend/internal/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -278,6 +279,31 @@ func TestServeStreamServesLocalFilePath(t *testing.T) {
 	}
 	if drv.calls != 1 {
 		t.Fatalf("link calls = %d, want 1", drv.calls)
+	}
+}
+
+func TestLocalFilePathWindowsDrive(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"backslash", `E:\videos\file.mp4`, true},
+		{"forward_slash", `E:/videos/file.mp4`, true},
+		{"lowercase", `d:\file.mp4`, true},
+		{"unix_abs", `/mnt/videos/file.mp4`, false},
+		{"http_url", `http://example.com/file.mp4`, false},
+		{"too_short", `E:`, false},
+		{"no_separator", `E:file.mp4`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, _ := url.Parse(tc.raw)
+			_, got := localFilePath(u, tc.raw)
+			if got != tc.want {
+				t.Fatalf("localFilePath(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/proxy/proxy_test.go
+++ b/backend/internal/proxy/proxy_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 


### PR DESCRIPTION
url.Parse treats Windows drive letters (e.g. 'E:') as URL scheme, causing localFilePath() to miss the local-file detection and fall through to http.NewRequestWithContext, which fails with 'unsupported protocol scheme "e"'.

Add isWindowsDrivePath() check to detect [A-Za-z]:[\/] patterns before scheme-based checks.