### PR TITLE
fix: 本地上传的视频被拉黑后无法恢复

### DIFF
--- a/backend/cmd/server/app.go
+++ b/backend/cmd/server/app.go
@@ -90,6 +90,9 @@ type App struct {
 	// the catalog and purges each one after a successful provider delete.
 	blacklistSourceDeleteMu    sync.Mutex
 	blacklistSourceDeleteState api.BlacklistSourceDeleteStatus
+	// blacklistVideoLocks serializes restore and source deletion for the same
+	// tombstone without making unrelated videos wait on a slow provider call.
+	blacklistVideoLocks videoOperationLocks
 
 	// tagJobMu protects the admin-visible tag job status. tagMaintenanceMu
 	// serializes bulk writes to video_tags across startup, manual, and nightly
@@ -97,6 +100,41 @@ type App struct {
 	tagJobMu         sync.Mutex
 	tagMaintenanceMu sync.Mutex
 	tagJobState      api.TagJobStatus
+}
+
+type videoOperationLocks struct {
+	mu    sync.Mutex
+	items map[string]*videoOperationLock
+}
+
+type videoOperationLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (locks *videoOperationLocks) lock(videoID string) func() {
+	locks.mu.Lock()
+	if locks.items == nil {
+		locks.items = make(map[string]*videoOperationLock)
+	}
+	item := locks.items[videoID]
+	if item == nil {
+		item = &videoOperationLock{}
+		locks.items[videoID] = item
+	}
+	item.refs++
+	locks.mu.Unlock()
+
+	item.mu.Lock()
+	return func() {
+		item.mu.Unlock()
+		locks.mu.Lock()
+		item.refs--
+		if item.refs == 0 {
+			delete(locks.items, videoID)
+		}
+		locks.mu.Unlock()
+	}
 }
 
 type driveScanProgress struct {

--- a/backend/cmd/server/blacklist.go
+++ b/backend/cmd/server/blacklist.go
@@ -341,6 +341,37 @@ func (a *App) removeVideoSourceFile(ctx context.Context, v *catalog.Video) (bool
 	return true, nil
 }
 
+// verifyRestorableSource 确认 direct 恢复策略的源文件仍然存在。这类来源（本地
+// 上传）不会被任何扫盘或爬取重新发现，取消拉黑等于当场重建记录，因此文件已经
+// 不在时必须拒绝，否则库里会多出一条点开就播放失败的视频。
+func (a *App) verifyRestorableSource(ctx context.Context, driveID, fileID string) error {
+	driveID = strings.TrimSpace(driveID)
+	fileID = strings.TrimSpace(fileID)
+	if fileID == "" {
+		return fmt.Errorf("restore from drive %s: empty file id", driveID)
+	}
+	if a == nil || a.registry == nil {
+		return fmt.Errorf("restore from drive %s: drive registry unavailable: %w", driveID, drives.ErrNotSupported)
+	}
+	if _, ok := a.registry.Get(driveID); !ok {
+		if err := a.ensureDriveAttached(ctx, driveID); err != nil {
+			return fmt.Errorf("restore from drive %s: attach drive: %w", driveID, err)
+		}
+	}
+	drv, ok := a.registry.Get(driveID)
+	if !ok {
+		return fmt.Errorf("restore from drive %s: drive not attached: %w", driveID, drives.ErrNotSupported)
+	}
+	entry, err := drv.Stat(ctx, fileID)
+	if err != nil {
+		return fmt.Errorf("restore from drive %s: stat %s: %w", driveID, fileID, err)
+	}
+	if entry == nil || entry.IsDir {
+		return fmt.Errorf("restore from drive %s: %s is not a regular file", driveID, fileID)
+	}
+	return nil
+}
+
 func (a *App) cleanupDriveVideosForDelete(ctx context.Context, driveID string) (int, error) {
 	if a == nil || a.cat == nil {
 		return 0, nil

--- a/backend/cmd/server/blacklist.go
+++ b/backend/cmd/server/blacklist.go
@@ -177,16 +177,15 @@ func (a *App) runBlacklistSourceDelete(ctx context.Context, reqs ...api.Blacklis
 		}
 		a.blacklistSourceDeleteMu.Unlock()
 
-		deleteErr := a.removeDeletedVideoSourceFile(ctx, item)
-		if deleteErr == nil {
-			deleteErr = a.purgeDeletedVideoTombstone(ctx, item.ID)
-		}
+		skipped, deleteErr := a.deleteBlacklistedVideoSource(ctx, item)
 
 		a.blacklistSourceDeleteMu.Lock()
 		a.blacklistSourceDeleteState.Processed++
 		if deleteErr != nil {
 			a.blacklistSourceDeleteState.Failed++
 			a.blacklistSourceDeleteState.LastError = deleteErr.Error()
+		} else if skipped {
+			a.blacklistSourceDeleteState.Skipped++
 		} else {
 			a.blacklistSourceDeleteState.Deleted++
 		}
@@ -194,6 +193,8 @@ func (a *App) runBlacklistSourceDelete(ctx context.Context, reqs ...api.Blacklis
 
 		if deleteErr != nil {
 			log.Printf("[blacklist-source-delete] id=%s drive=%s file=%s failed: %v", item.ID, item.DriveID, item.FileID, deleteErr)
+		} else if skipped {
+			log.Printf("[blacklist-source-delete] id=%s skipped: tombstone changed or is no longer pending", item.ID)
 		} else {
 			log.Printf("[blacklist-source-delete] id=%s drive=%s file=%s deleted", item.ID, item.DriveID, item.FileID)
 		}
@@ -207,6 +208,47 @@ func (a *App) runBlacklistSourceDelete(ctx context.Context, reqs ...api.Blacklis
 	}
 
 	a.finishBlacklistSourceDelete("completed", nil)
+}
+
+// deleteBlacklistedVideoSource revalidates a snapshot item while holding the
+// same per-video lock used by direct restore. A restored, claimed, or newly
+// recreated tombstone is a skip, not permission to delete the stale snapshot's
+// source file.
+func (a *App) deleteBlacklistedVideoSource(ctx context.Context, snapshot *catalog.DeletedVideo) (bool, error) {
+	if snapshot == nil {
+		return false, errors.New("remove blacklisted source: empty tombstone")
+	}
+	unlock := a.blacklistVideoLocks.lock(snapshot.ID)
+	defer unlock()
+	if err := persistence.RLockContext(ctx); err != nil {
+		return false, err
+	}
+	defer persistence.RUnlock()
+
+	items, err := a.cat.ListDeletedVideosPendingSourceDeletionByIDs(ctx, []string{snapshot.ID})
+	if err != nil {
+		return false, err
+	}
+	if len(items) == 0 {
+		return true, nil
+	}
+	current := items[0]
+	if current.DeletedAt != snapshot.DeletedAt ||
+		current.DriveID != snapshot.DriveID ||
+		current.FileID != snapshot.FileID ||
+		current.ParentID != snapshot.ParentID ||
+		current.FileName != snapshot.FileName ||
+		current.Size != snapshot.Size ||
+		current.Reason != snapshot.Reason {
+		return true, nil
+	}
+	if err := a.removeDeletedVideoSourceFile(ctx, current); err != nil {
+		return false, err
+	}
+	if err := a.purgeDeletedVideoTombstone(ctx, current.ID); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 func (a *App) removeDeletedVideoSourceFile(ctx context.Context, item *catalog.DeletedVideo) error {
@@ -341,35 +383,76 @@ func (a *App) removeVideoSourceFile(ctx context.Context, v *catalog.Video) (bool
 	return true, nil
 }
 
-// verifyRestorableSource 确认 direct 恢复策略的源文件仍然存在。这类来源（本地
-// 上传）不会被任何扫盘或爬取重新发现，取消拉黑等于当场重建记录，因此文件已经
-// 不在时必须拒绝，否则库里会多出一条点开就播放失败的视频。
-func (a *App) verifyRestorableSource(ctx context.Context, driveID, fileID string) error {
+// restoreDeletedVideo coordinates provider inspection, the catalog state
+// transition, and application side effects under the same per-video lock used
+// by source deletion. Catalog returns the restored row so direct restores enter
+// the same generation queues as newly uploaded videos.
+func (a *App) restoreDeletedVideo(ctx context.Context, videoID string) error {
+	if a == nil || a.cat == nil {
+		return sql.ErrNoRows
+	}
+	videoID = strings.TrimSpace(videoID)
+	if videoID == "" {
+		return sql.ErrNoRows
+	}
+	unlock := a.blacklistVideoLocks.lock(videoID)
+	defer unlock()
+	if err := persistence.RLockContext(ctx); err != nil {
+		return err
+	}
+
+	result, err := a.cat.RestoreDeletedVideo(ctx, videoID, func(driveID, fileID string) (catalog.DeletedVideoSourceInfo, error) {
+		return a.inspectRestorableSource(ctx, driveID, fileID)
+	})
+	persistence.RUnlock()
+	if err != nil {
+		return err
+	}
+	if result.Video != nil {
+		// The catalog commit is already durable. A client disconnect at this point
+		// must not strand the restored row in pending derived-asset state.
+		postRestoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		a.enqueueUploadedVideo(postRestoreCtx, result.Video)
+		cancel()
+		if a.onTagsChanged != nil {
+			a.onTagsChanged()
+		}
+	}
+	return nil
+}
+
+// inspectRestorableSource confirms that a direct-restore source is a playable
+// regular file and returns provider-owned metadata used to repair stale size,
+// timestamps, and fingerprints.
+func (a *App) inspectRestorableSource(ctx context.Context, driveID, fileID string) (catalog.DeletedVideoSourceInfo, error) {
 	driveID = strings.TrimSpace(driveID)
 	fileID = strings.TrimSpace(fileID)
 	if fileID == "" {
-		return fmt.Errorf("restore from drive %s: empty file id", driveID)
+		return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: empty file id", driveID)
 	}
 	if a == nil || a.registry == nil {
-		return fmt.Errorf("restore from drive %s: drive registry unavailable: %w", driveID, drives.ErrNotSupported)
+		return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: drive registry unavailable: %w", driveID, drives.ErrNotSupported)
 	}
 	if _, ok := a.registry.Get(driveID); !ok {
 		if err := a.ensureDriveAttached(ctx, driveID); err != nil {
-			return fmt.Errorf("restore from drive %s: attach drive: %w", driveID, err)
+			return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: attach drive: %w", driveID, err)
 		}
 	}
 	drv, ok := a.registry.Get(driveID)
 	if !ok {
-		return fmt.Errorf("restore from drive %s: drive not attached: %w", driveID, drives.ErrNotSupported)
+		return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: drive not attached: %w", driveID, drives.ErrNotSupported)
 	}
 	entry, err := drv.Stat(ctx, fileID)
 	if err != nil {
-		return fmt.Errorf("restore from drive %s: stat %s: %w", driveID, fileID, err)
+		return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: stat %s: %w", driveID, fileID, err)
 	}
 	if entry == nil || entry.IsDir {
-		return fmt.Errorf("restore from drive %s: %s is not a regular file", driveID, fileID)
+		return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: %s is not a regular file", driveID, fileID)
 	}
-	return nil
+	if entry.Size <= 0 {
+		return catalog.DeletedVideoSourceInfo{}, fmt.Errorf("restore from drive %s: %s is empty", driveID, fileID)
+	}
+	return catalog.DeletedVideoSourceInfo{Size: entry.Size, ModTime: entry.ModTime}, nil
 }
 
 func (a *App) cleanupDriveVideosForDelete(ctx context.Context, driveID string) (int, error) {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -411,6 +411,9 @@ func main() {
 		GetBlacklistSourceDeleteStatus: func() api.BlacklistSourceDeleteStatus {
 			return app.blacklistSourceDeleteStatus()
 		},
+		OnVerifyRestorableSource: func(reqCtx context.Context, driveID, fileID string) error {
+			return app.verifyRestorableSource(reqCtx, driveID, fileID)
+		},
 		OnStartTagRetag: func() bool {
 			return app.startTagRetag(ctx)
 		},

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -411,8 +411,8 @@ func main() {
 		GetBlacklistSourceDeleteStatus: func() api.BlacklistSourceDeleteStatus {
 			return app.blacklistSourceDeleteStatus()
 		},
-		OnVerifyRestorableSource: func(reqCtx context.Context, driveID, fileID string) error {
-			return app.verifyRestorableSource(reqCtx, driveID, fileID)
+		OnRemoveBlacklist: func(reqCtx context.Context, videoID string) error {
+			return app.restoreDeletedVideo(reqCtx, videoID)
 		},
 		OnStartTagRetag: func() bool {
 			return app.startTagRetag(ctx)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1458,6 +1458,268 @@ func TestEnqueueUploadedVideoQueuesLocalGenerationByDefault(t *testing.T) {
 	t.Fatalf("preview status = %q, thumbnail url = %q; want generated local teaser and thumbnail", got.PreviewStatus, got.ThumbnailURL)
 }
 
+func TestRestoreDeletedVideoQueuesDerivedAssetsAndInvalidatesTags(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	video := &catalog.Video{
+		ID: "local-upload-restored", DriveID: "local-upload", FileID: "restored.mp4",
+		FileName: "restored.mp4", Title: "Restored", Size: 4096,
+		ThumbnailURL: "/p/thumb/local-upload-restored", PreviewLocal: "/tmp/restored.mp4", PreviewStatus: "ready",
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := cat.UpsertVideo(ctx, video); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, video.ID); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+
+	drv := &serverRestorableLocalUploadDrive{entry: &drives.Entry{
+		ID: video.FileID, Name: video.FileName, Size: video.Size, ModTime: now,
+	}}
+	registry := proxy.NewRegistry()
+	registry.Set(drv.ID(), drv)
+	gen := &serverFakeTeaserGenerator{}
+	worker := preview.NewWorker(gen, cat, drv)
+	thumbWorker := preview.NewThumbWorker(gen, cat, drv)
+	tagInvalidations := 0
+	app := &App{
+		cat:          cat,
+		registry:     registry,
+		workers:      map[string]*preview.Worker{"local-upload": worker},
+		thumbWorkers: map[string]*preview.ThumbWorker{"local-upload": thumbWorker},
+		onTagsChanged: func() {
+			tagInvalidations++
+		},
+	}
+
+	if err := app.restoreDeletedVideo(ctx, video.ID); err != nil {
+		t.Fatalf("restore deleted video: %v", err)
+	}
+	if got := worker.Status().QueueLength; got != 1 {
+		t.Fatalf("preview queue length = %d, want 1", got)
+	}
+	if got := thumbWorker.Status().QueueLength; got != 1 {
+		t.Fatalf("thumbnail queue length = %d, want 1", got)
+	}
+	if tagInvalidations != 1 {
+		t.Fatalf("tag cache invalidations = %d, want 1", tagInvalidations)
+	}
+	restored, err := cat.GetVideo(ctx, video.ID)
+	if err != nil {
+		t.Fatalf("get restored video: %v", err)
+	}
+	if restored.PreviewStatus != "pending" || restored.ThumbnailURL != "" {
+		t.Fatalf("restored derived state = preview:%q thumbnail:%q", restored.PreviewStatus, restored.ThumbnailURL)
+	}
+}
+
+func TestBlacklistSourceDeleteSkipsSnapshotRestoredBeforeProcessing(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	video := &catalog.Video{
+		ID: "local-upload-stale-delete", DriveID: "local-upload", FileID: "stale.mp4",
+		FileName: "stale.mp4", Title: "Stale", Size: 2048,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := cat.UpsertVideo(ctx, video); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, video.ID); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	snapshot, err := cat.ListDeletedVideosPendingSourceDeletion(ctx)
+	if err != nil || len(snapshot) != 1 {
+		t.Fatalf("source deletion snapshot = %d err=%v, want one", len(snapshot), err)
+	}
+
+	drv := &serverRestorableLocalUploadDrive{entry: &drives.Entry{
+		ID: video.FileID, Name: video.FileName, Size: video.Size, ModTime: now,
+	}}
+	registry := proxy.NewRegistry()
+	registry.Set(drv.ID(), drv)
+	app := &App{cat: cat, registry: registry}
+	if err := app.restoreDeletedVideo(ctx, video.ID); err != nil {
+		t.Fatalf("restore deleted video: %v", err)
+	}
+	skipped, err := app.deleteBlacklistedVideoSource(ctx, snapshot[0])
+	if err != nil {
+		t.Fatalf("process stale source deletion snapshot: %v", err)
+	}
+	if !skipped {
+		t.Fatal("stale source deletion snapshot was not skipped")
+	}
+	drv.mu.Lock()
+	removeCalls := drv.removeCalls
+	drv.mu.Unlock()
+	if removeCalls != 0 {
+		t.Fatalf("source remove calls = %d, want 0", removeCalls)
+	}
+	if _, err := cat.GetVideo(ctx, video.ID); err != nil {
+		t.Fatalf("restored video was damaged by stale source deletion: %v", err)
+	}
+
+	// Reusing the same stable video ID must not let the old job claim a newer
+	// tombstone generation created after the restore.
+	time.Sleep(2 * time.Millisecond)
+	if err := cat.DeleteVideoWithTombstone(ctx, video.ID); err != nil {
+		t.Fatalf("create newer tombstone: %v", err)
+	}
+	skipped, err = app.deleteBlacklistedVideoSource(ctx, snapshot[0])
+	if err != nil {
+		t.Fatalf("process snapshot against newer tombstone: %v", err)
+	}
+	if !skipped {
+		t.Fatal("stale snapshot claimed a newer tombstone generation")
+	}
+	drv.mu.Lock()
+	removeCalls = drv.removeCalls
+	drv.mu.Unlock()
+	if removeCalls != 0 {
+		t.Fatalf("source remove calls after newer tombstone = %d, want 0", removeCalls)
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, video.ID); err != nil || !deleted {
+		t.Fatalf("newer tombstone changed: deleted=%v err=%v", deleted, err)
+	}
+}
+
+func TestBlacklistSourceDeleteAndRestoreAreSerializedPerVideo(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	video := &catalog.Video{
+		ID: "local-upload-delete-restore-race", DriveID: "local-upload", FileID: "race.mp4",
+		FileName: "race.mp4", Title: "Race", Size: 2048,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := cat.UpsertVideo(ctx, video); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, video.ID); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	snapshot, err := cat.ListDeletedVideosPendingSourceDeletion(ctx)
+	if err != nil || len(snapshot) != 1 {
+		t.Fatalf("source deletion snapshot = %d err=%v, want one", len(snapshot), err)
+	}
+
+	removeStarted := make(chan struct{}, 1)
+	allowRemove := make(chan struct{})
+	var releaseRemoveOnce sync.Once
+	releaseRemove := func() { releaseRemoveOnce.Do(func() { close(allowRemove) }) }
+	t.Cleanup(releaseRemove)
+	drv := &serverRestorableLocalUploadDrive{
+		entry:         &drives.Entry{ID: video.FileID, Name: video.FileName, Size: video.Size, ModTime: now},
+		removeStarted: removeStarted,
+		allowRemove:   allowRemove,
+	}
+	registry := proxy.NewRegistry()
+	registry.Set(drv.ID(), drv)
+	app := &App{cat: cat, registry: registry}
+
+	type deleteResult struct {
+		skipped bool
+		err     error
+	}
+	deleteDone := make(chan deleteResult, 1)
+	go func() {
+		skipped, err := app.deleteBlacklistedVideoSource(ctx, snapshot[0])
+		deleteDone <- deleteResult{skipped: skipped, err: err}
+	}()
+	select {
+	case <-removeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("source deletion did not reach provider remove")
+	}
+
+	restoreDone := make(chan error, 1)
+	go func() { restoreDone <- app.restoreDeletedVideo(ctx, video.ID) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		app.blacklistVideoLocks.mu.Lock()
+		item := app.blacklistVideoLocks.items[video.ID]
+		refs := 0
+		if item != nil {
+			refs = item.refs
+		}
+		app.blacklistVideoLocks.mu.Unlock()
+		if refs == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("restore did not wait on the per-video operation lock")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	drv.mu.Lock()
+	statCalls := drv.statCalls
+	drv.mu.Unlock()
+	if statCalls != 0 {
+		t.Fatalf("restore inspected source during deletion: stat calls = %d", statCalls)
+	}
+
+	releaseRemove()
+	if result := <-deleteDone; result.err != nil || result.skipped {
+		t.Fatalf("source deletion result = skipped:%v err:%v", result.skipped, result.err)
+	}
+	if err := <-restoreDone; !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("restore after source deletion error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := cat.GetVideo(ctx, video.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("source-deleted video was restored: %v", err)
+	}
+}
+
+func TestRestoreDeletedVideoRejectsEmptySource(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	video := &catalog.Video{
+		ID: "local-upload-empty", DriveID: "local-upload", FileID: "empty.mp4",
+		FileName: "empty.mp4", Title: "Empty", Size: 100,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := cat.UpsertVideo(ctx, video); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, video.ID); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	drv := &serverRestorableLocalUploadDrive{entry: &drives.Entry{ID: video.FileID, Name: video.FileName}}
+	registry := proxy.NewRegistry()
+	registry.Set(drv.ID(), drv)
+	app := &App{cat: cat, registry: registry}
+
+	if err := app.restoreDeletedVideo(ctx, video.ID); !errors.Is(err, catalog.ErrDeletedVideoSourceMissing) {
+		t.Fatalf("empty source restore error = %v, want ErrDeletedVideoSourceMissing", err)
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, video.ID); err != nil || !deleted {
+		t.Fatalf("empty source tombstone changed: deleted=%v err=%v", deleted, err)
+	}
+}
+
 func TestShouldScanDriveSkipsLocalUpload(t *testing.T) {
 	if shouldScanDrive(&serverLocalUploadFakeDrive{}) {
 		t.Fatal("local upload drive should not be scanned")
@@ -2837,6 +3099,54 @@ type serverLocalUploadFakeDrive struct {
 }
 
 func (d *serverLocalUploadFakeDrive) ID() string { return "local-upload" }
+
+type serverRestorableLocalUploadDrive struct {
+	serverFakeDrive
+	mu            sync.Mutex
+	entry         *drives.Entry
+	statCalls     int
+	removeCalls   int
+	removeStarted chan struct{}
+	allowRemove   <-chan struct{}
+}
+
+func (d *serverRestorableLocalUploadDrive) ID() string { return "local-upload" }
+
+func (d *serverRestorableLocalUploadDrive) Stat(context.Context, string) (*drives.Entry, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.statCalls++
+	if d.entry == nil {
+		return nil, os.ErrNotExist
+	}
+	copy := *d.entry
+	return &copy, nil
+}
+
+func (d *serverRestorableLocalUploadDrive) Remove(ctx context.Context, _ string) error {
+	d.mu.Lock()
+	d.removeCalls++
+	removeStarted := d.removeStarted
+	allowRemove := d.allowRemove
+	d.mu.Unlock()
+	if removeStarted != nil {
+		select {
+		case removeStarted <- struct{}{}:
+		default:
+		}
+	}
+	if allowRemove != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-allowRemove:
+		}
+	}
+	d.mu.Lock()
+	d.entry = nil
+	d.mu.Unlock()
+	return nil
+}
 
 // seedDriveWithTeaser 在 catalog 里 upsert 一个测试用的 drive 行，把 TeaserEnabled
 // 设为 enabled。teaser 入队判断现在按 per-drive 而不是全局 setting，所以涉及到

--- a/backend/internal/api/admin.go
+++ b/backend/internal/api/admin.go
@@ -66,11 +66,11 @@ type AdminServer struct {
 	OnDeleteVideo                  func(ctx context.Context, videoID string, deleteSource bool) (DeleteVideoResult, error)
 	OnStartBlacklistSourceDelete   func(BlacklistSourceDeleteRequest) bool
 	GetBlacklistSourceDeleteStatus func() BlacklistSourceDeleteStatus
-	// OnVerifyRestorableSource 校验 direct 恢复策略的源文件是否还在。这类来源
-	// 不会被任何扫盘或爬取重新发现，取消拉黑就是立刻重建记录，所以必须先确认
-	// 文件仍然存在，否则会放出一条点开就播放失败的视频。未注入时跳过校验。
-	OnVerifyRestorableSource func(ctx context.Context, driveID, fileID string) error
-	OnStartTagRetag                func() bool
+	// OnRemoveBlacklist owns the complete application-level restore operation:
+	// provider inspection, catalog mutation, source-delete coordination, and any
+	// post-restore generation/cache work. Tests may omit it for non-direct paths.
+	OnRemoveBlacklist func(ctx context.Context, videoID string) error
+	OnStartTagRetag   func() bool
 	// OnTagsChanged invalidates read-side tag caches after a catalog mutation.
 	OnTagsChanged                func()
 	GetTagJobStatus              func() TagJobStatus
@@ -171,6 +171,7 @@ type BlacklistSourceDeleteStatus struct {
 	Total        int    `json:"total"`
 	Processed    int    `json:"processed"`
 	Deleted      int    `json:"deleted"`
+	Skipped      int    `json:"skipped"`
 	Failed       int    `json:"failed"`
 	CurrentFile  string `json:"currentFile,omitempty"`
 	LastError    string `json:"lastError,omitempty"`

--- a/backend/internal/api/admin.go
+++ b/backend/internal/api/admin.go
@@ -66,6 +66,10 @@ type AdminServer struct {
 	OnDeleteVideo                  func(ctx context.Context, videoID string, deleteSource bool) (DeleteVideoResult, error)
 	OnStartBlacklistSourceDelete   func(BlacklistSourceDeleteRequest) bool
 	GetBlacklistSourceDeleteStatus func() BlacklistSourceDeleteStatus
+	// OnVerifyRestorableSource 校验 direct 恢复策略的源文件是否还在。这类来源
+	// 不会被任何扫盘或爬取重新发现，取消拉黑就是立刻重建记录，所以必须先确认
+	// 文件仍然存在，否则会放出一条点开就播放失败的视频。未注入时跳过校验。
+	OnVerifyRestorableSource func(ctx context.Context, driveID, fileID string) error
 	OnStartTagRetag                func() bool
 	// OnTagsChanged invalidates read-side tag caches after a catalog mutation.
 	OnTagsChanged                func()

--- a/backend/internal/api/admin_library.go
+++ b/backend/internal/api/admin_library.go
@@ -286,15 +286,23 @@ func (a *AdminServer) blacklistSourceDeleteStatus(ctx context.Context) Blacklist
 }
 
 // handleRemoveBlacklist 允许视频在后续手动/定时任务中重新入库，不会立即触发
-// 扫盘或爬取。不可重新发现的来源会返回 409。
+// 扫盘或爬取。direct 策略的来源（本地上传）没有任何重新发现的途径，改为当场
+// 重建记录，因此先校验保留下来的源文件还在。不可恢复的来源仍然返回 409。
 func (a *AdminServer) handleRemoveBlacklist(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if err := a.Catalog.RemoveDeletedVideo(r.Context(), id); err != nil {
+	var verifySource func(driveID, fileID string) error
+	if a.OnVerifyRestorableSource != nil {
+		verifySource = func(driveID, fileID string) error {
+			return a.OnVerifyRestorableSource(r.Context(), driveID, fileID)
+		}
+	}
+	if err := a.Catalog.RemoveDeletedVideoWithSourceCheck(r.Context(), id, verifySource); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeErr(w, http.StatusNotFound, err)
 			return
 		}
-		if errors.Is(err, catalog.ErrDeletedVideoNotRestorable) {
+		if errors.Is(err, catalog.ErrDeletedVideoNotRestorable) ||
+			errors.Is(err, catalog.ErrDeletedVideoSourceMissing) {
 			writeErr(w, http.StatusConflict, err)
 			return
 		}

--- a/backend/internal/api/admin_library.go
+++ b/backend/internal/api/admin_library.go
@@ -290,18 +290,19 @@ func (a *AdminServer) blacklistSourceDeleteStatus(ctx context.Context) Blacklist
 // 重建记录，因此先校验保留下来的源文件还在。不可恢复的来源仍然返回 409。
 func (a *AdminServer) handleRemoveBlacklist(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	var verifySource func(driveID, fileID string) error
-	if a.OnVerifyRestorableSource != nil {
-		verifySource = func(driveID, fileID string) error {
-			return a.OnVerifyRestorableSource(r.Context(), driveID, fileID)
-		}
+	var err error
+	if a.OnRemoveBlacklist != nil {
+		err = a.OnRemoveBlacklist(r.Context(), id)
+	} else {
+		err = a.Catalog.RemoveDeletedVideo(r.Context(), id)
 	}
-	if err := a.Catalog.RemoveDeletedVideoWithSourceCheck(r.Context(), id, verifySource); err != nil {
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeErr(w, http.StatusNotFound, err)
 			return
 		}
 		if errors.Is(err, catalog.ErrDeletedVideoNotRestorable) ||
+			errors.Is(err, catalog.ErrDeletedVideoSourceCheckRequired) ||
 			errors.Is(err, catalog.ErrDeletedVideoSourceMissing) {
 			writeErr(w, http.StatusConflict, err)
 			return

--- a/backend/internal/api/admin_test.go
+++ b/backend/internal/api/admin_test.go
@@ -296,20 +296,26 @@ func TestHandleRemoveBlacklistRejectsNonRestorableVideo(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = cat.Close() })
 
+	// 被去重删掉的视频不可恢复，应当去看保留下来的那一条。
 	now := time.Now()
-	if err := cat.UpsertVideo(ctx, &catalog.Video{
-		ID: "local-upload-video", DriveID: "local-upload", FileID: "upload.mp4",
-		Title: "Upload", PublishedAt: now, CreatedAt: now, UpdatedAt: now,
-	}); err != nil {
-		t.Fatalf("seed video: %v", err)
+	for _, id := range []string{"canonical-video", "duplicate-video"} {
+		if err := cat.UpsertVideo(ctx, &catalog.Video{
+			ID: id, DriveID: "remote", FileID: id + ".mp4",
+			Title: id, PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
 	}
-	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-video"); err != nil {
+	if err := cat.DeleteVideoWithTombstoneOptions(ctx, "duplicate-video", catalog.DeleteVideoTombstoneOptions{
+		Reason:           catalog.DeletedVideoReasonDuplicate,
+		CanonicalVideoID: "canonical-video",
+	}); err != nil {
 		t.Fatalf("tombstone video: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodDelete, "/admin/api/blacklist/local-upload-video", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/blacklist/duplicate-video", nil)
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", "local-upload-video")
+	rctx.URLParams.Add("id", "duplicate-video")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	rr := httptest.NewRecorder()
 
@@ -318,8 +324,154 @@ func TestHandleRemoveBlacklistRejectsNonRestorableVideo(t *testing.T) {
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body = %s", rr.Code, rr.Body.String())
 	}
-	if deleted, err := cat.IsVideoDeleted(ctx, "local-upload-video"); err != nil || !deleted {
+	if deleted, err := cat.IsVideoDeleted(ctx, "duplicate-video"); err != nil || !deleted {
 		t.Fatalf("non-restorable tombstone was removed: deleted=%v err=%v", deleted, err)
+	}
+}
+
+// 本地上传的视频没有任何重新发现的途径，取消拉黑必须当场把记录放回媒体库。
+func TestHandleRemoveBlacklistRestoresLocalUploadImmediately(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &catalog.Video{
+		ID: "local-upload-video", DriveID: "local-upload", FileID: "upload.mp4",
+		FileName: "upload.mp4", Title: "Upload", PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-video"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+
+	verified := ""
+	server := &AdminServer{
+		Catalog: cat,
+		OnVerifyRestorableSource: func(_ context.Context, driveID, fileID string) error {
+			verified = driveID + "/" + fileID
+			return nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/blacklist/local-upload-video", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "local-upload-video")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+
+	server.handleRemoveBlacklist(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if verified != "local-upload/upload.mp4" {
+		t.Fatalf("verified source = %q, want local-upload/upload.mp4", verified)
+	}
+	if _, err := cat.GetVideo(ctx, "local-upload-video"); err != nil {
+		t.Fatalf("video was not restored: %v", err)
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, "local-upload-video"); err != nil || deleted {
+		t.Fatalf("tombstone still present: deleted=%v err=%v", deleted, err)
+	}
+}
+
+// 源文件已经不在时必须拒绝恢复，否则库里会多出一条点开就播放失败的视频。
+func TestHandleRemoveBlacklistRejectsDirectRestoreWhenSourceMissing(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &catalog.Video{
+		ID: "local-upload-video", DriveID: "local-upload", FileID: "upload.mp4",
+		FileName: "upload.mp4", Title: "Upload", PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-video"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+
+	server := &AdminServer{
+		Catalog: cat,
+		OnVerifyRestorableSource: func(context.Context, string, string) error {
+			return errors.New("stat upload.mp4: no such file")
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/blacklist/local-upload-video", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "local-upload-video")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+
+	server.handleRemoveBlacklist(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %s", rr.Code, rr.Body.String())
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, "local-upload-video"); err != nil || !deleted {
+		t.Fatalf("tombstone was removed despite missing source: deleted=%v err=%v", deleted, err)
+	}
+	if _, err := cat.GetVideo(ctx, "local-upload-video"); err == nil {
+		t.Fatalf("video must not be restored when the source file is gone")
+	}
+}
+
+// 可扫描来源不该触发源文件校验：它们本来就要等下一轮扫盘，此刻文件在不在
+// 都不影响「删掉墓碑」这个动作。
+func TestHandleRemoveBlacklistSkipsSourceCheckForScannableDrive(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &catalog.Video{
+		ID: "remote-video", DriveID: "remote", FileID: "remote.mp4",
+		FileName: "remote.mp4", Title: "Remote", PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "remote-video"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+
+	server := &AdminServer{
+		Catalog: cat,
+		OnVerifyRestorableSource: func(context.Context, string, string) error {
+			t.Fatalf("scannable drive must not be source-checked")
+			return nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/blacklist/remote-video", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "remote-video")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+
+	server.handleRemoveBlacklist(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	// 扫盘来源只是移除墓碑，不会当场重建记录。
+	if _, err := cat.GetVideo(ctx, "remote-video"); err == nil {
+		t.Fatalf("scannable restore must wait for the next scan")
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, "remote-video"); err != nil || deleted {
+		t.Fatalf("tombstone not removed: deleted=%v err=%v", deleted, err)
 	}
 }
 

--- a/backend/internal/api/admin_test.go
+++ b/backend/internal/api/admin_test.go
@@ -352,9 +352,12 @@ func TestHandleRemoveBlacklistRestoresLocalUploadImmediately(t *testing.T) {
 	verified := ""
 	server := &AdminServer{
 		Catalog: cat,
-		OnVerifyRestorableSource: func(_ context.Context, driveID, fileID string) error {
-			verified = driveID + "/" + fileID
-			return nil
+		OnRemoveBlacklist: func(ctx context.Context, id string) error {
+			_, err := cat.RestoreDeletedVideo(ctx, id, func(driveID, fileID string) (catalog.DeletedVideoSourceInfo, error) {
+				verified = driveID + "/" + fileID
+				return catalog.DeletedVideoSourceInfo{Size: 1024, ModTime: now}, nil
+			})
+			return err
 		},
 	}
 
@@ -402,8 +405,11 @@ func TestHandleRemoveBlacklistRejectsDirectRestoreWhenSourceMissing(t *testing.T
 
 	server := &AdminServer{
 		Catalog: cat,
-		OnVerifyRestorableSource: func(context.Context, string, string) error {
-			return errors.New("stat upload.mp4: no such file")
+		OnRemoveBlacklist: func(ctx context.Context, id string) error {
+			_, err := cat.RestoreDeletedVideo(ctx, id, func(string, string) (catalog.DeletedVideoSourceInfo, error) {
+				return catalog.DeletedVideoSourceInfo{}, errors.New("stat upload.mp4: no such file")
+			})
+			return err
 		},
 	}
 
@@ -449,9 +455,12 @@ func TestHandleRemoveBlacklistSkipsSourceCheckForScannableDrive(t *testing.T) {
 
 	server := &AdminServer{
 		Catalog: cat,
-		OnVerifyRestorableSource: func(context.Context, string, string) error {
-			t.Fatalf("scannable drive must not be source-checked")
-			return nil
+		OnRemoveBlacklist: func(ctx context.Context, id string) error {
+			_, err := cat.RestoreDeletedVideo(ctx, id, func(string, string) (catalog.DeletedVideoSourceInfo, error) {
+				t.Fatalf("scannable drive must not be source-checked")
+				return catalog.DeletedVideoSourceInfo{}, nil
+			})
+			return err
 		},
 	}
 

--- a/backend/internal/catalog/catalog.go
+++ b/backend/internal/catalog/catalog.go
@@ -173,6 +173,35 @@ type Video struct {
 
 func (c *Catalog) UpsertVideo(ctx context.Context, v *Video) error {
 	existed := c.videoExists(ctx, v.ID)
+	storedTags, err := upsertVideoRow(ctx, c.db, v)
+	if err != nil {
+		return err
+	}
+	if !existed {
+		if len(storedTags) > 0 {
+			return c.replaceVideoTags(ctx, v.ID, storedTags, "manual", true, true)
+		}
+		assignments, err := c.MatchTagAssignments(ctx, v.Title, v.FileName, v.Author, v.DirName)
+		if err != nil {
+			return err
+		}
+		if len(assignments) > 0 {
+			_, err = c.ReplaceAutoVideoTags(ctx, v.ID, assignments)
+			return err
+		}
+	}
+	return nil
+}
+
+type videoRowExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+// upsertVideoRow owns the videos-table statement without opening a transaction.
+// Ordinary scans call it through UpsertVideo; tombstone restoration calls it
+// with an existing transaction so the row, tag assignments, and tombstone can
+// move to their new state atomically.
+func upsertVideoRow(ctx context.Context, exec videoRowExecer, v *Video) ([]string, error) {
 	v.ContentHash = normalizeContentHash(v.ContentHash)
 	v.SampledSHA256 = normalizeContentHash(v.SampledSHA256)
 	fingerprintStatus := nullableStatus(v.FingerprintStatus)
@@ -206,18 +235,20 @@ func (c *Catalog) UpsertVideo(ctx context.Context, v *Video) error {
 		v.PreviewUpdatedAt = time.Time{}
 	}
 
-	_, err := c.db.ExecContext(ctx, `
+	_, err := exec.ExecContext(ctx, `
 INSERT INTO videos (
   id, drive_id, file_id, file_name, content_hash, sampled_sha256, fingerprint_status, fingerprint_error, parent_id, dir_name, title, author, tags,
 	  duration_seconds, size_bytes, ext, quality, thumbnail_url, thumbnail_updated_at, thumbnail_status,
 	  preview_file_id, preview_local, preview_updated_at, preview_status,
-	  views, last_viewed_at, favorites, comments, likes, dislikes,
+	  transcode_status, transcode_error, transcoded_file_id, transcoded_size,
+	  views, last_viewed_at, favorites, comments, likes, last_liked_at, dislikes,
 	  hidden, badges, description, published_at, created_at, updated_at
 	) VALUES (
 	  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 	  ?, ?, ?, ?, ?, ?, CASE WHEN COALESCE(?, '') != '' THEN 'ready' ELSE 'pending' END,
 	  ?, ?, ?, ?,
-	  ?, ?, ?, ?, ?, ?,
+	  ?, ?, ?, ?,
+	  ?, ?, ?, ?, ?, ?, ?,
 	  ?, ?, ?, ?, ?, ?
 	)
 ON CONFLICT(id) DO UPDATE SET
@@ -281,27 +312,15 @@ ON CONFLICT(id) DO UPDATE SET
 		v.ID, v.DriveID, v.FileID, v.FileName, v.ContentHash, v.SampledSHA256, fingerprintStatus, v.FingerprintError, v.ParentID, v.DirName, v.Title, v.Author, string(tagsJSON),
 		v.DurationSeconds, v.Size, v.Ext, v.Quality, v.ThumbnailURL, thumbnailUpdatedAt, v.ThumbnailURL,
 		v.PreviewFileID, v.PreviewLocal, previewUpdatedAt, nullableStatus(v.PreviewStatus),
-		v.Views, unixMilliOrZero(v.LastViewedAt), v.Favorites, v.Comments, v.Likes, v.Dislikes,
+		v.TranscodeStatus, v.TranscodeError, v.TranscodedFileID, v.TranscodedSize,
+		v.Views, unixMilliOrZero(v.LastViewedAt), v.Favorites, v.Comments, v.Likes, unixMilliOrZero(v.LastLikedAt), v.Dislikes,
 		boolToInt(v.Hidden), string(badgesJSON), v.Description,
 		v.PublishedAt.UnixMilli(), v.CreatedAt.UnixMilli(), v.UpdatedAt.UnixMilli(),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if !existed {
-		if len(storedTags) > 0 {
-			return c.replaceVideoTags(ctx, v.ID, storedTags, "manual", true, true)
-		}
-		assignments, err := c.MatchTagAssignments(ctx, v.Title, v.FileName, v.Author, v.DirName)
-		if err != nil {
-			return err
-		}
-		if len(assignments) > 0 {
-			_, err = c.ReplaceAutoVideoTags(ctx, v.ID, assignments)
-			return err
-		}
-	}
-	return nil
+	return storedTags, nil
 }
 
 func nullableStatus(s string) string {
@@ -1097,11 +1116,52 @@ const (
 
 var (
 	ErrDeletedVideoNotRestorable = errors.New("deleted video is not restorable")
+	// ErrDeletedVideoSourceCheckRequired prevents catalog-only callers from
+	// bypassing the source inspection that a direct restore requires.
+	ErrDeletedVideoSourceCheckRequired = errors.New("deleted video source check is required")
 	// ErrDeletedVideoSourceMissing means a direct restore was attempted but the
 	// retained source file is gone, so rebuilding the row would publish a video
 	// that cannot be played.
 	ErrDeletedVideoSourceMissing = errors.New("deleted video source file is missing")
 )
+
+const deletedVideoRestorePayloadVersion = 1
+
+// DeletedVideoSourceInfo is the provider-owned state observed immediately
+// before a direct restore. Catalog uses it both to reject unusable files and to
+// invalidate stale source-derived metadata when a retained file was replaced.
+type DeletedVideoSourceInfo struct {
+	Size    int64
+	ModTime time.Time
+}
+
+type DeletedVideoRestoreResult struct {
+	RestorePolicy string
+	Video         *Video
+}
+
+type deletedVideoRestorePayload struct {
+	Version        int                                `json:"version"`
+	Video          *Video                             `json:"video"`
+	TagsManual     bool                               `json:"tagsManual"`
+	TagAssignments []deletedVideoTagRestoreAssignment `json:"tagAssignments,omitempty"`
+}
+
+// deletedVideoTagRestoreAssignment keeps both sides of a tag relation. The tag
+// definition may be pruned when the video is tombstoned, while assignment
+// source/evidence determines whether future automatic retagging may replace it.
+type deletedVideoTagRestoreAssignment struct {
+	Label         string `json:"label"`
+	Source        string `json:"source"`
+	Evidence      string `json:"evidence,omitempty"`
+	CreatedAt     int64  `json:"createdAt,omitempty"`
+	TagAliases    string `json:"tagAliases,omitempty"`
+	TagMatchRules string `json:"tagMatchRules,omitempty"`
+	TagSource     string `json:"tagSource,omitempty"`
+	TagOrigin     string `json:"tagOrigin,omitempty"`
+	TagCreatedAt  int64  `json:"tagCreatedAt,omitempty"`
+	TagUpdatedAt  int64  `json:"tagUpdatedAt,omitempty"`
+}
 
 type DeleteVideoTombstoneOptions struct {
 	Reason           string
@@ -1134,21 +1194,21 @@ func (c *Catalog) DeleteVideoWithTombstoneOptions(ctx context.Context, id string
 	if options.Reason != DeletedVideoReasonDuplicate {
 		options.CanonicalVideoID = ""
 	}
-	restoreVideo, err := c.GetVideo(ctx, id)
-	if err != nil {
-		return err
-	}
-	restorePayloadData, err := json.Marshal(restoreVideo)
-	if err != nil {
-		return fmt.Errorf("catalog: encode deleted video restore payload: %w", err)
-	}
-	restorePayload := string(restorePayloadData)
-
 	tx, err := c.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
+	restoreVideo, err := scanVideo(tx.QueryRowContext(ctx,
+		`SELECT `+allVideoCols+` FROM videos WHERE id = ?`, id))
+	if err != nil {
+		return err
+	}
+	restorePayloadData, err := buildDeletedVideoRestorePayload(ctx, tx, restoreVideo)
+	if err != nil {
+		return fmt.Errorf("catalog: encode deleted video restore payload: %w", err)
+	}
+	restorePayload := string(restorePayloadData)
 
 	restoreVideo.ContentHash = normalizeContentHash(restoreVideo.ContentHash)
 
@@ -1477,35 +1537,120 @@ func (c *Catalog) PurgeDeletedVideo(ctx context.Context, id string) error {
 
 // RemoveDeletedVideo 允许可扫描来源在后续任务中重新入库。本函数不会触发
 // 扫描或爬取。爬虫来源会保留墓碑和 seen 记录，并标记为待目录扫描恢复，
-// 使下一轮爬取仍将其当作已见来源跳过。
+// 使下一轮爬取仍将其当作已见来源跳过。direct 来源必须通过
+// RestoreDeletedVideo 提供源文件检查，避免 catalog-only 调用绕过安全边界。
 func (c *Catalog) RemoveDeletedVideo(ctx context.Context, id string) error {
-	return c.RemoveDeletedVideoWithSourceCheck(ctx, id, nil)
+	_, err := c.RestoreDeletedVideo(ctx, id, nil)
+	return err
 }
 
-// RemoveDeletedVideoWithSourceCheck 与 RemoveDeletedVideo 相同，但在 direct
-// 策略当场重建记录之前，先让调用方确认保留下来的源文件还在——只有这条路径
-// 会无条件写回记录，文件已经不在时必须拒绝，否则库里会多出一条点开就播放
-// 失败的视频。verifySource 为 nil 时跳过校验。
-func (c *Catalog) RemoveDeletedVideoWithSourceCheck(
+// RestoreDeletedVideo removes or advances a tombstone according to its policy.
+// Direct restoration is the only branch that creates a catalog row, so it
+// requires provider-owned source inspection and returns the restored video for
+// application-level generation queues. Its row, tag assignments, and tombstone
+// deletion commit in one SQLite transaction.
+func (c *Catalog) RestoreDeletedVideo(
 	ctx context.Context,
 	id string,
-	verifySource func(driveID, fileID string) error,
-) error {
+	inspectSource func(driveID, fileID string) (DeletedVideoSourceInfo, error),
+) (DeletedVideoRestoreResult, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return sql.ErrNoRows
+		return DeletedVideoRestoreResult{}, sql.ErrNoRows
 	}
+
+	deleted, driveKind, _, err := c.deletedVideoForRestore(ctx, c.db, id)
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	deleted.RestorePolicy = deletedVideoRestorePolicy(deleted, driveKind)
+	if deleted.RestorePolicy == DeletedVideoRestorePolicyNone {
+		return DeletedVideoRestoreResult{}, deletedVideoNotRestorableError(deleted)
+	}
+
+	if deleted.RestorePolicy == DeletedVideoRestorePolicyDirect {
+		if inspectSource == nil {
+			return DeletedVideoRestoreResult{}, ErrDeletedVideoSourceCheckRequired
+		}
+		source, err := inspectSource(deleted.DriveID, deleted.FileID)
+		if err != nil {
+			return DeletedVideoRestoreResult{}, fmt.Errorf("%w: %v", ErrDeletedVideoSourceMissing, err)
+		}
+		if source.Size <= 0 {
+			return DeletedVideoRestoreResult{}, fmt.Errorf("%w: source file is empty", ErrDeletedVideoSourceMissing)
+		}
+		return c.restoreDeletedVideoDirect(ctx, id, source)
+	}
+
 	tx, err := c.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return DeletedVideoRestoreResult{}, err
 	}
 	defer tx.Rollback()
+	deleted, driveKind, _, err = c.deletedVideoForRestore(ctx, tx, id)
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	deleted.RestorePolicy = deletedVideoRestorePolicy(deleted, driveKind)
+	if deleted.RestorePolicy == DeletedVideoRestorePolicyNone {
+		return DeletedVideoRestoreResult{}, deletedVideoNotRestorableError(deleted)
+	}
+	if deleted.RestorePolicy == DeletedVideoRestorePolicyCrawler {
+		prefix := driveKind + "-" + deleted.DriveID + "-"
+		if !strings.HasPrefix(deleted.ID, prefix) {
+			return DeletedVideoRestoreResult{}, fmt.Errorf("%w: crawler source id is unavailable", ErrDeletedVideoNotRestorable)
+		}
+		sourceID := strings.TrimSpace(strings.TrimPrefix(deleted.ID, prefix))
+		if sourceID == "" {
+			return DeletedVideoRestoreResult{}, fmt.Errorf("%w: crawler source id is unavailable", ErrDeletedVideoNotRestorable)
+		}
+		res, err := tx.ExecContext(ctx, `
+UPDATE deleted_videos
+   SET restore_requested = 1
+	WHERE id = ?
+	  AND COALESCE(restore_requested, 0) = 0`, id)
+		if err != nil {
+			return DeletedVideoRestoreResult{}, err
+		}
+		if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+			return DeletedVideoRestoreResult{}, sql.ErrNoRows
+		}
+		if err := tx.Commit(); err != nil {
+			return DeletedVideoRestoreResult{}, err
+		}
+		return DeletedVideoRestoreResult{RestorePolicy: DeletedVideoRestorePolicyCrawler}, nil
+	}
 
+	res, err := tx.ExecContext(ctx, `
+DELETE FROM deleted_videos
+ WHERE id = ?
+   AND COALESCE(restore_requested, 0) = 0`, id)
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return DeletedVideoRestoreResult{}, sql.ErrNoRows
+	}
+	if err := tx.Commit(); err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	return DeletedVideoRestoreResult{RestorePolicy: DeletedVideoRestorePolicyScan}, nil
+}
+
+type deletedVideoRestoreQuerier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (c *Catalog) deletedVideoForRestore(
+	ctx context.Context,
+	query deletedVideoRestoreQuerier,
+	id string,
+) (*DeletedVideo, string, string, error) {
 	var deleted DeletedVideo
 	var sourceDeleted int
 	var driveKind string
 	var restorePayload string
-	err = tx.QueryRowContext(ctx, `
+	err := query.QueryRowContext(ctx, `
 SELECT dv.id,
        COALESCE(dv.drive_id, ''),
        COALESCE(dv.file_id, ''),
@@ -1515,10 +1660,12 @@ SELECT dv.id,
        COALESCE(dv.reason, ''),
        COALESCE(dv.source_deleted, 0),
        COALESCE(dv.restore_payload, ''),
-       COALESCE(d.kind, '')
+       COALESCE(d.kind, ''),
+       COALESCE(dv.deleted_at, 0)
   FROM deleted_videos dv
   LEFT JOIN drives d ON d.id = dv.drive_id
- WHERE dv.id = ?`, id).Scan(
+ WHERE dv.id = ?
+   AND COALESCE(dv.restore_requested, 0) = 0`, id).Scan(
 		&deleted.ID,
 		&deleted.DriveID,
 		&deleted.FileID,
@@ -1529,78 +1676,170 @@ SELECT dv.id,
 		&sourceDeleted,
 		&restorePayload,
 		&driveKind,
+		&deleted.DeletedAt,
 	)
 	if err != nil {
-		return err
+		return nil, "", "", err
 	}
 	deleted.SourceDeleted = sourceDeleted != 0
-	deleted.RestorePolicy = deletedVideoRestorePolicy(&deleted, driveKind)
-	if deleted.RestorePolicy == DeletedVideoRestorePolicyNone {
-		switch {
-		case deleted.SourceDeleted:
-			return fmt.Errorf("%w: source file was deleted", ErrDeletedVideoNotRestorable)
-		case deleted.Reason == DeletedVideoReasonDuplicate:
-			return fmt.Errorf("%w: duplicate videos must use the retained canonical video", ErrDeletedVideoNotRestorable)
-		default:
-			return fmt.Errorf("%w: source does not support rediscovery", ErrDeletedVideoNotRestorable)
+	return &deleted, driveKind, restorePayload, nil
+}
+
+func deletedVideoNotRestorableError(deleted *DeletedVideo) error {
+	switch {
+	case deleted == nil:
+		return sql.ErrNoRows
+	case deleted.SourceDeleted:
+		return fmt.Errorf("%w: source file was deleted", ErrDeletedVideoNotRestorable)
+	case deleted.Reason == DeletedVideoReasonDuplicate:
+		return fmt.Errorf("%w: duplicate videos must use the retained canonical video", ErrDeletedVideoNotRestorable)
+	default:
+		return fmt.Errorf("%w: source does not support rediscovery", ErrDeletedVideoNotRestorable)
+	}
+}
+
+func (c *Catalog) restoreDeletedVideoDirect(
+	ctx context.Context,
+	id string,
+	source DeletedVideoSourceInfo,
+) (DeletedVideoRestoreResult, error) {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	defer tx.Rollback()
+
+	deleted, driveKind, restorePayload, err := c.deletedVideoForRestore(ctx, tx, id)
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	deleted.RestorePolicy = deletedVideoRestorePolicy(deleted, driveKind)
+	if deleted.RestorePolicy != DeletedVideoRestorePolicyDirect {
+		if deleted.RestorePolicy == DeletedVideoRestorePolicyNone {
+			return DeletedVideoRestoreResult{}, deletedVideoNotRestorableError(deleted)
 		}
+		return DeletedVideoRestoreResult{}, fmt.Errorf("%w: restore policy changed to %s", ErrDeletedVideoNotRestorable, deleted.RestorePolicy)
 	}
 
-	// Direct restores rebuild the row here and now: nothing will ever rescan
-	// this source, so deferring to a later pass would leave the video gone for
-	// good. The tombstone payload holds the whole row, so title, author and tags
-	// survive. UpsertVideo owns its own statements, so the read transaction is
-	// released first and the two writes follow the same non-atomic order the
-	// crawler restore path already uses.
-	if deleted.RestorePolicy == DeletedVideoRestorePolicyDirect {
-		if verifySource != nil {
-			if err := verifySource(deleted.DriveID, deleted.FileID); err != nil {
-				return fmt.Errorf("%w: %v", ErrDeletedVideoSourceMissing, err)
+	// A row can coexist with a tombstone only when an older, non-atomic direct
+	// restore inserted the row but failed to remove its tombstone. Treat that row
+	// as the completed restore and only finish the tombstone transition. Replacing
+	// it would discard views, reactions, shares, or edits created in the meantime.
+	existing, existingErr := scanVideo(tx.QueryRowContext(ctx,
+		`SELECT `+allVideoCols+` FROM videos WHERE id = ?`, id))
+	if existingErr == nil {
+		if existing.DriveID != deleted.DriveID || existing.FileID != deleted.FileID {
+			return DeletedVideoRestoreResult{}, fmt.Errorf(
+				"%w: existing video source does not match tombstone", ErrDeletedVideoNotRestorable)
+		}
+		if deletedVideoSourceChanged(deleted, existing, source) {
+			if err := resetPartiallyRestoredVideoSourceTx(ctx, tx, id, source); err != nil {
+				return DeletedVideoRestoreResult{}, err
+			}
+			existing, err = scanVideo(tx.QueryRowContext(ctx,
+				`SELECT `+allVideoCols+` FROM videos WHERE id = ?`, id))
+			if err != nil {
+				return DeletedVideoRestoreResult{}, err
 			}
 		}
-		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
-			return err
+		if err := deletePendingDeletedVideoTx(ctx, tx, id); err != nil {
+			return DeletedVideoRestoreResult{}, err
 		}
-		video, err := directRestoreVideo(&deleted, restorePayload)
-		if err != nil {
-			return err
+		if err := tx.Commit(); err != nil {
+			return DeletedVideoRestoreResult{}, err
 		}
-		if err := c.UpsertVideo(ctx, video); err != nil {
-			return err
-		}
-		return c.PurgeDeletedVideo(ctx, id)
+		return DeletedVideoRestoreResult{
+			RestorePolicy: DeletedVideoRestorePolicyDirect,
+			Video:         existing,
+		}, nil
+	}
+	if !errors.Is(existingErr, sql.ErrNoRows) {
+		return DeletedVideoRestoreResult{}, existingErr
 	}
 
-	if deleted.RestorePolicy == DeletedVideoRestorePolicyCrawler {
-		prefix := driveKind + "-" + deleted.DriveID + "-"
-		if !strings.HasPrefix(deleted.ID, prefix) {
-			return fmt.Errorf("%w: crawler source id is unavailable", ErrDeletedVideoNotRestorable)
-		}
-		sourceID := strings.TrimSpace(strings.TrimPrefix(deleted.ID, prefix))
-		if sourceID == "" {
-			return fmt.Errorf("%w: crawler source id is unavailable", ErrDeletedVideoNotRestorable)
-		}
-		res, err := tx.ExecContext(ctx, `
-UPDATE deleted_videos
-   SET restore_requested = 1
- WHERE id = ?`, id)
-		if err != nil {
-			return err
-		}
-		if rows, err := res.RowsAffected(); err == nil && rows == 0 {
-			return sql.ErrNoRows
-		}
-		return tx.Commit()
+	payload, err := decodeDeletedVideoRestorePayload(deleted.ID, restorePayload)
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
 	}
+	video := directRestoreVideo(deleted, payload.Video, source)
 
-	res, err := tx.ExecContext(ctx, `DELETE FROM deleted_videos WHERE id = ?`, id)
+	// Normal tombstoning removes these relations. Clear any orphaned rows left by
+	// an interrupted legacy/manual repair before recreating the exact tag set.
+	for _, statement := range []string{
+		`DELETE FROM video_tags WHERE video_id = ?`,
+		`DELETE FROM video_shares WHERE video_id = ?`,
+		`DELETE FROM video_reaction_visits WHERE video_id = ?`,
+	} {
+		if _, err := tx.ExecContext(ctx, statement, id); err != nil {
+			return DeletedVideoRestoreResult{}, err
+		}
+	}
+	if _, err := upsertVideoRow(ctx, tx, video); err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	if err := restoreDeletedVideoTagsTx(ctx, tx, video, payload); err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	restoredVideo, err := scanVideo(tx.QueryRowContext(ctx,
+		`SELECT `+allVideoCols+` FROM videos WHERE id = ?`, id))
+	if err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	if err := deletePendingDeletedVideoTx(ctx, tx, id); err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return DeletedVideoRestoreResult{}, err
+	}
+	return DeletedVideoRestoreResult{
+		RestorePolicy: DeletedVideoRestorePolicyDirect,
+		Video:         restoredVideo,
+	}, nil
+}
+
+func deletePendingDeletedVideoTx(ctx context.Context, tx *sql.Tx, id string) error {
+	res, err := tx.ExecContext(ctx, `
+DELETE FROM deleted_videos
+ WHERE id = ?
+   AND COALESCE(restore_requested, 0) = 0`, id)
 	if err != nil {
 		return err
 	}
 	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
 		return sql.ErrNoRows
 	}
-	return tx.Commit()
+	return nil
+}
+
+func resetPartiallyRestoredVideoSourceTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	id string,
+	source DeletedVideoSourceInfo,
+) error {
+	_, err := tx.ExecContext(ctx, `
+UPDATE videos
+   SET size_bytes = ?,
+       content_hash = '',
+       sampled_sha256 = '',
+       fingerprint_status = 'pending',
+       fingerprint_error = '',
+       duration_seconds = 0,
+       thumbnail_url = '',
+       thumbnail_updated_at = 0,
+       thumbnail_status = 'pending',
+       thumbnail_failures = 0,
+       preview_file_id = '',
+       preview_local = '',
+       preview_updated_at = 0,
+       preview_status = 'pending',
+       transcode_status = '',
+       transcode_error = '',
+       transcoded_file_id = '',
+       transcoded_size = 0,
+       updated_at = ?
+ WHERE id = ?`, source.Size, time.Now().UnixMilli(), id)
+	return err
 }
 
 // CrawlerRestoreRequest is a crawler tombstone that the user removed from the
@@ -1645,11 +1884,11 @@ SELECT id,
 			return nil, err
 		}
 		if strings.TrimSpace(payload) != "" {
-			var video Video
-			if err := json.Unmarshal([]byte(payload), &video); err != nil {
-				return nil, fmt.Errorf("catalog: decode restore payload for %s: %w", request.ID, err)
+			restored, err := decodeDeletedVideoRestorePayload(request.ID, payload)
+			if err != nil {
+				return nil, err
 			}
-			request.Video = &video
+			request.Video = restored.Video
 		}
 		out = append(out, request)
 	}
@@ -3386,21 +3625,243 @@ func normalizeDeletedVideoReason(reason string) string {
 	}
 }
 
-// directRestoreVideo rebuilds the catalog row for a direct restore from the
-// tombstone payload. Derived assets (thumbnail, preview, transcode output) were
-// deleted together with the original row, so their state is reset to pending
-// and the generation workers rebuild them; keeping the recorded paths would
-// publish a video pointing at files that no longer exist.
-func directRestoreVideo(deleted *DeletedVideo, restorePayload string) (*Video, error) {
-	if deleted == nil {
+type deletedVideoRestorePayloadQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func buildDeletedVideoRestorePayload(
+	ctx context.Context,
+	query deletedVideoRestorePayloadQuerier,
+	video *Video,
+) ([]byte, error) {
+	if video == nil {
 		return nil, sql.ErrNoRows
 	}
-	video := &Video{}
-	if payload := strings.TrimSpace(restorePayload); payload != "" {
-		if err := json.Unmarshal([]byte(payload), video); err != nil {
-			return nil, fmt.Errorf("catalog: decode restore payload for %s: %w", deleted.ID, err)
+	payload := deletedVideoRestorePayload{
+		Version: deletedVideoRestorePayloadVersion,
+		Video:   video,
+	}
+	var tagsManual int
+	if err := query.QueryRowContext(ctx,
+		`SELECT COALESCE(tags_manual, 0) FROM videos WHERE id = ?`, video.ID,
+	).Scan(&tagsManual); err != nil {
+		return nil, err
+	}
+	payload.TagsManual = tagsManual != 0
+
+	rows, err := query.QueryContext(ctx, `
+SELECT t.label,
+       COALESCE(vt.source, ''),
+       COALESCE(vt.evidence, ''),
+       COALESCE(vt.created_at, 0),
+       COALESCE(t.aliases, '[]'),
+       COALESCE(t.match_rules, '{}'),
+       COALESCE(t.source, 'user'),
+       COALESCE(t.origin, ''),
+       COALESCE(t.created_at, 0),
+       COALESCE(t.updated_at, 0)
+  FROM video_tags vt
+  JOIN tags t ON t.id = vt.tag_id
+ WHERE vt.video_id = ?
+ ORDER BY vt.created_at, t.id`, video.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var assignment deletedVideoTagRestoreAssignment
+		if err := rows.Scan(
+			&assignment.Label,
+			&assignment.Source,
+			&assignment.Evidence,
+			&assignment.CreatedAt,
+			&assignment.TagAliases,
+			&assignment.TagMatchRules,
+			&assignment.TagSource,
+			&assignment.TagOrigin,
+			&assignment.TagCreatedAt,
+			&assignment.TagUpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		payload.TagAssignments = append(payload.TagAssignments, assignment)
+		seen[strings.ToLower(strings.TrimSpace(assignment.Label))] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Heal old or externally-written rows whose JSON labels have no matching
+	// relation. Their provenance is unknowable; preserve an explicit manual lock
+	// when present and otherwise leave them replaceable by automatic retagging.
+	for _, label := range video.Tags {
+		key := strings.ToLower(strings.TrimSpace(label))
+		if key == "" || seen[key] {
+			continue
+		}
+		payload.TagAssignments = append(payload.TagAssignments,
+			fallbackDeletedVideoTagAssignment(label, payload.TagsManual))
+	}
+	return json.Marshal(payload)
+}
+
+func decodeDeletedVideoRestorePayload(id, encoded string) (deletedVideoRestorePayload, error) {
+	encoded = strings.TrimSpace(encoded)
+	if encoded == "" {
+		return deletedVideoRestorePayload{Version: deletedVideoRestorePayloadVersion}, nil
+	}
+	var probe struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(encoded), &probe); err != nil {
+		return deletedVideoRestorePayload{}, fmt.Errorf("catalog: decode restore payload for %s: %w", id, err)
+	}
+	var payload deletedVideoRestorePayload
+	if probe.Version > 0 {
+		if probe.Version != deletedVideoRestorePayloadVersion {
+			return deletedVideoRestorePayload{}, fmt.Errorf(
+				"catalog: decode restore payload for %s: unsupported version %d", id, probe.Version)
+		}
+		if err := json.Unmarshal([]byte(encoded), &payload); err != nil {
+			return deletedVideoRestorePayload{}, fmt.Errorf("catalog: decode restore payload for %s: %w", id, err)
+		}
+		if payload.Video == nil {
+			return deletedVideoRestorePayload{}, fmt.Errorf("catalog: decode restore payload for %s: missing video", id)
+		}
+	} else {
+		// Versions before this follow-up stored a raw Video JSON object. Assignment
+		// provenance cannot be recovered, so retaining its labels as manual is the
+		// only backward-compatible choice that does not discard user selections.
+		var video Video
+		if err := json.Unmarshal([]byte(encoded), &video); err != nil {
+			return deletedVideoRestorePayload{}, fmt.Errorf("catalog: decode restore payload for %s: %w", id, err)
+		}
+		payload = deletedVideoRestorePayload{
+			Version:    deletedVideoRestorePayloadVersion,
+			Video:      &video,
+			TagsManual: len(video.Tags) > 0,
 		}
 	}
+	if payload.Video != nil && len(payload.TagAssignments) == 0 {
+		for _, label := range payload.Video.Tags {
+			payload.TagAssignments = append(payload.TagAssignments,
+				fallbackDeletedVideoTagAssignment(label, payload.TagsManual))
+		}
+	}
+	if payload.Video != nil && len(payload.Video.Tags) == 0 && len(payload.TagAssignments) > 0 {
+		for _, assignment := range payload.TagAssignments {
+			payload.Video.Tags = append(payload.Video.Tags, assignment.Label)
+		}
+	}
+	return payload, nil
+}
+
+func fallbackDeletedVideoTagAssignment(label string, manual bool) deletedVideoTagRestoreAssignment {
+	assignment := deletedVideoTagRestoreAssignment{
+		Label:         strings.TrimSpace(label),
+		Source:        "auto",
+		TagAliases:    "[]",
+		TagMatchRules: "{}",
+		TagSource:     "generated",
+	}
+	if manual {
+		assignment.Source = "manual"
+		assignment.TagSource = "user"
+	}
+	return assignment
+}
+
+func restoreDeletedVideoTagsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	video *Video,
+	payload deletedVideoRestorePayload,
+) error {
+	if video == nil {
+		return sql.ErrNoRows
+	}
+	now := time.Now().UnixMilli()
+	for _, assignment := range payload.TagAssignments {
+		assignment.Label = strings.TrimSpace(assignment.Label)
+		if assignment.Label == "" {
+			continue
+		}
+		if !json.Valid([]byte(assignment.TagAliases)) {
+			assignment.TagAliases = "[]"
+		}
+		if !json.Valid([]byte(assignment.TagMatchRules)) {
+			assignment.TagMatchRules = "{}"
+		}
+		if strings.TrimSpace(assignment.TagSource) == "" {
+			assignment.TagSource = "generated"
+			if payload.TagsManual || assignment.Source == "manual" {
+				assignment.TagSource = "user"
+			}
+		}
+		if assignment.TagCreatedAt <= 0 {
+			assignment.TagCreatedAt = now
+		}
+		if assignment.TagUpdatedAt <= 0 {
+			assignment.TagUpdatedAt = assignment.TagCreatedAt
+		}
+		if assignment.CreatedAt <= 0 {
+			assignment.CreatedAt = now
+		}
+		if strings.TrimSpace(assignment.Source) == "" {
+			assignment.Source = "auto"
+			if payload.TagsManual {
+				assignment.Source = "manual"
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO tags (label, aliases, match_rules, source, origin, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(label) DO NOTHING`,
+			assignment.Label,
+			assignment.TagAliases,
+			assignment.TagMatchRules,
+			assignment.TagSource,
+			assignment.TagOrigin,
+			assignment.TagCreatedAt,
+			assignment.TagUpdatedAt,
+		); err != nil {
+			return err
+		}
+		var tagID int64
+		if err := tx.QueryRowContext(ctx,
+			`SELECT id FROM tags WHERE label = ? COLLATE NOCASE`, assignment.Label,
+		).Scan(&tagID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO video_tags (video_id, tag_id, source, evidence, created_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(video_id, tag_id) DO UPDATE SET
+  source = excluded.source,
+  evidence = excluded.evidence,
+  created_at = excluded.created_at`,
+			video.ID, tagID, assignment.Source, assignment.Evidence, assignment.CreatedAt,
+		); err != nil {
+			return err
+		}
+	}
+	return syncVideoTagsJSONTx(ctx, tx, video.ID, payload.TagsManual)
+}
+
+// directRestoreVideo rebuilds the catalog row for a direct restore. Derived
+// assets were deleted with the original row, so their paths and state are reset
+// for application workers. Provider-observed size/timestamps make legacy
+// payloads usable and invalidate fingerprints if the retained file changed.
+func directRestoreVideo(deleted *DeletedVideo, restoreVideo *Video, source DeletedVideoSourceInfo) *Video {
+	video := &Video{}
+	if restoreVideo != nil {
+		copy := *restoreVideo
+		copy.Tags = append([]string(nil), restoreVideo.Tags...)
+		copy.Badges = append([]string(nil), restoreVideo.Badges...)
+		video = &copy
+	}
+	originalSize := video.Size
 	video.ID = deleted.ID
 	video.DriveID = deleted.DriveID
 	video.FileID = deleted.FileID
@@ -3414,8 +3875,35 @@ func directRestoreVideo(deleted *DeletedVideo, restorePayload string) (*Video, e
 	if strings.TrimSpace(video.Title) == "" {
 		video.Title = strings.TrimSuffix(video.FileName, path.Ext(video.FileName))
 	}
-	if video.Size <= 0 {
-		video.Size = deleted.Size
+	if strings.TrimSpace(video.Ext) == "" {
+		video.Ext = strings.TrimPrefix(strings.ToLower(path.Ext(video.FileName)), ".")
+	}
+	original := *video
+	original.Size = originalSize
+	if deletedVideoSourceChanged(deleted, &original, source) {
+		video.ContentHash = ""
+		video.SampledSHA256 = ""
+		video.FingerprintStatus = "pending"
+		video.FingerprintError = ""
+		video.DurationSeconds = 0
+	}
+	if video.SampledSHA256 == "" && video.FingerprintStatus == "ready" {
+		video.FingerprintStatus = "pending"
+		video.FingerprintError = ""
+	}
+	video.Size = source.Size
+	fallbackTime := source.ModTime
+	if fallbackTime.IsZero() && deleted.DeletedAt > 0 {
+		fallbackTime = time.UnixMilli(deleted.DeletedAt)
+	}
+	if fallbackTime.IsZero() {
+		fallbackTime = time.Now()
+	}
+	if video.CreatedAt.IsZero() {
+		video.CreatedAt = fallbackTime
+	}
+	if video.PublishedAt.IsZero() {
+		video.PublishedAt = video.CreatedAt
 	}
 	// The row was tombstoned, never hidden; restoring it must not resurrect the
 	// deprecated hidden flag even if an old payload carried it.
@@ -3430,7 +3918,36 @@ func directRestoreVideo(deleted *DeletedVideo, restorePayload string) (*Video, e
 	video.TranscodeError = ""
 	video.TranscodedFileID = ""
 	video.TranscodedSize = 0
-	return video, nil
+	return video
+}
+
+func deletedVideoSourceChanged(
+	deleted *DeletedVideo,
+	video *Video,
+	source DeletedVideoSourceInfo,
+) bool {
+	expectedSize := int64(0)
+	if deleted != nil {
+		expectedSize = deleted.Size
+	}
+	if expectedSize <= 0 && video != nil {
+		expectedSize = video.Size
+	}
+	if expectedSize > 0 && source.Size != expectedSize {
+		return true
+	}
+	if video != nil && video.Size != source.Size {
+		return true
+	}
+	// deleted_at is millisecond precision. Requiring a full millisecond beyond
+	// it avoids treating a source written in the same truncated millisecond as a
+	// post-tombstone replacement.
+	if deleted != nil && !source.ModTime.IsZero() && deleted.DeletedAt > 0 &&
+		source.ModTime.After(time.UnixMilli(deleted.DeletedAt).Add(time.Millisecond)) {
+		return true
+	}
+	return expectedSize <= 0 && video != nil &&
+		(video.ContentHash != "" || video.SampledSHA256 != "")
 }
 
 // deletedVideoRestorePolicy decides how (and whether) a tombstone can go back

--- a/backend/internal/catalog/catalog.go
+++ b/backend/internal/catalog/catalog.go
@@ -1086,9 +1086,22 @@ const (
 	DeletedVideoRestorePolicyNone    = "none"
 	DeletedVideoRestorePolicyScan    = "scan"
 	DeletedVideoRestorePolicyCrawler = "crawler"
+	// DeletedVideoRestorePolicyDirect covers sources whose file is retained by
+	// this application but that cannot be enumerated, so no scan or crawl will
+	// ever rediscover them. Local uploads are the only such source today: the
+	// drive supports Stat but returns ErrNotSupported for List. The tombstone
+	// already carries the full restore payload, so the row is rebuilt directly
+	// instead of waiting for a rediscovery pass that would never come.
+	DeletedVideoRestorePolicyDirect = "direct"
 )
 
-var ErrDeletedVideoNotRestorable = errors.New("deleted video is not restorable")
+var (
+	ErrDeletedVideoNotRestorable = errors.New("deleted video is not restorable")
+	// ErrDeletedVideoSourceMissing means a direct restore was attempted but the
+	// retained source file is gone, so rebuilding the row would publish a video
+	// that cannot be played.
+	ErrDeletedVideoSourceMissing = errors.New("deleted video source file is missing")
+)
 
 type DeleteVideoTombstoneOptions struct {
 	Reason           string
@@ -1466,6 +1479,18 @@ func (c *Catalog) PurgeDeletedVideo(ctx context.Context, id string) error {
 // 扫描或爬取。爬虫来源会保留墓碑和 seen 记录，并标记为待目录扫描恢复，
 // 使下一轮爬取仍将其当作已见来源跳过。
 func (c *Catalog) RemoveDeletedVideo(ctx context.Context, id string) error {
+	return c.RemoveDeletedVideoWithSourceCheck(ctx, id, nil)
+}
+
+// RemoveDeletedVideoWithSourceCheck 与 RemoveDeletedVideo 相同，但在 direct
+// 策略当场重建记录之前，先让调用方确认保留下来的源文件还在——只有这条路径
+// 会无条件写回记录，文件已经不在时必须拒绝，否则库里会多出一条点开就播放
+// 失败的视频。verifySource 为 nil 时跳过校验。
+func (c *Catalog) RemoveDeletedVideoWithSourceCheck(
+	ctx context.Context,
+	id string,
+	verifySource func(driveID, fileID string) error,
+) error {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return sql.ErrNoRows
@@ -1479,19 +1504,30 @@ func (c *Catalog) RemoveDeletedVideo(ctx context.Context, id string) error {
 	var deleted DeletedVideo
 	var sourceDeleted int
 	var driveKind string
+	var restorePayload string
 	err = tx.QueryRowContext(ctx, `
 SELECT dv.id,
        COALESCE(dv.drive_id, ''),
+       COALESCE(dv.file_id, ''),
+       COALESCE(dv.parent_id, ''),
+       COALESCE(dv.file_name, ''),
+       COALESCE(dv.size_bytes, 0),
        COALESCE(dv.reason, ''),
        COALESCE(dv.source_deleted, 0),
+       COALESCE(dv.restore_payload, ''),
        COALESCE(d.kind, '')
   FROM deleted_videos dv
   LEFT JOIN drives d ON d.id = dv.drive_id
  WHERE dv.id = ?`, id).Scan(
 		&deleted.ID,
 		&deleted.DriveID,
+		&deleted.FileID,
+		&deleted.ParentID,
+		&deleted.FileName,
+		&deleted.Size,
 		&deleted.Reason,
 		&sourceDeleted,
+		&restorePayload,
 		&driveKind,
 	)
 	if err != nil {
@@ -1508,6 +1544,31 @@ SELECT dv.id,
 		default:
 			return fmt.Errorf("%w: source does not support rediscovery", ErrDeletedVideoNotRestorable)
 		}
+	}
+
+	// Direct restores rebuild the row here and now: nothing will ever rescan
+	// this source, so deferring to a later pass would leave the video gone for
+	// good. The tombstone payload holds the whole row, so title, author and tags
+	// survive. UpsertVideo owns its own statements, so the read transaction is
+	// released first and the two writes follow the same non-atomic order the
+	// crawler restore path already uses.
+	if deleted.RestorePolicy == DeletedVideoRestorePolicyDirect {
+		if verifySource != nil {
+			if err := verifySource(deleted.DriveID, deleted.FileID); err != nil {
+				return fmt.Errorf("%w: %v", ErrDeletedVideoSourceMissing, err)
+			}
+		}
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			return err
+		}
+		video, err := directRestoreVideo(&deleted, restorePayload)
+		if err != nil {
+			return err
+		}
+		if err := c.UpsertVideo(ctx, video); err != nil {
+			return err
+		}
+		return c.PurgeDeletedVideo(ctx, id)
 	}
 
 	if deleted.RestorePolicy == DeletedVideoRestorePolicyCrawler {
@@ -3325,12 +3386,65 @@ func normalizeDeletedVideoReason(reason string) string {
 	}
 }
 
+// directRestoreVideo rebuilds the catalog row for a direct restore from the
+// tombstone payload. Derived assets (thumbnail, preview, transcode output) were
+// deleted together with the original row, so their state is reset to pending
+// and the generation workers rebuild them; keeping the recorded paths would
+// publish a video pointing at files that no longer exist.
+func directRestoreVideo(deleted *DeletedVideo, restorePayload string) (*Video, error) {
+	if deleted == nil {
+		return nil, sql.ErrNoRows
+	}
+	video := &Video{}
+	if payload := strings.TrimSpace(restorePayload); payload != "" {
+		if err := json.Unmarshal([]byte(payload), video); err != nil {
+			return nil, fmt.Errorf("catalog: decode restore payload for %s: %w", deleted.ID, err)
+		}
+	}
+	video.ID = deleted.ID
+	video.DriveID = deleted.DriveID
+	video.FileID = deleted.FileID
+	video.ParentID = deleted.ParentID
+	if strings.TrimSpace(video.FileName) == "" {
+		video.FileName = strings.TrimSpace(deleted.FileName)
+	}
+	if strings.TrimSpace(video.FileName) == "" {
+		video.FileName = deleted.FileID
+	}
+	if strings.TrimSpace(video.Title) == "" {
+		video.Title = strings.TrimSuffix(video.FileName, path.Ext(video.FileName))
+	}
+	if video.Size <= 0 {
+		video.Size = deleted.Size
+	}
+	// The row was tombstoned, never hidden; restoring it must not resurrect the
+	// deprecated hidden flag even if an old payload carried it.
+	video.Hidden = false
+	video.ThumbnailURL = ""
+	video.ThumbnailUpdatedAt = time.Time{}
+	video.PreviewFileID = ""
+	video.PreviewLocal = ""
+	video.PreviewUpdatedAt = time.Time{}
+	video.PreviewStatus = "pending"
+	video.TranscodeStatus = ""
+	video.TranscodeError = ""
+	video.TranscodedFileID = ""
+	video.TranscodedSize = 0
+	return video, nil
+}
+
+// deletedVideoRestorePolicy decides how (and whether) a tombstone can go back
+// to the library. The order matters: a missing source file and a deduplicated
+// row are unrestorable no matter which drive they came from, so those are
+// checked before the per-drive branches below.
 func deletedVideoRestorePolicy(v *DeletedVideo, driveKind string) string {
 	if v == nil ||
 		v.SourceDeleted ||
-		v.Reason == DeletedVideoReasonDuplicate ||
-		strings.TrimSpace(v.DriveID) == "local-upload" {
+		v.Reason == DeletedVideoReasonDuplicate {
 		return DeletedVideoRestorePolicyNone
+	}
+	if strings.TrimSpace(v.DriveID) == "local-upload" {
+		return DeletedVideoRestorePolicyDirect
 	}
 	if strings.TrimSpace(driveKind) == "scriptcrawler" {
 		return DeletedVideoRestorePolicyCrawler

--- a/backend/internal/catalog/video_management_test.go
+++ b/backend/internal/catalog/video_management_test.go
@@ -264,15 +264,41 @@ func TestBlacklistRestorePolicies(t *testing.T) {
 		t.Fatalf("source-deleted catalog lookup error = %v, want sql.ErrNoRows", err)
 	}
 
+	// 本地上传的源文件被保留，但这个盘不支持枚举，永远不会被扫盘或爬取重新
+	// 发现，所以取消拉黑必须当场重建记录。
 	seedVideo("local-upload-video", "local-upload", "upload-file", "Upload")
 	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-video"); err != nil {
 		t.Fatalf("tombstone local upload: %v", err)
 	}
-	if got := findDeleted("local-upload-video").RestorePolicy; got != DeletedVideoRestorePolicyNone {
-		t.Fatalf("local upload restore policy = %q, want %q", got, DeletedVideoRestorePolicyNone)
+	if got := findDeleted("local-upload-video").RestorePolicy; got != DeletedVideoRestorePolicyDirect {
+		t.Fatalf("local upload restore policy = %q, want %q", got, DeletedVideoRestorePolicyDirect)
 	}
-	if err := cat.RemoveDeletedVideo(ctx, "local-upload-video"); !errors.Is(err, ErrDeletedVideoNotRestorable) {
-		t.Fatalf("restore local upload error = %v, want ErrDeletedVideoNotRestorable", err)
+
+	// 源文件已删的本地上传仍然不可恢复：source_deleted 的优先级高于来源类型。
+	seedVideo("local-upload-gone", "local-upload", "gone-file", "Gone upload")
+	if err := cat.DeleteVideoWithTombstoneOptions(ctx, "local-upload-gone", DeleteVideoTombstoneOptions{
+		SourceDeleted: true,
+	}); err != nil {
+		t.Fatalf("delete local upload with source: %v", err)
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, "local-upload-gone"); err != nil || deleted {
+		t.Fatalf("source-deleted local upload should not keep tombstone: deleted=%v err=%v", deleted, err)
+	}
+
+	// 被去重删掉的本地上传也仍然不可恢复：应当去看保留下来的那一条。
+	seedVideo("local-upload-canonical", "local-upload", "canonical-file", "Canonical upload")
+	seedVideo("local-upload-duplicate", "local-upload", "duplicate-file", "Duplicate upload")
+	if err := cat.DeleteVideoWithTombstoneOptions(ctx, "local-upload-duplicate", DeleteVideoTombstoneOptions{
+		Reason:           DeletedVideoReasonDuplicate,
+		CanonicalVideoID: "local-upload-canonical",
+	}); err != nil {
+		t.Fatalf("tombstone duplicate local upload: %v", err)
+	}
+	if got := findDeleted("local-upload-duplicate").RestorePolicy; got != DeletedVideoRestorePolicyNone {
+		t.Fatalf("duplicate local upload restore policy = %q, want %q", got, DeletedVideoRestorePolicyNone)
+	}
+	if err := cat.RemoveDeletedVideo(ctx, "local-upload-duplicate"); !errors.Is(err, ErrDeletedVideoNotRestorable) {
+		t.Fatalf("restore duplicate local upload error = %v, want ErrDeletedVideoNotRestorable", err)
 	}
 
 	seedVideo("canonical-video", "remote", "canonical", "Canonical title")
@@ -293,11 +319,124 @@ func TestBlacklistRestorePolicies(t *testing.T) {
 		t.Fatalf("restore duplicate error = %v, want ErrDeletedVideoNotRestorable", err)
 	}
 
-	for _, id := range []string{"local-upload-video", "duplicate-video"} {
+	for _, id := range []string{"local-upload-duplicate", "duplicate-video"} {
 		deleted, err := cat.IsVideoDeleted(ctx, id)
 		if err != nil || !deleted {
 			t.Fatalf("non-restorable tombstone %s was removed: deleted=%v err=%v", id, deleted, err)
 		}
+	}
+}
+
+// 取消拉黑本地上传时记录当场重建，且标题、作者、标签这些用户数据都要跟着回来
+// ——墓碑里存的是完整的 restore payload。派生资源（封面/预览/转码产物）在拉黑
+// 时已被删除，必须重置为待生成，否则会指向不存在的文件。
+func TestRemoveDeletedVideoDirectRestoresLocalUploadLosslessly(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &Video{
+		ID: "local-upload-rich", DriveID: "local-upload", FileID: "rich.mp4",
+		FileName: "rich.mp4", Title: "用户起的标题", Author: "上传者",
+		Tags: []string{"标签一", "标签二"}, Description: "简介", DurationSeconds: 42,
+		Size: 4096, Ext: "mp4", Quality: "HD",
+		ThumbnailURL: "/p/thumb/local-upload-rich", PreviewLocal: "/data/previews/local-upload-rich.mp4",
+		PreviewStatus: "ready", TranscodeStatus: "ready", TranscodedFileID: "transcoded.mp4",
+		TranscodedSize: 2048, Views: 7, Likes: 3,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-rich"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	if _, err := cat.GetVideo(ctx, "local-upload-rich"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("video lookup after tombstone = %v, want sql.ErrNoRows", err)
+	}
+
+	if err := cat.RemoveDeletedVideo(ctx, "local-upload-rich"); err != nil {
+		t.Fatalf("remove blacklist: %v", err)
+	}
+
+	restored, err := cat.GetVideo(ctx, "local-upload-rich")
+	if err != nil {
+		t.Fatalf("get restored video: %v", err)
+	}
+	if restored.Title != "用户起的标题" || restored.Author != "上传者" ||
+		restored.Description != "简介" || restored.DurationSeconds != 42 {
+		t.Fatalf("user metadata lost: %#v", restored)
+	}
+	if len(restored.Tags) != 2 || restored.Tags[0] != "标签一" || restored.Tags[1] != "标签二" {
+		t.Fatalf("tags = %#v, want both restored", restored.Tags)
+	}
+	if restored.DriveID != "local-upload" || restored.FileID != "rich.mp4" || restored.Size != 4096 {
+		t.Fatalf("source identity lost: %#v", restored)
+	}
+	if restored.Hidden {
+		t.Fatalf("restored video must not be hidden")
+	}
+	if restored.ThumbnailURL != "" || restored.PreviewLocal != "" ||
+		restored.PreviewStatus != "pending" {
+		t.Fatalf("derived assets not reset: thumb=%q preview=%q status=%q",
+			restored.ThumbnailURL, restored.PreviewLocal, restored.PreviewStatus)
+	}
+	if restored.TranscodeStatus != "" || restored.TranscodedFileID != "" || restored.TranscodedSize != 0 {
+		t.Fatalf("transcode state not reset: %#v", restored)
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, "local-upload-rich"); err != nil || deleted {
+		t.Fatalf("tombstone still present after restore: deleted=%v err=%v", deleted, err)
+	}
+	current, blacklisted, err := cat.VideoManagementCounts(ctx)
+	if err != nil {
+		t.Fatalf("counts: %v", err)
+	}
+	if current != 1 || blacklisted != 0 {
+		t.Fatalf("counts = current %d blacklisted %d, want 1/0", current, blacklisted)
+	}
+}
+
+// 墓碑是老版本写的、restore_payload 为空时，仍然要能恢复出一条可用记录：
+// 标题从文件名兜底，大小取墓碑里的值。
+func TestRemoveDeletedVideoDirectRestoresWithoutPayload(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &Video{
+		ID: "legacy-upload", DriveID: "local-upload", FileID: "legacy.mp4",
+		FileName: "我的视频.mp4", Title: "旧标题", Size: 512,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "legacy-upload"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	if _, err := cat.db.ExecContext(ctx,
+		`UPDATE deleted_videos SET restore_payload = '' WHERE id = ?`, "legacy-upload"); err != nil {
+		t.Fatalf("clear restore payload: %v", err)
+	}
+
+	if err := cat.RemoveDeletedVideo(ctx, "legacy-upload"); err != nil {
+		t.Fatalf("remove blacklist: %v", err)
+	}
+	restored, err := cat.GetVideo(ctx, "legacy-upload")
+	if err != nil {
+		t.Fatalf("get restored video: %v", err)
+	}
+	if restored.FileName != "我的视频.mp4" || restored.Title != "我的视频" {
+		t.Fatalf("fallback identity = file %q title %q", restored.FileName, restored.Title)
+	}
+	if restored.FileID != "legacy.mp4" || restored.Size != 512 {
+		t.Fatalf("fallback source = file %q size %d", restored.FileID, restored.Size)
 	}
 }
 

--- a/backend/internal/catalog/video_management_test.go
+++ b/backend/internal/catalog/video_management_test.go
@@ -273,6 +273,9 @@ func TestBlacklistRestorePolicies(t *testing.T) {
 	if got := findDeleted("local-upload-video").RestorePolicy; got != DeletedVideoRestorePolicyDirect {
 		t.Fatalf("local upload restore policy = %q, want %q", got, DeletedVideoRestorePolicyDirect)
 	}
+	if err := cat.RemoveDeletedVideo(ctx, "local-upload-video"); !errors.Is(err, ErrDeletedVideoSourceCheckRequired) {
+		t.Fatalf("unchecked direct restore error = %v, want ErrDeletedVideoSourceCheckRequired", err)
+	}
 
 	// 源文件已删的本地上传仍然不可恢复：source_deleted 的优先级高于来源类型。
 	seedVideo("local-upload-gone", "local-upload", "gone-file", "Gone upload")
@@ -358,8 +361,14 @@ func TestRemoveDeletedVideoDirectRestoresLocalUploadLosslessly(t *testing.T) {
 		t.Fatalf("video lookup after tombstone = %v, want sql.ErrNoRows", err)
 	}
 
-	if err := cat.RemoveDeletedVideo(ctx, "local-upload-rich"); err != nil {
+	result, err := cat.RestoreDeletedVideo(ctx, "local-upload-rich", func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: 4096, ModTime: now}, nil
+	})
+	if err != nil {
 		t.Fatalf("remove blacklist: %v", err)
+	}
+	if result.RestorePolicy != DeletedVideoRestorePolicyDirect || result.Video == nil {
+		t.Fatalf("restore result = %#v, want direct video", result)
 	}
 
 	restored, err := cat.GetVideo(ctx, "local-upload-rich")
@@ -425,8 +434,14 @@ func TestRemoveDeletedVideoDirectRestoresWithoutPayload(t *testing.T) {
 		t.Fatalf("clear restore payload: %v", err)
 	}
 
-	if err := cat.RemoveDeletedVideo(ctx, "legacy-upload"); err != nil {
+	result, err := cat.RestoreDeletedVideo(ctx, "legacy-upload", func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: 512, ModTime: now.Add(-time.Hour)}, nil
+	})
+	if err != nil {
 		t.Fatalf("remove blacklist: %v", err)
+	}
+	if result.Video == nil {
+		t.Fatal("legacy direct restore did not return a video")
 	}
 	restored, err := cat.GetVideo(ctx, "legacy-upload")
 	if err != nil {
@@ -437,6 +452,233 @@ func TestRemoveDeletedVideoDirectRestoresWithoutPayload(t *testing.T) {
 	}
 	if restored.FileID != "legacy.mp4" || restored.Size != 512 {
 		t.Fatalf("fallback source = file %q size %d", restored.FileID, restored.Size)
+	}
+	if restored.PublishedAt.IsZero() || restored.PublishedAt.Year() == 1 {
+		t.Fatalf("fallback published_at = %v, want a usable timestamp", restored.PublishedAt)
+	}
+}
+
+func TestRemoveDeletedVideoDirectPreservesAutomaticTagProvenance(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &Video{
+		ID: "local-upload-auto-tags", DriveID: "local-upload", FileID: "auto-tags.mp4",
+		FileName: "auto-tags.mp4", Title: "自动标签示例", Size: 1024,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	res, err := cat.db.ExecContext(ctx, `
+INSERT INTO tags (label, aliases, match_rules, source, origin, created_at, updated_at)
+VALUES (?, '[]', '{}', 'generated', '', ?, ?)`, "自动标签", now.UnixMilli(), now.UnixMilli())
+	if err != nil {
+		t.Fatalf("seed automatic tag: %v", err)
+	}
+	tagID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("automatic tag id: %v", err)
+	}
+	if _, _, err := cat.upsertVideoTagAssignment(ctx, "local-upload-auto-tags", tagID, "auto", "标题:自动标签"); err != nil {
+		t.Fatalf("assign automatic tag: %v", err)
+	}
+	if err := cat.syncVideoTagsJSON(ctx, "local-upload-auto-tags", false); err != nil {
+		t.Fatalf("sync automatic tag JSON: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-auto-tags"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+
+	if _, err := cat.RestoreDeletedVideo(ctx, "local-upload-auto-tags", func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: 1024, ModTime: now}, nil
+	}); err != nil {
+		t.Fatalf("restore video: %v", err)
+	}
+	var tagsManual int
+	var assignmentSource, tagSource string
+	if err := cat.db.QueryRowContext(ctx, `
+SELECT COALESCE(v.tags_manual, 0), vt.source, t.source
+  FROM videos v
+  JOIN video_tags vt ON vt.video_id = v.id
+  JOIN tags t ON t.id = vt.tag_id
+ WHERE v.id = ? AND t.label = ?`, "local-upload-auto-tags", "自动标签").Scan(
+		&tagsManual, &assignmentSource, &tagSource,
+	); err != nil {
+		t.Fatalf("read restored tag provenance: %v", err)
+	}
+	if tagsManual != 0 || assignmentSource != "auto" || tagSource != "generated" {
+		t.Fatalf("restored tag provenance = manual:%d assignment:%q tag:%q", tagsManual, assignmentSource, tagSource)
+	}
+}
+
+func TestRemoveDeletedVideoDirectIsAtomicWhenTombstoneDeleteFails(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &Video{
+		ID: "local-upload-atomic", DriveID: "local-upload", FileID: "atomic.mp4",
+		FileName: "atomic.mp4", Title: "Atomic", Size: 2048,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-atomic"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	if _, err := cat.db.ExecContext(ctx, `
+CREATE TRIGGER fail_direct_restore_tombstone_delete
+BEFORE DELETE ON deleted_videos
+WHEN OLD.id = 'local-upload-atomic'
+BEGIN
+  SELECT RAISE(ABORT, 'injected tombstone delete failure');
+END`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+
+	if _, err := cat.RestoreDeletedVideo(ctx, "local-upload-atomic", func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: 2048, ModTime: now}, nil
+	}); err == nil {
+		t.Fatal("direct restore unexpectedly succeeded")
+	}
+	if _, err := cat.GetVideo(ctx, "local-upload-atomic"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("video row escaped failed restore transaction: %v", err)
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, "local-upload-atomic"); err != nil || !deleted {
+		t.Fatalf("tombstone lost after failed restore: deleted=%v err=%v", deleted, err)
+	}
+}
+
+func TestRemoveDeletedVideoDirectFinishesLegacyPartialRestoreWithoutLosingActivity(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	original := &Video{
+		ID: "local-upload-partial", DriveID: "local-upload", FileID: "partial.mp4",
+		FileName: "partial.mp4", Title: "Before partial restore", Size: 2048,
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := cat.UpsertVideo(ctx, original); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, original.ID); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+
+	// PR #89 could leave this state when UpsertVideo succeeded and the following
+	// tombstone purge failed. Activity and edits made on the visible row must
+	// survive a retry under the atomic follow-up implementation.
+	partial := *original
+	partial.Title = "Edited after partial restore"
+	partial.Views = 17
+	partial.Likes = 3
+	if err := cat.UpsertVideo(ctx, &partial); err != nil {
+		t.Fatalf("seed partial restore row: %v", err)
+	}
+	if _, err := cat.db.ExecContext(ctx, `
+INSERT INTO video_shares (id, token_hash, video_id, created_at)
+VALUES ('partial-share', 'partial-token', ?, ?)`, original.ID, now.UnixMilli()); err != nil {
+		t.Fatalf("seed partial restore share: %v", err)
+	}
+	if _, err := cat.db.ExecContext(ctx, `
+INSERT INTO video_reaction_visits (video_id, visit_id, reaction, created_at, updated_at)
+VALUES (?, 'partial-visit', 'like', ?, ?)`, original.ID, now.UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatalf("seed partial restore reaction: %v", err)
+	}
+
+	result, err := cat.RestoreDeletedVideo(ctx, original.ID, func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: original.Size, ModTime: now}, nil
+	})
+	if err != nil {
+		t.Fatalf("finish partial restore: %v", err)
+	}
+	if result.Video == nil || result.Video.Title != partial.Title ||
+		result.Video.Views != partial.Views || result.Video.Likes != partial.Likes {
+		t.Fatalf("partial row was replaced: %#v", result.Video)
+	}
+	for name, query := range map[string]string{
+		"share":    `SELECT COUNT(*) FROM video_shares WHERE video_id = 'local-upload-partial'`,
+		"reaction": `SELECT COUNT(*) FROM video_reaction_visits WHERE video_id = 'local-upload-partial'`,
+	} {
+		var count int
+		if err := cat.db.QueryRowContext(ctx, query).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("preserved %s count = %d err=%v, want 1", name, count, err)
+		}
+	}
+	if deleted, err := cat.IsVideoDeleted(ctx, original.ID); err != nil || deleted {
+		t.Fatalf("partial restore tombstone remains: deleted=%v err=%v", deleted, err)
+	}
+}
+
+func TestRemoveDeletedVideoDirectRefreshesChangedSourceMetadata(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	if err := cat.UpsertVideo(ctx, &Video{
+		ID: "local-upload-replaced", DriveID: "local-upload", FileID: "replaced.mp4",
+		FileName: "replaced.mp4", Title: "Replaced", Size: 100,
+		ContentHash: "old-content", SampledSHA256: "old-sample", FingerprintStatus: "ready",
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-replaced"); err != nil {
+		t.Fatalf("tombstone video: %v", err)
+	}
+	if _, err := cat.RestoreDeletedVideo(ctx, "local-upload-replaced", func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: 200, ModTime: now.Add(time.Minute)}, nil
+	}); err != nil {
+		t.Fatalf("restore replaced source: %v", err)
+	}
+	restored, err := cat.GetVideo(ctx, "local-upload-replaced")
+	if err != nil {
+		t.Fatalf("get restored video: %v", err)
+	}
+	if restored.Size != 200 || restored.ContentHash != "" || restored.SampledSHA256 != "" || restored.FingerprintStatus != "pending" {
+		t.Fatalf("changed source metadata was not invalidated: %#v", restored)
+	}
+
+	if err := cat.UpsertVideo(ctx, &Video{
+		ID: "local-upload-replaced-same-size", DriveID: "local-upload", FileID: "same-size.mp4",
+		FileName: "same-size.mp4", Title: "Same-size replacement", Size: 100,
+		ContentHash: "same-old-content", SampledSHA256: "same-old-sample", FingerprintStatus: "ready",
+		PublishedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed same-size video: %v", err)
+	}
+	if err := cat.DeleteVideoWithTombstone(ctx, "local-upload-replaced-same-size"); err != nil {
+		t.Fatalf("tombstone same-size video: %v", err)
+	}
+	if _, err := cat.RestoreDeletedVideo(ctx, "local-upload-replaced-same-size", func(string, string) (DeletedVideoSourceInfo, error) {
+		return DeletedVideoSourceInfo{Size: 100, ModTime: now.Add(24 * time.Hour)}, nil
+	}); err != nil {
+		t.Fatalf("restore same-size replacement: %v", err)
+	}
+	restored, err = cat.GetVideo(ctx, "local-upload-replaced-same-size")
+	if err != nil {
+		t.Fatalf("get same-size replacement: %v", err)
+	}
+	if restored.ContentHash != "" || restored.SampledSHA256 != "" || restored.FingerprintStatus != "pending" {
+		t.Fatalf("same-size replacement metadata was not invalidated: %#v", restored)
 	}
 }
 

--- a/src/admin/VideosPage.tsx
+++ b/src/admin/VideosPage.tsx
@@ -1062,9 +1062,11 @@ function BlacklistTab({
         return next;
       });
       show(
-        target.restorePolicy === "crawler"
-          ? "已取消拉黑，将在下次爬虫任务时生效"
-          : "已取消拉黑，将在下次手动或定时扫盘时生效",
+        target.restorePolicy === "direct"
+          ? "已取消拉黑，视频已恢复到媒体库"
+          : target.restorePolicy === "crawler"
+            ? "已取消拉黑，将在下次爬虫任务时生效"
+            : "已取消拉黑，将在下次手动或定时扫盘时生效",
         "success"
       );
       if (list.length === 1 && page > 1) {
@@ -1308,7 +1310,7 @@ function BlacklistTab({
                         ) : null
                       ) : (
                         <span className="admin-blacklist-unavailable">
-                          {v.driveId === "local-upload" ? "不可自动恢复" : "不可恢复"}
+                          不可恢复
                         </span>
                       )}
                       {sourceDeletable && (
@@ -1392,9 +1394,11 @@ function BlacklistTab({
         title="取消拉黑"
         message={
           removeTarget
-            ? removeTarget.restorePolicy === "crawler"
-              ? `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？此操作不会立即运行爬虫，将在下次爬虫任务时生效。`
-              : `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？视频将在下次扫盘时恢复`
+            ? removeTarget.restorePolicy === "direct"
+              ? `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？视频将立即恢复到媒体库，封面和预览会重新生成。`
+              : removeTarget.restorePolicy === "crawler"
+                ? `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？此操作不会立即运行爬虫，将在下次爬虫任务时生效。`
+                : `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？视频将在下次扫盘时恢复`
             : ""
         }
         confirmText="取消拉黑"

--- a/src/admin/VideosPage.tsx
+++ b/src/admin/VideosPage.tsx
@@ -1002,12 +1002,10 @@ function BlacklistTab({
           timer = window.setTimeout(poll, 2000);
           return;
         }
-        show(
-          status.failed > 0
-            ? `源文件删除完成：成功 ${status.deleted}，失败 ${status.failed}`
-            : `源文件删除完成：成功 ${status.deleted}`,
-          status.failed > 0 ? "info" : "success"
-        );
+        const summary = [`成功 ${status.deleted}`];
+        if (status.skipped > 0) summary.push(`跳过 ${status.skipped}`);
+        if (status.failed > 0) summary.push(`失败 ${status.failed}`);
+        show(`源文件删除完成：${summary.join("，")}`, status.failed > 0 ? "info" : "success");
         setSelectedIds(new Set());
         void refresh();
       } catch {
@@ -1279,9 +1277,6 @@ function BlacklistTab({
                     <div className="admin-blacklist-filecell">
                       <span className="admin-blacklist-filename" title={v.fileName || undefined}>{v.fileName || <span className="admin-text-faint">（无文件名）</span>}</span>
                       {v.reason === "duplicate" && <span className="admin-blacklist-reason-pill">重复文件</span>}
-                      {v.driveId === "local-upload" && (
-                        <span className="admin-blacklist-reason-pill">本地上传</span>
-                      )}
                     </div>
                   </td>
                   <td data-label="来源" className="admin-mono-cell admin-blacklist-source-cell">
@@ -1294,7 +1289,8 @@ function BlacklistTab({
                           type="button"
                           className="admin-btn"
                           onClick={() => setRemoveTarget(v)}
-                          title="取消拉黑"
+                          disabled={sourceDeleteRunning}
+                          title={sourceDeleteRunning ? "源文件删除任务运行中" : "取消拉黑"}
                         >
                           取消拉黑
                         </button>
@@ -1394,14 +1390,10 @@ function BlacklistTab({
         title="取消拉黑"
         message={
           removeTarget
-            ? removeTarget.restorePolicy === "direct"
-              ? `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？视频将立即恢复到媒体库，封面和预览会重新生成。`
-              : removeTarget.restorePolicy === "crawler"
-                ? `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？此操作不会立即运行爬虫，将在下次爬虫任务时生效。`
-                : `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？视频将在下次扫盘时恢复`
+            ? `确定取消拉黑「${removeTarget.fileName || removeTarget.id}」吗？`
             : ""
         }
-        confirmText="取消拉黑"
+        confirmText="确认"
         centerMessage
         loading={removing}
         onCancel={() => {

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -1112,6 +1112,7 @@ export type BlacklistSourceDeleteStatus = {
   total: number;
   processed: number;
   deleted: number;
+  skipped: number;
   failed: number;
   currentFile?: string;
   lastError?: string;

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -1074,7 +1074,8 @@ export type AdminDeletedVideo = {
   sourceDeleted: boolean;
   canonicalVideoId?: string;
   canonicalTitle?: string;
-  restorePolicy: "none" | "scan" | "crawler";
+  // direct：本地上传这类无法被扫盘/爬取重新发现的来源，取消拉黑时当场重建记录。
+  restorePolicy: "none" | "scan" | "crawler" | "direct";
   deletedAt: number;
 };
 

--- a/tests/adminResponsive.test.ts
+++ b/tests/adminResponsive.test.ts
@@ -866,11 +866,17 @@ test("blacklist cancel action uses ordinary button styling", () => {
   assert.match(videosPageSource, /v\.restorePolicy !== "none"/);
   assert.match(videosPageSource, /取消拉黑/);
   assert.doesNotMatch(videosPageSource, /重新入库/);
-  assert.match(videosPageSource, /视频将在下次扫盘时恢复/);
-  assert.doesNotMatch(videosPageSource, /此操作不会立即扫盘/);
-  assert.match(videosPageSource, /此操作不会立即运行爬虫/);
+  assert.match(
+    videosPageSource,
+    /open=\{removeTarget !== null\}[\s\S]*?确定取消拉黑「\$\{removeTarget\.fileName \|\| removeTarget\.id\}」吗？/
+  );
+  assert.doesNotMatch(videosPageSource, /视频将在下次扫盘时恢复/);
+  assert.doesNotMatch(videosPageSource, /此操作不会立即运行爬虫/);
   assert.match(videosPageSource, /v\.sourceDeleted/);
-  assert.match(videosPageSource, /v\.driveId === "local-upload"/);
+  assert.doesNotMatch(
+    videosPageSource,
+    /<span className="admin-blacklist-reason-pill">本地上传<\/span>/
+  );
   assert.doesNotMatch(videosPageSource, /被删除和被隐藏的视频会进入黑名单/);
   assert.doesNotMatch(videosPageSource, /原始记录、封面、预览已删除/);
   assert.match(unavailable, /color\s*:\s*var\(--text-faint\)/);
@@ -881,14 +887,18 @@ test("blacklist cancel action uses ordinary button styling", () => {
 test("local upload blacklist entries restore immediately instead of waiting for a scan", () => {
   assert.match(apiSource, /restorePolicy: "none" \| "scan" \| "crawler" \| "direct"/);
   assert.match(videosPageSource, /target\.restorePolicy === "direct"[\s\S]*?已取消拉黑，视频已恢复到媒体库/);
-  assert.match(
-    videosPageSource,
-    /removeTarget\.restorePolicy === "direct"[\s\S]*?视频将立即恢复到媒体库，封面和预览会重新生成。/
-  );
+  assert.match(videosPageSource, /open=\{removeTarget !== null\}[\s\S]*?confirmText="确认"/);
+  assert.doesNotMatch(videosPageSource, /视频将立即恢复到媒体库，封面和预览会重新生成。/);
   // 恢复按钮对 direct 一样要出现：判断条件是「不等于 none」而不是白名单。
   assert.match(videosPageSource, /v\.restorePolicy !== "none"/);
+  assert.match(videosPageSource, /v\.restorePolicy !== "none"[\s\S]*?disabled=\{sourceDeleteRunning\}/);
   // 「不可自动恢复」这个中间态没有了：现在要么能恢复，要么就是真的不可恢复。
   assert.doesNotMatch(videosPageSource, /不可自动恢复/);
+});
+
+test("blacklist source deletion reports tombstones skipped after restore", () => {
+  assert.match(apiSource, /skipped: number/);
+  assert.match(videosPageSource, /status\.skipped > 0[\s\S]*?跳过 \$\{status\.skipped\}/);
 });
 
 test("blacklist duplicate reason renders as a compact pill", () => {
@@ -951,7 +961,14 @@ test("blacklist source files can be deleted by one serialized background task", 
   assert.doesNotMatch(blacklistSource, /selectMode|toggleSelectMode|批量选择|退出选择|admin-videos-bulk-actions__mobile-exit/);
   assert.doesNotMatch(blacklistSource, /className="admin-btn is-danger admin-videos-bulk-actions__btn"|<Trash2 size=\{13\} \/> 批量删除/);
   assert.match(videosPageSource, /title="删除源文件"/);
-  assert.equal(Array.from(blacklistSource.matchAll(/confirmText="确认"/g)).length, 3);
+  assert.equal(
+    Array.from(
+      blacklistSource.matchAll(
+        /confirmText="确认"[\s\S]{0,200}?modalClassName="admin-modal--delete-confirm admin-modal--source-delete-flat"/g
+      )
+    ).length,
+    3
+  );
   assert.doesNotMatch(videosPageSource, /confirmText="删除全部"|confirmText="删除"/);
   assert.doesNotMatch(videosPageSource, /<DeleteSourceNotice|function DeleteSourceNotice/);
   assert.doesNotMatch(adminCss, /admin-delete-source-option--notice/);

--- a/tests/adminResponsive.test.ts
+++ b/tests/adminResponsive.test.ts
@@ -876,6 +876,21 @@ test("blacklist cancel action uses ordinary button styling", () => {
   assert.match(unavailable, /color\s*:\s*var\(--text-faint\)/);
 });
 
+// 本地上传的源文件被保留，但这个盘不支持枚举，扫盘和爬虫都不会重新发现它，
+// 所以取消拉黑是当场恢复，文案不能再说「等下次扫盘」。
+test("local upload blacklist entries restore immediately instead of waiting for a scan", () => {
+  assert.match(apiSource, /restorePolicy: "none" \| "scan" \| "crawler" \| "direct"/);
+  assert.match(videosPageSource, /target\.restorePolicy === "direct"[\s\S]*?已取消拉黑，视频已恢复到媒体库/);
+  assert.match(
+    videosPageSource,
+    /removeTarget\.restorePolicy === "direct"[\s\S]*?视频将立即恢复到媒体库，封面和预览会重新生成。/
+  );
+  // 恢复按钮对 direct 一样要出现：判断条件是「不等于 none」而不是白名单。
+  assert.match(videosPageSource, /v\.restorePolicy !== "none"/);
+  // 「不可自动恢复」这个中间态没有了：现在要么能恢复，要么就是真的不可恢复。
+  assert.doesNotMatch(videosPageSource, /不可自动恢复/);
+});
+
 test("blacklist duplicate reason renders as a compact pill", () => {
   const pill = ruleBody(adminCss, ".admin-blacklist-reason-pill");
 


### PR DESCRIPTION
## 问题

前台点「不再展示」会删掉视频记录并写一条黑名单墓碑（`OnHideVideo` → `deleteVideo(ctx, id, false)`）。对本地上传的视频，这个操作**不可逆**：

- `deletedVideoRestorePolicy` 把 `drive_id == "local-upload"` 判为 `none`，后台黑名单页面因此连「取消拉黑」按钮都不渲染，只显示「不可自动恢复」
- 但拉黑时 `deleteSource=false`，**源文件其实还在 uploads 目录里**
- 之所以判为不可恢复，是因为 `localupload.Driver.List()` 直接返回 `drives.ErrNotSupported`（`internal/drives/localupload/driver.go:32`），这个盘无法枚举，没有任何扫盘或爬取能重新发现它；`maintainLocalUploadFileNames` 也只遍历已入库的视频，不扫描目录

结果是：文件占着磁盘，视频永远回不来，用户在后台没有任何补救手段，只能重新上传一遍。

## 改动

新增第四种恢复策略 `direct`，适用于「源文件由本应用保留、但无法枚举」的来源（目前只有本地上传）。取消拉黑时**当场重建记录**，而不是去等一场永远不会到来的扫盘。

恢复是无损的：`DeleteVideoWithTombstoneOptions` 本来就把完整的 Video JSON 存进了 `restore_payload`（`catalog.go:1128`），所以标题、作者、标签、简介、时长都能还原。派生资源（封面、预览、转码产物）在拉黑时已被物理删除，因此重置为 `pending` 交给生成 worker 重建 —— 保留原路径会让记录指向不存在的文件。

因为 direct 是唯一**无条件写回记录**的路径，恢复前会先让调用方确认保留下来的源文件仍然存在（`RemoveDeletedVideoWithSourceCheck`）。其他策略靠「扫不到就不入库」天然安全，不需要这层校验，也不会触发它。

实现上参考了爬虫已有的 `RestoreRequestedVideos`——「保留文件 + 墓碑 → 重新入库」这套流程本来就跑通了，本地上传只是缺了对应的那一半。

## 兼容性

策略判定的顺序做了调整，把「源文件已删」和「重复文件」提到来源判断之前：

```go
if v == nil || v.SourceDeleted || v.Reason == duplicate {
    return none          // 与来源无关，最先命中
}
if v.DriveID == "local-upload" { return direct }
if driveKind == "scriptcrawler" { return crawler }
return scan
```

所以行为发生变化的**只有**「本地上传 + 源文件还在 + 非重复」这一种组合，也就是这个 bug 本身。源文件已删的本地上传、被去重删掉的本地上传、普通网盘、爬虫来源，行为全部不变，这三条都有测试锁定。

`restorePolicy` 全项目只有两个消费点（`ListDeletedVideos` 展示、`RemoveDeletedVideo` 分支判断）；扫盘拦截、去重、备份恢复、源文件删除队列都是直接查 SQL，不读这个字段。

`RemoveDeletedVideo(ctx, id)` 的签名保持不变，11 个既有调用点一个都没改。

## 测试

后端新增/更新 6 个用例（`internal/catalog` + `internal/api`）：

- 本地上传 → `direct`
- 源文件已删的本地上传 → 仍为 `none`（优先级回归）
- 被去重删掉的本地上传 → 仍为 `none`（优先级回归）
- 无损恢复：元数据保留、派生资源重置、墓碑清除、计数正确
- 老墓碑 `restore_payload` 为空时的兜底（标题从文件名还原）
- API 层：恢复成功并调用源文件校验 / 源文件缺失返回 409 且不恢复 / 扫盘来源不触发校验且仍是等下次扫盘

前端新增 1 个用例（`tests/adminResponsive.test.ts`），481 个前端测试全绿，`tsc --noEmit` 干净。

在**纯上游代码基**（8cda4a5）上验证过：`go build ./...` 通过，`internal/catalog` 与黑名单相关测试全部通过。另外跑了全量回归对比（上游基线 vs 本改动），失败集合零新增。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up 修正

Review 后补充了系统级完整性修复（`8d09e75`）：

- `direct` 恢复改为在同一事务中写回视频、标签关系并删除 tombstone，同时兼容旧版恢复 payload，避免留下部分恢复状态。
- 恢复前重新读取 provider 元数据，拒绝缺失、空文件或拉黑后已被替换的源文件；成功后主动进入封面、预览和转码生成队列。
- 取消拉黑与后台源文件删除按视频 ID 串行化；删除任务会重新校验 tombstone 快照，已恢复或发生变化的条目按 `skipped` 处理，避免误删恢复后的源文件。
- 管理端统一使用简短确认文案，确认按钮改为“确认”，移除重复的“本地上传”徽标，并展示删除任务的 `skipped` 计数。
- 补充 catalog、API、server 与前端回归测试。