### PR TITLE
feat: 视频列表无限滚动 + 虚拟列表 | Infinite scroll & virtual list for the video listing

### DIFF
--- a/backend/cmd/seed-videos/main.go
+++ b/backend/cmd/seed-videos/main.go
@@ -1,0 +1,93 @@
+// 本地开发用的一次性数据放大工具：以现有的某条视频为模板生成大量可列出的
+// 行，用来压测列表页的无限滚动 / 虚拟列表。只做 INSERT，不改动既有数据。
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	dbPath := flag.String("db", "./data/video-site.db", "sqlite path")
+	count := flag.Int("count", 0, "how many synthetic rows to insert")
+	prefix := flag.String("prefix", "seed", "id prefix for generated rows")
+	purge := flag.Bool("purge", false, "delete previously generated rows with this prefix")
+	flag.Parse()
+
+	db, err := sql.Open("sqlite", *dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	like := *prefix + "-%"
+
+	if *purge {
+		res, err := db.Exec(`DELETE FROM videos WHERE id LIKE ?`, like)
+		if err != nil {
+			log.Fatal(err)
+		}
+		removed, _ := res.RowsAffected()
+		fmt.Printf("purged %d generated rows\n", removed)
+	}
+
+	if *count > 0 {
+		now := time.Now().UnixMilli()
+		// content_hash / sampled_sha256 置空 + file_name 唯一，避免被去重触发器
+		// 判成同一条视频的副本而丢掉 is_canonical。
+		res, err := db.Exec(`
+WITH RECURSIVE seq(n) AS (
+    SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ?
+),
+template AS (
+    SELECT * FROM videos WHERE id NOT LIKE ? ORDER BY created_at LIMIT 1
+)
+INSERT INTO videos (
+    id, drive_id, file_id, file_name, content_hash, sampled_sha256,
+    fingerprint_status, parent_id, dir_name, title, author, tags,
+    duration_seconds, size_bytes, ext, quality, thumbnail_url,
+    thumbnail_updated_at, thumbnail_status, preview_local, preview_updated_at,
+    preview_status, views, favorites, comments, likes, dislikes, hidden,
+    is_canonical, badges, description, published_at, created_at, updated_at
+)
+SELECT
+    ? || '-' || printf('%05d', seq.n),
+    template.drive_id,
+    -- 复用模板行的真实 file_id，生成的视频才真的能播放和出封面。
+    template.file_id,
+    ? || '-' || printf('%05d', seq.n) || '.mp4',
+    '', '', 'pending',
+    template.parent_id, template.dir_name,
+    '压测视频 ' || printf('%05d', seq.n),
+    template.author, template.tags,
+    template.duration_seconds,
+    COALESCE(template.size_bytes, 0) + seq.n,
+    template.ext, template.quality, template.thumbnail_url,
+    template.thumbnail_updated_at, template.thumbnail_status,
+    template.preview_local, template.preview_updated_at, template.preview_status,
+    seq.n % 97, 0, 0, seq.n % 53, 0, 0, 1,
+    template.badges, template.description,
+    ? - seq.n * 60000, ?, ?
+FROM seq, template`,
+			*count, like, *prefix, *prefix, now, now, now)
+		if err != nil {
+			log.Fatal(err)
+		}
+		inserted, _ := res.RowsAffected()
+		fmt.Printf("inserted %d rows\n", inserted)
+	}
+
+	var total, listable int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM videos`).Scan(&total); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM videos WHERE COALESCE(hidden,0)=0 AND is_canonical=1`).Scan(&listable); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("total rows: %d, listable rows: %d\n", total, listable)
+}

--- a/backend/cmd/seed-videos/main.go
+++ b/backend/cmd/seed-videos/main.go
@@ -1,5 +1,5 @@
-// 本地开发用的一次性数据放大工具：以现有的某条视频为模板生成大量可列出的
-// 行，用来压测列表页的无限滚动 / 虚拟列表。只做 INSERT，不改动既有数据。
+// 本地开发用的一次性数据放大工具：以现有视频为模板生成可列出的测试行，
+// 用来压测无限滚动和虚拟列表。生成记录会单独登记，清理时不会按通配符猜测。
 package main
 
 import (
@@ -7,50 +7,113 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
 
+var safeSeedPrefix = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$`)
+
+type seedResult struct {
+	purged   int64
+	inserted int64
+	total    int64
+	listable int64
+}
+
 func main() {
 	dbPath := flag.String("db", "./data/video-site.db", "sqlite path")
 	count := flag.Int("count", 0, "how many synthetic rows to insert")
-	prefix := flag.String("prefix", "seed", "id prefix for generated rows")
-	purge := flag.Bool("purge", false, "delete previously generated rows with this prefix")
+	prefix := flag.String("prefix", "seed", "generated-row namespace")
+	purge := flag.Bool("purge", false, "delete generated rows registered under this namespace")
 	flag.Parse()
 
-	db, err := sql.Open("sqlite", *dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	result, err := seedVideos(*dbPath, *count, *prefix, *purge)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db.Close()
-
-	like := *prefix + "-%"
-
 	if *purge {
-		res, err := db.Exec(`DELETE FROM videos WHERE id LIKE ?`, like)
-		if err != nil {
-			log.Fatal(err)
-		}
-		removed, _ := res.RowsAffected()
-		fmt.Printf("purged %d generated rows\n", removed)
+		fmt.Printf("purged %d registered rows\n", result.purged)
+	}
+	if *count > 0 {
+		fmt.Printf("inserted %d registered rows\n", result.inserted)
+	}
+	fmt.Printf("total rows: %d, listable rows: %d\n", result.total, result.listable)
+}
+
+func seedVideos(dbPath string, count int, prefix string, purge bool) (seedResult, error) {
+	var result seedResult
+	if !safeSeedPrefix.MatchString(prefix) {
+		return result, fmt.Errorf("prefix must be 1-32 ASCII letters, digits, hyphens or underscores, and start with a letter or digit")
+	}
+	if count < 0 {
+		return result, fmt.Errorf("count cannot be negative")
 	}
 
-	if *count > 0 {
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return result, fmt.Errorf("open database: %w", err)
+	}
+	defer db.Close()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return result, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`
+CREATE TABLE IF NOT EXISTS dev_seed_video_rows (
+    video_id   TEXT PRIMARY KEY,
+    namespace  TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+)`); err != nil {
+		return result, fmt.Errorf("create seed registry: %w", err)
+	}
+
+	if purge {
+		res, err := tx.Exec(`
+DELETE FROM videos
+ WHERE id IN (
+     SELECT video_id FROM dev_seed_video_rows WHERE namespace = ?
+ )`, prefix)
+		if err != nil {
+			return result, fmt.Errorf("purge registered videos: %w", err)
+		}
+		result.purged, err = res.RowsAffected()
+		if err != nil {
+			return result, fmt.Errorf("count purged videos: %w", err)
+		}
+		if _, err := tx.Exec(`DELETE FROM dev_seed_video_rows WHERE namespace = ?`, prefix); err != nil {
+			return result, fmt.Errorf("purge seed registry: %w", err)
+		}
+	}
+
+	if count > 0 {
 		now := time.Now().UnixMilli()
-		// content_hash / sampled_sha256 置空 + file_name 唯一，避免被去重触发器
-		// 判成同一条视频的副本而丢掉 is_canonical。
-		res, err := db.Exec(`
+		res, err := tx.Exec(`
 WITH RECURSIVE seq(n) AS (
     SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ?
 ),
 template AS (
-    SELECT * FROM videos WHERE id NOT LIKE ? ORDER BY created_at LIMIT 1
+    SELECT *
+      FROM videos
+     WHERE id NOT IN (SELECT video_id FROM dev_seed_video_rows)
+       AND COALESCE(hidden, 0) = 0
+       AND is_canonical = 1
+       AND (
+            drive_id = 'local-upload'
+            OR EXISTS (SELECT 1 FROM drives WHERE drives.id = videos.drive_id)
+            OR NOT EXISTS (SELECT 1 FROM drives)
+       )
+     ORDER BY created_at, id
+     LIMIT 1
 )
 INSERT INTO videos (
     id, drive_id, file_id, file_name, content_hash, sampled_sha256,
-    fingerprint_status, parent_id, dir_name, title, author, tags,
-    duration_seconds, size_bytes, ext, quality, thumbnail_url,
+    fingerprint_status, fingerprint_error, parent_id, dir_name, title, author, tags,
+    duration_seconds, size_bytes, ext, thumbnail_url,
     thumbnail_updated_at, thumbnail_status, preview_local, preview_updated_at,
     preview_status, views, favorites, comments, likes, dislikes, hidden,
     is_canonical, badges, description, published_at, created_at, updated_at
@@ -58,36 +121,64 @@ INSERT INTO videos (
 SELECT
     ? || '-' || printf('%05d', seq.n),
     template.drive_id,
-    -- 复用模板行的真实 file_id，生成的视频才真的能播放和出封面。
     template.file_id,
     ? || '-' || printf('%05d', seq.n) || '.mp4',
-    '', '', 'pending',
+    '', '', 'failed', 'development seed row; fingerprint disabled',
     template.parent_id, template.dir_name,
     '压测视频 ' || printf('%05d', seq.n),
     template.author, template.tags,
     template.duration_seconds,
     COALESCE(template.size_bytes, 0) + seq.n,
-    template.ext, template.quality, template.thumbnail_url,
+    template.ext, template.thumbnail_url,
     template.thumbnail_updated_at, template.thumbnail_status,
     template.preview_local, template.preview_updated_at, template.preview_status,
     seq.n % 97, 0, 0, seq.n % 53, 0, 0, 1,
     template.badges, template.description,
     ? - seq.n * 60000, ?, ?
-FROM seq, template`,
-			*count, like, *prefix, *prefix, now, now, now)
+FROM seq, template`, count, prefix, prefix, now, now, now)
 		if err != nil {
-			log.Fatal(err)
+			return result, fmt.Errorf("insert seed videos: %w", err)
 		}
-		inserted, _ := res.RowsAffected()
-		fmt.Printf("inserted %d rows\n", inserted)
+		result.inserted, err = res.RowsAffected()
+		if err != nil {
+			return result, fmt.Errorf("count inserted videos: %w", err)
+		}
+		if result.inserted != int64(count) {
+			return result, fmt.Errorf(
+				"inserted %d rows, expected %d; database needs one visible non-seed template video",
+				result.inserted,
+				count,
+			)
+		}
+
+		if _, err := tx.Exec(`
+WITH RECURSIVE seq(n) AS (
+    SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ?
+)
+INSERT INTO dev_seed_video_rows (video_id, namespace, created_at)
+SELECT ? || '-' || printf('%05d', seq.n), ?, ? FROM seq`, count, prefix, prefix, now); err != nil {
+			return result, fmt.Errorf("register seed videos: %w", err)
+		}
 	}
 
-	var total, listable int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM videos`).Scan(&total); err != nil {
-		log.Fatal(err)
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM videos`).Scan(&result.total); err != nil {
+		return result, fmt.Errorf("count all videos: %w", err)
 	}
-	if err := db.QueryRow(`SELECT COUNT(*) FROM videos WHERE COALESCE(hidden,0)=0 AND is_canonical=1`).Scan(&listable); err != nil {
-		log.Fatal(err)
+	if err := tx.QueryRow(`
+SELECT COUNT(*)
+  FROM videos
+ WHERE COALESCE(hidden, 0) = 0
+   AND is_canonical = 1
+   AND (
+        drive_id = 'local-upload'
+        OR EXISTS (SELECT 1 FROM drives WHERE drives.id = videos.drive_id)
+        OR NOT EXISTS (SELECT 1 FROM drives)
+   )`).Scan(&result.listable); err != nil {
+		return result, fmt.Errorf("count listable videos: %w", err)
 	}
-	fmt.Printf("total rows: %d, listable rows: %d\n", total, listable)
+
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("commit seed transaction: %w", err)
+	}
+	return result, nil
 }

--- a/backend/cmd/seed-videos/main_test.go
+++ b/backend/cmd/seed-videos/main_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/video-site/backend/internal/catalog"
+)
+
+func TestSeedVideosRegistersAndPurgesOnlyItsExactRows(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "catalog.db")
+	cat, err := catalog.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	now := time.Now()
+	for index, id := range []string{"template", "load_test-real"} {
+		if err := cat.UpsertVideo(context.Background(), &catalog.Video{
+			ID: id, DriveID: "drive", FileID: "file-" + id,
+			FileName: id + ".mp4", Title: id, Size: int64(100 + index*100),
+			PublishedAt: now, CreatedAt: now.Add(time.Duration(index) * time.Second), UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("seed template %s: %v", id, err)
+		}
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatalf("close catalog: %v", err)
+	}
+
+	seeded, err := seedVideos(dbPath, 3, "load_test", false)
+	if err != nil {
+		t.Fatalf("seed videos: %v", err)
+	}
+	if seeded.inserted != 3 || seeded.total != 5 || seeded.listable != 5 {
+		t.Fatalf("seed result = %#v", seeded)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	var pendingSeedRows int
+	if err := db.QueryRow(`
+SELECT COUNT(*)
+  FROM videos
+ WHERE id IN (SELECT video_id FROM dev_seed_video_rows WHERE namespace = 'load_test')
+   AND COALESCE(fingerprint_status, 'pending') = 'pending'`).Scan(&pendingSeedRows); err != nil {
+		t.Fatalf("count pending seed fingerprints: %v", err)
+	}
+	if pendingSeedRows != 0 {
+		t.Fatalf("pending seed fingerprints = %d", pendingSeedRows)
+	}
+
+	purged, err := seedVideos(dbPath, 0, "load_test", true)
+	if err != nil {
+		t.Fatalf("purge videos: %v", err)
+	}
+	if purged.purged != 3 || purged.total != 2 || purged.listable != 2 {
+		t.Fatalf("purge result = %#v", purged)
+	}
+
+	var realRows, registryRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM videos WHERE id = 'load_test-real'`).Scan(&realRows); err != nil {
+		t.Fatalf("count real rows: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM dev_seed_video_rows WHERE namespace = 'load_test'`).Scan(&registryRows); err != nil {
+		t.Fatalf("count registry rows: %v", err)
+	}
+	if realRows != 1 || registryRows != 0 {
+		t.Fatalf("real rows = %d, registry rows = %d", realRows, registryRows)
+	}
+}
+
+func TestSeedVideosRejectsUnsafeNamespacesBeforeOpeningTheDatabase(t *testing.T) {
+	_, err := seedVideos(filepath.Join(t.TempDir(), "missing.db"), 1, "load%", false)
+	if err == nil || !strings.Contains(err.Error(), "prefix must") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSeedVideosRollsBackWhenThereIsNoVisibleTemplate(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "catalog.db")
+	cat, err := catalog.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatalf("close catalog: %v", err)
+	}
+
+	_, err = seedVideos(dbPath, 2, "load_test", false)
+	if err == nil || !strings.Contains(err.Error(), "visible non-seed template") {
+		t.Fatalf("error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM videos`).Scan(&rows); err != nil {
+		t.Fatalf("count videos: %v", err)
+	}
+	if rows != 0 {
+		t.Fatalf("video rows after rollback = %d", rows)
+	}
+}

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -68,6 +68,11 @@ type Server struct {
 	shortsFeeds   map[string]*shortsFeedSession
 	shortsFeedNow func() time.Time
 
+	videoFeedMu     sync.Mutex
+	videoFeeds      map[string]*videoFeedSession
+	videoFeedShared map[videoFeedSnapshotKey]string
+	videoFeedNow    func() time.Time
+
 	homeRecommendationMu       sync.Mutex
 	homeRecommendationSessions map[string]*homeRecommendationSession
 	homeRecommendationNow      func() time.Time
@@ -134,6 +139,24 @@ type VideoDTO struct {
 	Dislikes        int      `json:"dislikes"`
 	PublishedAt     string   `json:"publishedAt"`
 	Tags            []string `json:"tags,omitempty"`
+}
+
+// VideoCardDTO is the compact transport used by infinite listing feeds. The
+// omitted reaction, tag, storage and processing fields are loaded by the video
+// detail endpoint when the user actually opens a card.
+type VideoCardDTO struct {
+	ID              string   `json:"id"`
+	Href            string   `json:"href"`
+	Title           string   `json:"title"`
+	Thumbnail       string   `json:"thumbnail"`
+	PreviewSrc      string   `json:"previewSrc"`
+	PreviewDuration int      `json:"previewDuration"`
+	PreviewStrategy string   `json:"previewStrategy"`
+	Duration        string   `json:"duration"`
+	Badges          []string `json:"badges"`
+	Author          string   `json:"author"`
+	Views           int      `json:"views"`
+	PublishedAt     string   `json:"publishedAt"`
 }
 
 type TagDTO struct {
@@ -227,6 +250,7 @@ func (s *Server) RegisterRoutes(r chi.Router, a *auth.Authenticator) {
 		r.Get("/api/home", s.handleHome)
 		r.Get("/api/home/latest", s.handleHomeLatest)
 		r.Get("/api/list", s.handleList)
+		r.Get("/api/feed", s.handleVideoFeed)
 		r.Get("/api/video/{id}", s.handleVideoDetail)
 		r.Get("/api/video/{id}/collection", s.handleVideoCollection)
 		r.Get("/api/video/{id}/subtitles", s.handleVideoSubtitles)
@@ -349,24 +373,7 @@ func homeRecommendationCount(r *http.Request) (int, error) {
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query()
-	page, _ := strconv.Atoi(q.Get("page"))
-	size, _ := strconv.Atoi(q.Get("size"))
-	if size <= 0 {
-		size = 24
-	}
-	sort := q.Get("sort")
-	params := catalog.ListParams{
-		Keyword:   q.Get("q"),
-		Tag:       q.Get("tag"),
-		Sort:      sort,
-		Page:      page,
-		PageSize:  size,
-		SkipTotal: strings.EqualFold(q.Get("count"), "false"),
-	}
-	if sort == "" || sort == "latest" {
-		params.PreferReadyThumbnails = true
-	}
+	params := publicListParams(r)
 	items, total, err := s.Catalog.ListVideos(r.Context(), params)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, err)
@@ -379,6 +386,32 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		"page":  params.Page,
 		"size":  params.PageSize,
 	})
+}
+
+// publicListParams is shared by the paginated compatibility endpoint and the
+// snapshot feed so both expose the same filters and ordering semantics.
+func publicListParams(r *http.Request) catalog.ListParams {
+	q := r.URL.Query()
+	page, _ := strconv.Atoi(q.Get("page"))
+	size, _ := strconv.Atoi(q.Get("size"))
+	if size <= 0 {
+		size = 24
+	}
+	sortKey := strings.TrimSpace(q.Get("sort"))
+	switch sortKey {
+	case "", "latest", "hot", "recent":
+	default:
+		sortKey = ""
+	}
+	return catalog.ListParams{
+		Keyword:               strings.TrimSpace(q.Get("q")),
+		Tag:                   strings.TrimSpace(q.Get("tag")),
+		Sort:                  sortKey,
+		Page:                  page,
+		PageSize:              size,
+		SkipTotal:             strings.EqualFold(q.Get("count"), "false"),
+		PreferReadyThumbnails: sortKey == "" || sortKey == "latest",
+	}
 }
 
 func (s *Server) handleVideoDetail(w http.ResponseWriter, r *http.Request) {
@@ -1439,26 +1472,33 @@ func normalizeSubtitleExt(ext string) string {
 }
 
 func previewURL(v *catalog.Video) string {
-	base := "/p/preview/" + pathSegment(v.ID)
-	if v.PreviewUpdatedAt.IsZero() {
+	return previewURLFor(v.ID, v.PreviewUpdatedAt)
+}
+
+func previewURLFor(videoID string, updatedAt time.Time) string {
+	base := "/p/preview/" + pathSegment(videoID)
+	if updatedAt.IsZero() {
 		return base
 	}
-	return base + "?v=" + strconv.FormatInt(v.PreviewUpdatedAt.UnixMilli(), 10)
+	return base + "?v=" + strconv.FormatInt(updatedAt.UnixMilli(), 10)
 }
 
 func thumbnailURL(v *catalog.Video) string {
-	base := "/p/thumb/" + pathSegment(v.ID)
-	hasThumbnail := v.ThumbnailURL != ""
-	if v.ThumbnailURL != "" {
-		base = v.ThumbnailURL
-		if thumbnailURLMatchesVideoID(base, v.ID) {
-			base = "/p/thumb/" + pathSegment(v.ID)
-		}
+	return thumbnailURLFor(v.ID, v.ThumbnailURL, v.ThumbnailUpdatedAt)
+}
+
+func thumbnailURLFor(videoID, thumbnail string, updatedAt time.Time) string {
+	base := strings.TrimSpace(thumbnail)
+	if base == "" {
+		return ""
 	}
-	if !hasThumbnail || !strings.HasPrefix(base, "/p/thumb/") || v.ThumbnailUpdatedAt.IsZero() {
+	if thumbnailURLMatchesVideoID(base, videoID) {
+		base = "/p/thumb/" + pathSegment(videoID)
+	}
+	if !strings.HasPrefix(base, "/p/thumb/") || updatedAt.IsZero() {
 		return base
 	}
-	return base + "?v=" + strconv.FormatInt(v.ThumbnailUpdatedAt.UnixMilli(), 10)
+	return base + "?v=" + strconv.FormatInt(updatedAt.UnixMilli(), 10)
 }
 
 // transcodedSource 在视频有就绪的浏览器兼容性转码产物时返回产物的播放地址。
@@ -1733,6 +1773,31 @@ func mapVideos(vs []*catalog.Video) []VideoDTO {
 	out := make([]VideoDTO, 0, len(vs))
 	for _, v := range vs {
 		out = append(out, mapVideo(v))
+	}
+	return out
+}
+
+func mapVideoSummaries(videos []*catalog.VideoSummary) []VideoCardDTO {
+	out := make([]VideoCardDTO, 0, len(videos))
+	for _, video := range videos {
+		badges := video.Badges
+		if badges == nil {
+			badges = []string{}
+		}
+		out = append(out, VideoCardDTO{
+			ID:              video.ID,
+			Href:            "/video/" + pathSegment(video.ID),
+			Title:           video.Title,
+			Thumbnail:       thumbnailURLFor(video.ID, video.ThumbnailURL, video.ThumbnailUpdatedAt),
+			PreviewSrc:      previewURLFor(video.ID, video.PreviewUpdatedAt),
+			PreviewDuration: 12,
+			PreviewStrategy: "teaser-file",
+			Duration:        formatDuration(video.DurationSeconds),
+			Badges:          badges,
+			Author:          video.Author,
+			Views:           video.Views,
+			PublishedAt:     video.PublishedAt.Format("2006-01-02"),
+		})
 	}
 	return out
 }

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -679,8 +679,8 @@ func TestThumbnailURLVersionsLocalGeneratedThumbnails(t *testing.T) {
 		ID:                 "video-pending",
 		ThumbnailUpdatedAt: time.UnixMilli(1778863000123),
 	})
-	if got != "/p/thumb/video-pending" {
-		t.Fatalf("pending thumbnail URL = %q, want unversioned retryable URL", got)
+	if got != "" {
+		t.Fatalf("pending thumbnail URL = %q, want no advertised asset", got)
 	}
 }
 

--- a/backend/internal/api/video_feed.go
+++ b/backend/internal/api/video_feed.go
@@ -1,0 +1,348 @@
+package api
+
+import (
+	"context"
+	crand "crypto/rand"
+	"encoding/hex"
+	"errors"
+	"math/rand/v2"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/video-site/backend/internal/catalog"
+)
+
+const (
+	defaultVideoFeedBatchSize = 20
+	maxVideoFeedBatchSize     = 240
+	videoFeedLookupChunk      = 32
+	videoFeedTTL              = 24 * time.Hour
+	maxVideoFeedSessions      = 64
+)
+
+var (
+	errVideoFeedExpired     = errors.New("video feed expired")
+	errInvalidVideoFeedKind = errors.New("invalid video feed kind")
+)
+
+type videoFeedSession struct {
+	videoIDs   []string
+	lastAccess time.Time
+	sharedKey  *videoFeedSnapshotKey
+}
+
+// videoFeedSnapshotKey identifies deterministic feeds whose complete ordered
+// ID set is identical for every authenticated user. Batch size is deliberately
+// absent because it does not change the logical result set.
+type videoFeedSnapshotKey struct {
+	keyword string
+	tag     string
+	sort    string
+}
+
+type videoFeedSnapshotSeed struct {
+	videoIDs  []string
+	sharedKey *videoFeedSnapshotKey
+}
+
+type videoFeedResponse struct {
+	Items      []VideoCardDTO `json:"items"`
+	Total      int            `json:"total"`
+	FeedToken  string         `json:"feedToken"`
+	NextCursor int            `json:"nextCursor"`
+	Exhausted  bool           `json:"exhausted"`
+}
+
+// handleVideoFeed creates an immutable ordered ID snapshot when the first
+// response has a continuation, then serves idempotent token/cursor reads from
+// it. A result set completed by the first response is never retained. Live
+// inserts, deletes, thumbnail readiness and reaction changes therefore cannot
+// shift a later batch boundary.
+func (s *Server) handleVideoFeed(w http.ResponseWriter, r *http.Request) {
+	count, err := videoFeedQueryInt(r, "count", defaultVideoFeedBatchSize)
+	if err != nil || count < 1 || count > maxVideoFeedBatchSize {
+		writeErr(w, http.StatusBadRequest, errors.New("invalid video feed count"))
+		return
+	}
+	cursor, err := videoFeedQueryInt(r, "cursor", 0)
+	if err != nil || cursor < 0 {
+		writeErr(w, http.StatusBadRequest, errors.New("invalid video feed cursor"))
+		return
+	}
+
+	feedToken := strings.TrimSpace(r.URL.Query().Get("feedToken"))
+	if len(feedToken) > 128 {
+		writeErr(w, http.StatusBadRequest, errors.New("invalid video feed token"))
+		return
+	}
+
+	newFeed := feedToken == ""
+	var videoIDs []string
+	var snapshotSeed videoFeedSnapshotSeed
+	if newFeed {
+		if cursor != 0 {
+			writeErr(w, http.StatusBadRequest, errors.New("video feed cursor requires a token"))
+			return
+		}
+		snapshotSeed, err = s.newVideoFeedSnapshot(r)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, errInvalidVideoFeedKind) {
+				status = http.StatusBadRequest
+			}
+			writeErr(w, status, err)
+			return
+		}
+		videoIDs = snapshotSeed.videoIDs
+	} else {
+		videoIDs, err = s.loadVideoFeed(feedToken)
+		if err != nil {
+			writeErr(w, http.StatusGone, err)
+			return
+		}
+	}
+
+	if cursor > len(videoIDs) {
+		writeErr(w, http.StatusBadRequest, errors.New("video feed cursor is outside the snapshot"))
+		return
+	}
+
+	videos, nextCursor, err := s.loadVisibleVideoFeedBatch(
+		r.Context(),
+		videoIDs,
+		cursor,
+		count,
+	)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	exhausted := nextCursor >= len(videoIDs)
+	if newFeed && !exhausted {
+		candidateToken, err := newVideoFeedToken()
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, err)
+			return
+		}
+		feedToken, videoIDs = s.storeVideoFeed(
+			candidateToken,
+			videoIDs,
+			snapshotSeed.sharedKey,
+		)
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, videoFeedResponse{
+		Items:      mapVideoSummaries(videos),
+		Total:      len(videoIDs),
+		FeedToken:  feedToken,
+		NextCursor: nextCursor,
+		Exhausted:  exhausted,
+	})
+}
+
+func (s *Server) newVideoFeedSnapshot(r *http.Request) (videoFeedSnapshotSeed, error) {
+	switch kind := strings.TrimSpace(r.URL.Query().Get("kind")); kind {
+	case "listing", "latest":
+		params := publicListParams(r)
+		if kind == "latest" {
+			params.Keyword = ""
+			params.Tag = ""
+			params.Sort = "latest"
+			params.PreferReadyThumbnails = true
+		}
+		videoIDs, err := s.Catalog.ListVideoIDs(r.Context(), params)
+		if err != nil {
+			return videoFeedSnapshotSeed{}, err
+		}
+		sortKey := params.Sort
+		if sortKey == "" {
+			sortKey = "latest"
+		}
+		sharedKey := videoFeedSnapshotKey{
+			keyword: params.Keyword,
+			tag:     params.Tag,
+			sort:    sortKey,
+		}
+		return videoFeedSnapshotSeed{videoIDs: videoIDs, sharedKey: &sharedKey}, nil
+	case "recommend":
+		readyIDs, pendingIDs, err := s.Catalog.ListVisibleVideoIDsByThumbnailReadiness(r.Context())
+		if err != nil {
+			return videoFeedSnapshotSeed{}, err
+		}
+		rand.Shuffle(len(readyIDs), func(i, j int) {
+			readyIDs[i], readyIDs[j] = readyIDs[j], readyIDs[i]
+		})
+		rand.Shuffle(len(pendingIDs), func(i, j int) {
+			pendingIDs[i], pendingIDs[j] = pendingIDs[j], pendingIDs[i]
+		})
+		return videoFeedSnapshotSeed{videoIDs: append(readyIDs, pendingIDs...)}, nil
+	default:
+		return videoFeedSnapshotSeed{}, errInvalidVideoFeedKind
+	}
+}
+
+func videoFeedQueryInt(r *http.Request, name string, fallback int) (int, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(name))
+	if raw == "" {
+		return fallback, nil
+	}
+	return strconv.Atoi(raw)
+}
+
+func newVideoFeedToken() (string, error) {
+	var token [16]byte
+	if _, err := crand.Read(token[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(token[:]), nil
+}
+
+func (s *Server) videoFeedTime() time.Time {
+	if s.videoFeedNow != nil {
+		return s.videoFeedNow()
+	}
+	return time.Now()
+}
+
+func (s *Server) storeVideoFeed(
+	token string,
+	videoIDs []string,
+	sharedKey *videoFeedSnapshotKey,
+) (string, []string) {
+	now := s.videoFeedTime()
+	s.videoFeedMu.Lock()
+	defer s.videoFeedMu.Unlock()
+
+	if s.videoFeeds == nil {
+		s.videoFeeds = make(map[string]*videoFeedSession)
+	}
+	if s.videoFeedShared == nil {
+		s.videoFeedShared = make(map[videoFeedSnapshotKey]string)
+	}
+	s.pruneVideoFeedsLocked(now)
+
+	// Deterministic feeds with the same query and the same current ordered IDs
+	// share both their token and their immutable slice. We still query the
+	// catalog for a new session so inserts and ordering changes are observed; an
+	// old token keeps pointing at its old snapshot for stable pagination.
+	if sharedKey != nil {
+		if existingToken := s.videoFeedShared[*sharedKey]; existingToken != "" {
+			if existing := s.videoFeeds[existingToken]; existing != nil {
+				if slices.Equal(existing.videoIDs, videoIDs) {
+					existing.lastAccess = now
+					return existingToken, existing.videoIDs
+				}
+			} else {
+				delete(s.videoFeedShared, *sharedKey)
+			}
+		}
+	}
+
+	for len(s.videoFeeds) >= maxVideoFeedSessions {
+		var oldestToken string
+		var oldestAccess time.Time
+		for candidateToken, feed := range s.videoFeeds {
+			if oldestToken == "" || feed.lastAccess.Before(oldestAccess) {
+				oldestToken = candidateToken
+				oldestAccess = feed.lastAccess
+			}
+		}
+		if oldestToken == "" {
+			break
+		}
+		s.deleteVideoFeedLocked(oldestToken)
+	}
+
+	var storedSharedKey *videoFeedSnapshotKey
+	if sharedKey != nil {
+		key := *sharedKey
+		storedSharedKey = &key
+	}
+	s.videoFeeds[token] = &videoFeedSession{
+		videoIDs:   videoIDs,
+		lastAccess: now,
+		sharedKey:  storedSharedKey,
+	}
+	if storedSharedKey != nil {
+		s.videoFeedShared[*storedSharedKey] = token
+	}
+	return token, videoIDs
+}
+
+func (s *Server) loadVideoFeed(token string) ([]string, error) {
+	now := s.videoFeedTime()
+	s.videoFeedMu.Lock()
+	defer s.videoFeedMu.Unlock()
+
+	s.pruneVideoFeedsLocked(now)
+	feed := s.videoFeeds[token]
+	if feed == nil {
+		return nil, errVideoFeedExpired
+	}
+	feed.lastAccess = now
+	return feed.videoIDs, nil
+}
+
+func (s *Server) pruneVideoFeedsLocked(now time.Time) {
+	for token, feed := range s.videoFeeds {
+		if now.Sub(feed.lastAccess) >= videoFeedTTL {
+			s.deleteVideoFeedLocked(token)
+		}
+	}
+}
+
+func (s *Server) deleteVideoFeedLocked(token string) {
+	feed := s.videoFeeds[token]
+	if feed == nil {
+		return
+	}
+	delete(s.videoFeeds, token)
+	if feed.sharedKey != nil && s.videoFeedShared[*feed.sharedKey] == token {
+		delete(s.videoFeedShared, *feed.sharedKey)
+	}
+}
+
+// loadVisibleVideoFeedBatch skips snapshot entries that stopped being public
+// while still advancing the cursor over their positions.
+func (s *Server) loadVisibleVideoFeedBatch(
+	ctx context.Context,
+	videoIDs []string,
+	cursor int,
+	count int,
+) ([]*catalog.VideoSummary, int, error) {
+	videos := make([]*catalog.VideoSummary, 0, count)
+	lookupSize := videoFeedLookupSize(count)
+	for cursor < len(videoIDs) && len(videos) < count {
+		end := cursor + lookupSize
+		if end > len(videoIDs) {
+			end = len(videoIDs)
+		}
+		visible, err := s.Catalog.VisibleVideoSummariesByIDs(ctx, videoIDs[cursor:end])
+		if err != nil {
+			return nil, cursor, err
+		}
+		visibleByID := make(map[string]*catalog.VideoSummary, len(visible))
+		for _, video := range visible {
+			visibleByID[video.ID] = video
+		}
+		for cursor < end && len(videos) < count {
+			videoID := videoIDs[cursor]
+			cursor++
+			if video := visibleByID[videoID]; video != nil {
+				videos = append(videos, video)
+			}
+		}
+	}
+	return videos, cursor, nil
+}
+
+func videoFeedLookupSize(count int) int {
+	if count > videoFeedLookupChunk {
+		return count
+	}
+	return videoFeedLookupChunk
+}

--- a/backend/internal/api/video_feed_test.go
+++ b/backend/internal/api/video_feed_test.go
@@ -1,0 +1,338 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/video-site/backend/internal/catalog"
+)
+
+func TestVideoFeedUsesAnIdempotentSnapshotCursor(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	baseTime := time.Now().Add(-time.Hour)
+	for index := 0; index < 7; index++ {
+		id := "listing-" + strconv.Itoa(index)
+		if err := cat.UpsertVideo(ctx, &catalog.Video{
+			ID:          id,
+			DriveID:     "drive",
+			FileID:      "file-" + id,
+			Title:       id,
+			PublishedAt: baseTime.Add(time.Duration(index) * time.Minute),
+			CreatedAt:   baseTime,
+			UpdatedAt:   baseTime,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	server := &Server{Catalog: cat}
+	request := func(path string) videoFeedResponse {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		server.handleVideoFeed(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+		}
+		var response videoFeedResponse
+		if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		return response
+	}
+
+	first := request("/api/feed?kind=listing&sort=latest&count=3")
+	if first.FeedToken == "" || first.Total != 7 || first.NextCursor != 3 || first.Exhausted {
+		t.Fatalf("first response = %#v", first)
+	}
+	shared := request("/api/feed?kind=latest&count=3")
+	if shared.FeedToken != first.FeedToken {
+		t.Fatalf("identical deterministic feed token = %q, want shared %q", shared.FeedToken, first.FeedToken)
+	}
+	if len(server.videoFeeds) != 1 {
+		t.Fatalf("identical deterministic feeds stored %d snapshots, want 1", len(server.videoFeeds))
+	}
+	repeated := request("/api/feed?kind=listing&feedToken=" + first.FeedToken + "&cursor=0&count=3")
+	if got, want := videoFeedIDs(repeated.Items), videoFeedIDs(first.Items); !equalStrings(got, want) {
+		t.Fatalf("repeated batch = %v, want %v", got, want)
+	}
+
+	// A new video would move every live OFFSET page, but cannot enter the frozen
+	// snapshot or displace the next cursor range.
+	if err := cat.UpsertVideo(ctx, &catalog.Video{
+		ID:          "new-after-snapshot",
+		DriveID:     "drive",
+		FileID:      "file-new",
+		Title:       "new",
+		PublishedAt: time.Now(),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("insert after snapshot: %v", err)
+	}
+	fresh := request("/api/feed?kind=latest&count=3")
+	if fresh.FeedToken == first.FeedToken || fresh.Total != 8 {
+		t.Fatalf("changed deterministic feed reused stale snapshot: %#v", fresh)
+	}
+
+	stored := append([]string(nil), server.videoFeeds[first.FeedToken].videoIDs...)
+	next := request("/api/feed?kind=listing&feedToken=" + first.FeedToken + "&cursor=3&count=3")
+	if got, want := videoFeedIDs(next.Items), stored[3:6]; !equalStrings(got, want) {
+		t.Fatalf("next batch = %v, want frozen range %v", got, want)
+	}
+	for _, item := range next.Items {
+		if item.ID == "new-after-snapshot" {
+			t.Fatal("post-snapshot video leaked into an existing feed")
+		}
+	}
+}
+
+func TestVideoFeedAvoidsCompletedSnapshotsAndKeepsRecommendationsPrivate(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	for index := 0; index < 5; index++ {
+		id := "video-" + strconv.Itoa(index)
+		if err := cat.UpsertVideo(ctx, &catalog.Video{
+			ID: id, DriveID: "drive", FileID: "file-" + id, Title: id,
+			ThumbnailURL: "/p/thumb/" + id,
+			Badges:       []string{"new"},
+			PublishedAt:  now.Add(time.Duration(index) * time.Minute),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	server := &Server{Catalog: cat}
+	completed := requestVideoFeed(t, server, "/api/feed?kind=listing&count=5")
+	if completed.FeedToken != "" || !completed.Exhausted || completed.NextCursor != 5 {
+		t.Fatalf("completed first batch = %#v", completed)
+	}
+	if len(server.videoFeeds) != 0 {
+		t.Fatalf("completed first batch retained %d snapshots, want 0", len(server.videoFeeds))
+	}
+	encoded, err := json.Marshal(completed.Items[0])
+	if err != nil {
+		t.Fatalf("encode compact item: %v", err)
+	}
+	for _, unused := range []string{"tags", "likes", "comments", "description", "fileId"} {
+		if strings.Contains(string(encoded), `"`+unused+`"`) {
+			t.Fatalf("compact feed item still contains %q: %s", unused, encoded)
+		}
+	}
+
+	firstRandom := requestVideoFeed(t, server, "/api/feed?kind=recommend&count=2")
+	secondRandom := requestVideoFeed(t, server, "/api/feed?kind=recommend&count=2")
+	if firstRandom.FeedToken == "" || secondRandom.FeedToken == "" || firstRandom.FeedToken == secondRandom.FeedToken {
+		t.Fatalf("random recommendation tokens must stay private: %q / %q", firstRandom.FeedToken, secondRandom.FeedToken)
+	}
+	if len(server.videoFeeds) != 2 {
+		t.Fatalf("random recommendations stored %d snapshots, want 2", len(server.videoFeeds))
+	}
+}
+
+func TestVideoFeedSharesDeterministicSnapshotConcurrently(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	for index := 0; index < 10; index++ {
+		id := "shared-" + strconv.Itoa(index)
+		if err := cat.UpsertVideo(ctx, &catalog.Video{
+			ID: id, DriveID: "drive", FileID: "file-" + id, Title: id,
+			PublishedAt: now.Add(time.Duration(index) * time.Minute),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	server := &Server{Catalog: cat}
+	const clients = 16
+	tokens := make(chan string, clients)
+	errors := make(chan error, clients)
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	wait.Add(clients)
+	for range clients {
+		go func() {
+			defer wait.Done()
+			<-start
+			req := httptest.NewRequest(http.MethodGet, "/api/feed?kind=latest&count=2", nil)
+			rr := httptest.NewRecorder()
+			server.handleVideoFeed(rr, req)
+			if rr.Code != http.StatusOK {
+				errors <- fmt.Errorf("status = %d, body = %s", rr.Code, rr.Body.String())
+				return
+			}
+			var response videoFeedResponse
+			if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+				errors <- err
+				return
+			}
+			tokens <- response.FeedToken
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(tokens)
+	close(errors)
+	for err := range errors {
+		t.Fatalf("concurrent feed request: %v", err)
+	}
+
+	var sharedToken string
+	for token := range tokens {
+		if token == "" {
+			t.Fatal("concurrent feed returned an empty continuation token")
+		}
+		if sharedToken == "" {
+			sharedToken = token
+			continue
+		}
+		if token != sharedToken {
+			t.Fatalf("concurrent deterministic token = %q, want %q", token, sharedToken)
+		}
+	}
+	if len(server.videoFeeds) != 1 {
+		t.Fatalf("concurrent deterministic feeds stored %d snapshots, want 1", len(server.videoFeeds))
+	}
+}
+
+func TestVideoFeedLookupSizeCoversDeepRestoreInOneChunk(t *testing.T) {
+	if got := videoFeedLookupSize(maxVideoFeedBatchSize); got != maxVideoFeedBatchSize {
+		t.Fatalf("deep restore lookup size = %d, want %d", got, maxVideoFeedBatchSize)
+	}
+	if got := videoFeedLookupSize(12); got != videoFeedLookupChunk {
+		t.Fatalf("small batch lookup size = %d, want %d", got, videoFeedLookupChunk)
+	}
+}
+
+func TestVideoFeedSkipsRemovedSnapshotRowsAndExpires(t *testing.T) {
+	ctx := context.Background()
+	cat, err := catalog.Open(t.TempDir() + "/catalog.db")
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	now := time.Now()
+	for index := 0; index < 3; index++ {
+		id := "visible-" + strconv.Itoa(index)
+		if err := cat.UpsertVideo(ctx, &catalog.Video{
+			ID: id, DriveID: "drive", FileID: "file-" + id, Title: id,
+			PublishedAt: now.Add(time.Duration(index) * time.Minute),
+			CreatedAt:   now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	clock := now
+	server := &Server{Catalog: cat, videoFeedNow: func() time.Time { return clock }}
+	firstReq := httptest.NewRequest(http.MethodGet, "/api/feed?kind=latest&count=1", nil)
+	firstRR := httptest.NewRecorder()
+	server.handleVideoFeed(firstRR, firstReq)
+	if firstRR.Code != http.StatusOK {
+		t.Fatalf("first status = %d, body = %s", firstRR.Code, firstRR.Body.String())
+	}
+	var first videoFeedResponse
+	if err := json.NewDecoder(firstRR.Body).Decode(&first); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+
+	removedID := server.videoFeeds[first.FeedToken].videoIDs[first.NextCursor]
+	if err := cat.HideVideo(ctx, removedID); err != nil {
+		t.Fatalf("hide snapshot row: %v", err)
+	}
+	nextReq := httptest.NewRequest(
+		http.MethodGet,
+		"/api/feed?feedToken="+first.FeedToken+"&cursor="+strconv.Itoa(first.NextCursor)+"&count=1",
+		nil,
+	)
+	nextRR := httptest.NewRecorder()
+	server.handleVideoFeed(nextRR, nextReq)
+	if nextRR.Code != http.StatusOK {
+		t.Fatalf("next status = %d, body = %s", nextRR.Code, nextRR.Body.String())
+	}
+	var next videoFeedResponse
+	if err := json.NewDecoder(nextRR.Body).Decode(&next); err != nil {
+		t.Fatalf("decode next: %v", err)
+	}
+	if len(next.Items) != 1 || next.Items[0].ID == removedID || next.NextCursor <= first.NextCursor+1 {
+		t.Fatalf("next response did not skip removed row: %#v", next)
+	}
+
+	clock = clock.Add(videoFeedTTL)
+	expiredReq := httptest.NewRequest(
+		http.MethodGet,
+		"/api/feed?feedToken="+first.FeedToken+"&cursor="+strconv.Itoa(next.NextCursor)+"&count=1",
+		nil,
+	)
+	expiredRR := httptest.NewRecorder()
+	server.handleVideoFeed(expiredRR, expiredReq)
+	if expiredRR.Code != http.StatusGone {
+		t.Fatalf("expired status = %d, want %d", expiredRR.Code, http.StatusGone)
+	}
+}
+
+func requestVideoFeed(t *testing.T, server *Server, path string) videoFeedResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rr := httptest.NewRecorder()
+	server.handleVideoFeed(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var response videoFeedResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return response
+}
+
+func videoFeedIDs(items []VideoCardDTO) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/catalog/catalog.go
+++ b/backend/internal/catalog/catalog.go
@@ -174,6 +174,23 @@ type Video struct {
 	UpdatedAt        time.Time `json:"updatedAt"`
 }
 
+// VideoSummary is the public card-sized projection of a video. List feeds use
+// this instead of loading the full persistence object, whose hashes, storage
+// locations, processing state and description are only needed by detail and
+// maintenance paths.
+type VideoSummary struct {
+	ID                 string
+	Title              string
+	Author             string
+	DurationSeconds    int
+	ThumbnailURL       string
+	ThumbnailUpdatedAt time.Time
+	PreviewUpdatedAt   time.Time
+	Views              int
+	Badges             []string
+	PublishedAt        time.Time
+}
+
 func (c *Catalog) UpsertVideo(ctx context.Context, v *Video) error {
 	existed := c.videoExists(ctx, v.ID)
 	storedTags, err := upsertVideoRow(ctx, c.db, v)
@@ -2374,14 +2391,17 @@ type ListParams struct {
 	PageSize              int
 }
 
-func (c *Catalog) ListVideos(ctx context.Context, p ListParams) ([]*Video, int, error) {
-	if p.PageSize <= 0 {
-		p.PageSize = 24
-	}
-	if p.Page <= 0 {
-		p.Page = 1
-	}
+type videoListQuery struct {
+	whereSQL string
+	orderBy  string
+	args     []any
+}
 
+// buildVideoListQuery owns the public-list filtering and ordering contract.
+// Both paginated responses and cursor-feed snapshots must use this exact query;
+// otherwise the two views can silently disagree about which videos are visible
+// or how ties are ordered.
+func buildVideoListQuery(p ListParams) videoListQuery {
 	var where []string
 	var args []any
 	if p.Keyword != "" {
@@ -2434,35 +2454,49 @@ func (c *Catalog) ListVideos(ctx context.Context, p ListParams) ([]*Video, int, 
 	where = append(where, activeDriveWhereSQL)
 	where = append(where, uniqueVideoWhereSQL)
 
-	whereSQL := ""
-	whereSQL = " WHERE " + strings.Join(where, " AND ")
+	whereSQL := " WHERE " + strings.Join(where, " AND ")
 
 	readyOrderPrefix := ""
 	if p.PreferReadyThumbnails {
-		readyOrderPrefix = "CASE WHEN COALESCE(thumbnail_url, '') != '' THEN 0 ELSE 1 END, "
+		readyOrderPrefix = "CASE WHEN COALESCE(videos.thumbnail_url, '') != '' THEN 0 ELSE 1 END, "
 	}
 
-	orderBy := " ORDER BY " + readyOrderPrefix + "published_at DESC"
+	// Every order ends in videos.id so a snapshot has one deterministic total
+	// order even when timestamps and reaction counters are tied.
+	orderBy := " ORDER BY " + readyOrderPrefix + "videos.published_at DESC, videos.id ASC"
 	switch p.Sort {
 	case "hot":
 		// 热度 = 点赞数；点赞数相同按最近点赞时间，最后用发布时间兜底。
-		orderBy = " ORDER BY " + readyOrderPrefix + "likes DESC, COALESCE(last_liked_at, 0) DESC, published_at DESC"
+		orderBy = " ORDER BY " + readyOrderPrefix + "videos.likes DESC, COALESCE(videos.last_liked_at, 0) DESC, videos.published_at DESC, videos.id ASC"
 	case "recent":
-		orderBy = " ORDER BY " + readyOrderPrefix + "COALESCE(last_viewed_at, 0) DESC, published_at DESC"
+		orderBy = " ORDER BY " + readyOrderPrefix + "COALESCE(videos.last_viewed_at, 0) DESC, videos.published_at DESC, videos.id ASC"
 	}
+
+	return videoListQuery{whereSQL: whereSQL, orderBy: orderBy, args: args}
+}
+
+func (c *Catalog) ListVideos(ctx context.Context, p ListParams) ([]*Video, int, error) {
+	if p.PageSize <= 0 {
+		p.PageSize = 24
+	}
+	if p.Page <= 0 {
+		p.Page = 1
+	}
+	query := buildVideoListQuery(p)
 
 	var total int
 	if !p.SkipTotal {
-		if err := c.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM videos"+whereSQL, args...).Scan(&total); err != nil {
+		if err := c.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM videos"+query.whereSQL, query.args...).Scan(&total); err != nil {
 			return nil, 0, err
 		}
 	}
 
 	// list
 	offset := (p.Page - 1) * p.PageSize
+	queryArgs := append(append([]any(nil), query.args...), p.PageSize, offset)
 	rows, err := c.db.QueryContext(ctx,
-		"SELECT "+allVideoCols+" FROM videos"+whereSQL+orderBy+" LIMIT ? OFFSET ?",
-		append(args, p.PageSize, offset)...)
+		"SELECT "+allVideoCols+" FROM videos"+query.whereSQL+query.orderBy+" LIMIT ? OFFSET ?",
+		queryArgs...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -2476,7 +2510,38 @@ func (c *Catalog) ListVideos(ctx context.Context, p ListParams) ([]*Video, int, 
 		}
 		out = append(out, v)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
 	return out, total, nil
+}
+
+// ListVideoIDs freezes the complete ordered identity set for one public-list
+// query. Feed handlers page through this immutable ID slice instead of applying
+// OFFSET repeatedly to a live, mutable ordering.
+func (c *Catalog) ListVideoIDs(ctx context.Context, p ListParams) ([]string, error) {
+	query := buildVideoListQuery(p)
+	rows, err := c.db.QueryContext(ctx,
+		"SELECT videos.id FROM videos"+query.whereSQL+query.orderBy,
+		query.args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 // CountVisibleVideos 返回当前对前台可见的视频总数（未隐藏、且通过去重规则）。
@@ -2595,6 +2660,82 @@ func (c *Catalog) ListVisibleVideoIDsLatest(ctx context.Context, limit int) ([]s
 		return nil, err
 	}
 	return ids, nil
+}
+
+const videoSummaryCols = `
+videos.id, videos.title, COALESCE(videos.author, ''),
+COALESCE(videos.duration_seconds, 0), COALESCE(videos.thumbnail_url, ''),
+COALESCE(videos.thumbnail_updated_at, 0), COALESCE(videos.preview_updated_at, 0),
+COALESCE(videos.views, 0), COALESCE(videos.badges, '[]'), videos.published_at
+`
+
+// VisibleVideoSummariesByIDs loads only the fields rendered by public video
+// cards. Detail, playback and maintenance fields deliberately stay out of this
+// hot path. Results retain the caller's snapshot order.
+func (c *Catalog) VisibleVideoSummariesByIDs(ctx context.Context, ids []string) ([]*VideoSummary, error) {
+	cleaned := cleanVideoIDs(ids)
+	if len(cleaned) == 0 {
+		return nil, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(cleaned)), ",")
+	args := make([]any, 0, len(cleaned))
+	for _, id := range cleaned {
+		args = append(args, id)
+	}
+	rows, err := c.db.QueryContext(ctx,
+		`SELECT `+videoSummaryCols+` FROM videos
+		  WHERE videos.id IN (`+placeholders+`)
+		    AND COALESCE(videos.hidden, 0) = 0
+		    AND `+activeDriveWhereSQL+`
+		    AND `+uniqueVideoWhereSQL,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	byID := make(map[string]*VideoSummary, len(cleaned))
+	for rows.Next() {
+		video := &VideoSummary{}
+		var thumbnailUpdatedAt, previewUpdatedAt, publishedAt int64
+		var badgesJSON string
+		if err := rows.Scan(
+			&video.ID,
+			&video.Title,
+			&video.Author,
+			&video.DurationSeconds,
+			&video.ThumbnailURL,
+			&thumbnailUpdatedAt,
+			&previewUpdatedAt,
+			&video.Views,
+			&badgesJSON,
+			&publishedAt,
+		); err != nil {
+			return nil, err
+		}
+		_ = json.Unmarshal([]byte(badgesJSON), &video.Badges)
+		if thumbnailUpdatedAt > 0 {
+			video.ThumbnailUpdatedAt = time.UnixMilli(thumbnailUpdatedAt)
+		}
+		if previewUpdatedAt > 0 {
+			video.PreviewUpdatedAt = time.UnixMilli(previewUpdatedAt)
+		}
+		video.PublishedAt = time.UnixMilli(publishedAt)
+		byID[video.ID] = video
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]*VideoSummary, 0, len(byID))
+	for _, id := range cleaned {
+		if video := byID[id]; video != nil {
+			out = append(out, video)
+		}
+	}
+	return out, nil
 }
 
 // VisibleVideosByIDs loads the still-visible subset of ids while preserving

--- a/backend/internal/catalog/performance_benchmark_test.go
+++ b/backend/internal/catalog/performance_benchmark_test.go
@@ -149,6 +149,16 @@ func BenchmarkCatalogPublicReads20K(b *testing.B) {
 		}
 	})
 
+	b.Run("visible_summary_chunk_32", func(b *testing.B) {
+		b.ReportAllocs()
+		chunk := ids[:32]
+		for i := 0; i < b.N; i++ {
+			if _, err := cat.VisibleVideoSummariesByIDs(ctx, chunk); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
 	b.Run("upsert_existing_unchanged_dedup_keys", func(b *testing.B) {
 		video, err := cat.GetVideo(ctx, ids[0])
 		if err != nil {

--- a/backend/internal/catalog/video_summary_test.go
+++ b/backend/internal/catalog/video_summary_test.go
@@ -1,0 +1,74 @@
+package catalog
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestVisibleVideoSummariesByIDsReturnsOnlyVisibleCardsInSnapshotOrder(t *testing.T) {
+	ctx := context.Background()
+	cat, err := Open(filepath.Join(t.TempDir(), "catalog.db"))
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	t.Cleanup(func() { _ = cat.Close() })
+
+	base := time.UnixMilli(1_800_000_000_000)
+	for index, id := range []string{"first", "second", "hidden"} {
+		publishedAt := base.Add(time.Duration(index) * time.Minute)
+		video := &Video{
+			ID:                 id,
+			DriveID:            "drive",
+			FileID:             "file-" + id,
+			FileName:           id + ".mp4",
+			Title:              "Title " + id,
+			Author:             "Author " + id,
+			DurationSeconds:    120 + index,
+			ThumbnailURL:       "/p/thumb/" + id,
+			ThumbnailUpdatedAt: publishedAt,
+			PreviewLocal:       "previews/" + id + ".mp4",
+			PreviewStatus:      "ready",
+			PreviewUpdatedAt:   publishedAt,
+			Views:              100 + index,
+			Badges:             []string{"badge-" + id},
+			Description:        "detail-only description",
+			PublishedAt:        publishedAt,
+			CreatedAt:          publishedAt,
+			UpdatedAt:          publishedAt,
+		}
+		if err := cat.UpsertVideo(ctx, video); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	if err := cat.HideVideo(ctx, "hidden"); err != nil {
+		t.Fatalf("hide video: %v", err)
+	}
+
+	summaries, err := cat.VisibleVideoSummariesByIDs(
+		ctx,
+		[]string{"second", "missing", "hidden", "first"},
+	)
+	if err != nil {
+		t.Fatalf("load summaries: %v", err)
+	}
+	if len(summaries) != 2 || summaries[0].ID != "second" || summaries[1].ID != "first" {
+		t.Fatalf("summary order = %#v, want second then first", summaries)
+	}
+
+	second := summaries[0]
+	if second.Title != "Title second" || second.Author != "Author second" ||
+		second.DurationSeconds != 121 || second.ThumbnailURL != "/p/thumb/second" ||
+		second.Views != 101 || !second.PublishedAt.Equal(base.Add(time.Minute)) {
+		t.Fatalf("second summary = %#v", second)
+	}
+	if !second.ThumbnailUpdatedAt.Equal(base.Add(time.Minute)) ||
+		!second.PreviewUpdatedAt.Equal(base.Add(time.Minute)) {
+		t.Fatalf("summary asset revisions = %#v", second)
+	}
+	if !reflect.DeepEqual(second.Badges, []string{"badge-second"}) {
+		t.Fatalf("summary badges = %v", second.Badges)
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/merge": "^6.12.2",
         "@codemirror/state": "^6.7.1",
         "@noble/hashes": "^2.3.0",
+        "@tanstack/react-virtual": "^3.14.9",
         "@uiw/react-codemirror": "^4.25.11",
         "artplayer": "^5.4.0",
         "hls.js": "^1.6.16",
@@ -913,6 +914,33 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@codemirror/merge": "^6.12.2",
     "@codemirror/state": "^6.7.1",
     "@noble/hashes": "^2.3.0",
+    "@tanstack/react-virtual": "^3.14.9",
     "@uiw/react-codemirror": "^4.25.11",
     "artplayer": "^5.4.0",
     "hls.js": "^1.6.16",

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -5,6 +5,14 @@ type Props = {
   onVisibilityChange?: (visible: boolean) => void;
 };
 
+/**
+ * 虚拟列表会在滚动过程中按实测行高做位置补偿，平滑滚动动画会被这些补偿
+ * 打断、停在半路，所以返回顶部直接落到 0。
+ */
+function scrollToTop() {
+  window.scrollTo({ top: 0, behavior: "auto" });
+}
+
 export function BackToTop({ onVisibilityChange }: Props) {
   const [visible, setVisible] = useState(false);
 
@@ -26,7 +34,7 @@ export function BackToTop({ onVisibilityChange }: Props) {
   return (
     <button
       className={`back-to-top ${visible ? "is-visible" : ""}`}
-      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      onClick={scrollToTop}
       aria-label="返回顶部"
     >
       <ArrowUp size={18} />

--- a/src/components/HomeFeedTabs.tsx
+++ b/src/components/HomeFeedTabs.tsx
@@ -1,0 +1,35 @@
+import type { HomeFeedKey } from "@/lib/listingSearchParams";
+
+type Props = {
+  feed: HomeFeedKey;
+  onChange: (feed: HomeFeedKey) => void;
+};
+
+const HOME_FEED_TABS: { key: HomeFeedKey; label: string }[] = [
+  { key: "recommend", label: "随机推荐" },
+  { key: "latest", label: "最新视频" },
+];
+
+export function HomeFeedTabs({ feed, onChange }: Props) {
+  return (
+    <div className="home-feed-tabs" role="tablist" aria-label="首页视频">
+      {HOME_FEED_TABS.map((tab) => {
+        const active = tab.key === feed;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            className={`home-feed-tabs__tab ${active ? "is-active" : ""}`}
+            onClick={() => onChange(tab.key)}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export { HOME_FEED_TABS };

--- a/src/components/HomeFeedTabs.tsx
+++ b/src/components/HomeFeedTabs.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { HomeFeedKey } from "@/lib/listingSearchParams";
 
 type Props = {
@@ -10,7 +11,7 @@ const HOME_FEED_TABS: { key: HomeFeedKey; label: string }[] = [
   { key: "latest", label: "最新视频" },
 ];
 
-export function HomeFeedTabs({ feed, onChange }: Props) {
+export const HomeFeedTabs = memo(function HomeFeedTabs({ feed, onChange }: Props) {
   return (
     <div className="home-feed-tabs" role="tablist" aria-label="首页视频">
       {HOME_FEED_TABS.map((tab) => {
@@ -30,6 +31,6 @@ export function HomeFeedTabs({ feed, onChange }: Props) {
       })}
     </div>
   );
-}
+});
 
 export { HOME_FEED_TABS };

--- a/src/components/InfiniteFeedStatus.tsx
+++ b/src/components/InfiniteFeedStatus.tsx
@@ -1,0 +1,23 @@
+type Props = {
+  state: "loading" | "end";
+};
+
+export function InfiniteFeedStatus({ state }: Props) {
+  if (state === "end") {
+    return (
+      <div className="listing-infinite-status listing-infinite-status--end">
+        没有更多了
+      </div>
+    );
+  }
+
+  return (
+    <div className="listing-infinite-status" role="status" aria-live="polite">
+      <span
+        className="video-grid-refresh-overlay__spinner"
+        aria-hidden="true"
+      />
+      <span>正在加载更多</span>
+    </div>
+  );
+}

--- a/src/components/PromoStrip.tsx
+++ b/src/components/PromoStrip.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { promoItems } from "@/data/promos";
 
 const kindLabel: Record<string, string> = {
@@ -6,7 +7,7 @@ const kindLabel: Record<string, string> = {
   event: "活动",
 };
 
-export function PromoStrip() {
+export const PromoStrip = memo(function PromoStrip() {
   if (promoItems.length === 0) return null;
   return (
     <div className="promo-strip" aria-label="推荐内容">
@@ -21,4 +22,4 @@ export function PromoStrip() {
       ))}
     </div>
   );
-}
+});

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { memo, type FormEvent, useCallback, useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { Search } from "lucide-react";
 import { withListingNavigation } from "@/lib/listingSearchParams";
@@ -14,7 +14,7 @@ type SearchPanelProps = {
   className?: string;
 };
 
-export function SearchPanel({
+export const SearchPanel = memo(function SearchPanel({
   value,
   onSearch,
   navigationPath = "/list",
@@ -135,4 +135,4 @@ export function SearchPanel({
       )}
     </form>
   );
-}
+});

--- a/src/components/SortToolbar.tsx
+++ b/src/components/SortToolbar.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { LayoutGrid, List } from "lucide-react";
 import type { SortKey } from "@/types";
 
@@ -17,7 +18,7 @@ const sortOptions: { key: SortKey; label: string }[] = [
   { key: "recent", label: "最近观看" },
 ];
 
-export function SortToolbar({
+export const SortToolbar = memo(function SortToolbar({
   sort,
   view,
   onSortChange,
@@ -65,6 +66,6 @@ export function SortToolbar({
       </div>
     </div>
   );
-}
+});
 
 export type { ViewMode };

--- a/src/components/TagCloud.tsx
+++ b/src/components/TagCloud.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Link, useSearchParams } from "react-router";
 import { fetchTags, readCachedTags, type TagItem } from "@/data/videos";
 import { withListingNavigation } from "@/lib/listingSearchParams";
@@ -10,7 +18,10 @@ type TagCloudProps = {
   onTagSelect?: () => void;
 };
 
-export function TagCloud({ linkBasePath = "/list", onTagSelect }: TagCloudProps) {
+export const TagCloud = memo(function TagCloud({
+  linkBasePath = "/list",
+  onTagSelect,
+}: TagCloudProps) {
   const [params] = useSearchParams();
   const activeTag = params.get("tag")?.trim() ?? "";
   const initialTagsRef = useRef<TagItem[] | null>(readCachedTags());
@@ -177,4 +188,4 @@ export function TagCloud({ linkBasePath = "/list", onTagSelect }: TagCloudProps)
       </div>
     </div>
   );
-}
+});

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { memo, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { Link, useLocation } from "react-router";
 import type { PreviewState, VideoItem } from "@/types";
 import { prefetchVideoDetail } from "@/data/videos";
@@ -30,7 +30,7 @@ function useIsActivePreview(videoID: string): boolean {
   );
 }
 
-export function VideoCard({
+export const VideoCard = memo(function VideoCard({
   video,
   eager = false,
   highPriority = false,
@@ -280,7 +280,7 @@ export function VideoCard({
       </Link>
     </article>
   );
-}
+});
 
 // 从后端返回的 sourceLabel 推断网盘类型（用于颜色标识）。
 // 后端目前会下发中文名（"夸克网盘" / "115 网盘" / "PikPak" / "联通网盘" / "OneDrive"）

--- a/src/components/VirtualVideoGrid.tsx
+++ b/src/components/VirtualVideoGrid.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
+import {
+  virtualGridColumns,
+  virtualRowCount,
+  virtualRowRange,
+} from "@/lib/virtualGrid";
+import type { VideoItem } from "@/types";
+import { VideoCard } from "./VideoCard";
+
+/**
+ * 虚拟滚动的视频网格：以"整行"为虚拟单元交给 @tanstack/react-virtual 的
+ * window virtualizer 管理，只挂载可视区域附近的行，其余行由占位容器的
+ * 总高度顶出来，滚动条因此与完整列表等高。
+ *
+ * 每行本身仍是原来的 .video-grid，列数与列间距沿用既有 CSS；行高由
+ * measureElement 实测，卡片高度随断点或标题变化都不需要额外配置。
+ */
+
+const DEFAULT_OVERSCAN_ROWS = 2;
+const ESTIMATED_ROW_HEIGHT = 260;
+const ESTIMATED_COMPACT_ROW_HEIGHT = 120;
+
+export type VirtualGridRange = {
+  startIndex: number;
+  endIndex: number;
+  columns: number;
+};
+
+type Props = {
+  videos: VideoItem[];
+  compact?: boolean;
+  eagerCount?: number;
+  highPriorityCount?: number;
+  overscanRows?: number;
+  refreshMode?: "blocking" | "background";
+  onRangeChange?: (range: VirtualGridRange) => void;
+};
+
+export function VirtualVideoGrid({
+  videos,
+  compact,
+  eagerCount = 0,
+  highPriorityCount = 0,
+  overscanRows = DEFAULT_OVERSCAN_ROWS,
+  refreshMode,
+  onRangeChange,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [columns, setColumns] = useState(1);
+  // 列表容器距文档顶部的距离：window virtualizer 用它把窗口滚动换算成列表内偏移。
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const [rowHeight, setRowHeight] = useState(
+    compact ? ESTIMATED_COMPACT_ROW_HEIGHT : ESTIMATED_ROW_HEIGHT
+  );
+  const rowCount = virtualRowCount(videos.length, columns);
+
+  const virtualizer = useWindowVirtualizer({
+    count: rowCount,
+    estimateSize: () => rowHeight,
+    overscan: overscanRows,
+    scrollMargin,
+    getItemKey: (index) => videos[index * columns]?.id ?? index,
+  });
+
+  const measure = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    const nextMargin = rect.top + window.scrollY;
+    setScrollMargin((current) =>
+      Math.abs(current - nextMargin) < 1 ? current : nextMargin
+    );
+
+    const row = container.querySelector<HTMLElement>(".video-grid--virtual-row");
+    if (!row) return;
+    const nextColumns = virtualGridColumns(window.getComputedStyle(row));
+    setColumns((current) => (current === nextColumns ? current : nextColumns));
+    const nextRowHeight = row.getBoundingClientRect().height;
+    setRowHeight((current) =>
+      nextRowHeight > 0 && Math.abs(current - nextRowHeight) >= 1
+        ? nextRowHeight
+        : current
+    );
+  }, []);
+
+  // 布局阶段就要量出列数：首帧按单列渲染，浏览器绘制之前会被纠正过来。
+  useLayoutEffect(() => {
+    measure();
+  });
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
+    observer?.observe(container);
+    window.addEventListener("resize", measure);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [measure]);
+
+  // 列数变化会重排每一行的内容，之前测到的行高全部失效。
+  useEffect(() => {
+    virtualizer.measure();
+  }, [columns, compact, virtualizer]);
+
+  const virtualRows = virtualizer.getVirtualItems();
+  const firstRow = virtualRows[0]?.index ?? 0;
+  const lastRow = virtualRows[virtualRows.length - 1]?.index ?? -1;
+
+  useEffect(() => {
+    if (lastRow < 0) return;
+    onRangeChange?.({
+      startIndex: firstRow * columns,
+      endIndex: Math.min((lastRow + 1) * columns, videos.length),
+      columns,
+    });
+  }, [columns, firstRow, lastRow, onRangeChange, videos.length]);
+
+  const blockingRefresh = refreshMode === "blocking";
+  const backgroundRefresh = refreshMode === "background";
+
+  return (
+    <div
+      ref={containerRef}
+      className={`video-grid-region ${blockingRefresh ? "is-busy" : ""}`}
+      aria-busy={blockingRefresh || backgroundRefresh || undefined}
+    >
+      <div
+        className="video-grid-virtual-canvas"
+        style={{ height: virtualizer.getTotalSize() }}
+      >
+        {virtualRows.map((virtualRow) => {
+          const { start, end } = virtualRowRange(
+            virtualRow.index,
+            columns,
+            videos.length
+          );
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              className={`video-grid video-grid--virtual-row ${
+                compact ? "is-compact" : ""
+              }`}
+              style={{
+                transform: `translateY(${
+                  virtualRow.start - virtualizer.options.scrollMargin
+                }px)`,
+              }}
+            >
+              {videos.slice(start, end).map((video, offset) => {
+                const index = start + offset;
+                return (
+                  <VideoCard
+                    key={video.id}
+                    video={video}
+                    eager={index < eagerCount}
+                    highPriority={index < highPriorityCount}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+      {blockingRefresh && (
+        <div className="video-grid-refresh-overlay" aria-hidden="true" />
+      )}
+      {backgroundRefresh && (
+        <div className="video-grid-background-status" role="status">
+          <span className="video-grid-refresh-overlay__spinner" aria-hidden="true" />
+          <span>正在同步</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VirtualVideoGrid.tsx
+++ b/src/components/VirtualVideoGrid.tsx
@@ -1,6 +1,14 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import {
+  shouldLoadMore,
   virtualGridColumns,
   virtualRowCount,
   virtualRowRange,
@@ -10,8 +18,8 @@ import { VideoCard } from "./VideoCard";
 
 /**
  * 虚拟滚动的视频网格：以"整行"为虚拟单元交给 @tanstack/react-virtual 的
- * window virtualizer 管理，只挂载可视区域附近的行，其余行由占位容器的
- * 总高度顶出来，滚动条因此与完整列表等高。
+ * window virtualizer 管理，只挂载可视区域附近的行，其余已加载行由占位容器
+ * 顶出高度。未加载内容只保留固定尾行，滚动条随真实内容逐批增长。
  *
  * 每行本身仍是原来的 .video-grid，列数与列间距沿用既有 CSS；行高由
  * measureElement 实测，卡片高度随断点或标题变化都不需要额外配置。
@@ -20,12 +28,10 @@ import { VideoCard } from "./VideoCard";
 const DEFAULT_OVERSCAN_ROWS = 2;
 const ESTIMATED_ROW_HEIGHT = 260;
 const ESTIMATED_COMPACT_ROW_HEIGHT = 120;
-
-export type VirtualGridRange = {
-  startIndex: number;
-  endIndex: number;
-  columns: number;
-};
+const MOBILE_GRID_QUERY = "(max-width: 640px)";
+const TABLET_GRID_QUERY = "(max-width: 1024px)";
+const TAIL_ROW_HEIGHT = 56;
+const TAIL_ROW_KEY = "video-grid-tail";
 
 type Props = {
   videos: VideoItem[];
@@ -34,8 +40,39 @@ type Props = {
   highPriorityCount?: number;
   overscanRows?: number;
   refreshMode?: "blocking" | "background";
-  onRangeChange?: (range: VirtualGridRange) => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  prefetchRows?: number;
+  tailContent?: ReactNode;
+  onLoadMore?: () => void;
 };
+
+function readResponsiveGridColumns(): number {
+  if (typeof window === "undefined") return 4;
+  return virtualGridColumns({
+    compact: false,
+    mobile: window.matchMedia(MOBILE_GRID_QUERY).matches,
+    tablet: window.matchMedia(TABLET_GRID_QUERY).matches,
+  });
+}
+
+function useResponsiveGridColumns(): number {
+  const [columns, setColumns] = useState(readResponsiveGridColumns);
+
+  useEffect(() => {
+    const mobile = window.matchMedia(MOBILE_GRID_QUERY);
+    const tablet = window.matchMedia(TABLET_GRID_QUERY);
+    const update = () => setColumns(readResponsiveGridColumns());
+    mobile.addEventListener("change", update);
+    tablet.addEventListener("change", update);
+    return () => {
+      mobile.removeEventListener("change", update);
+      tablet.removeEventListener("change", update);
+    };
+  }, []);
+
+  return columns;
+}
 
 export function VirtualVideoGrid({
   videos,
@@ -44,82 +81,125 @@ export function VirtualVideoGrid({
   highPriorityCount = 0,
   overscanRows = DEFAULT_OVERSCAN_ROWS,
   refreshMode,
-  onRangeChange,
+  hasMore = false,
+  loadingMore = false,
+  prefetchRows = 2,
+  tailContent,
+  onLoadMore,
 }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [columns, setColumns] = useState(1);
+  const containerWidthRef = useRef(0);
+  const responsiveColumns = useResponsiveGridColumns();
+  const columns = compact ? 1 : responsiveColumns;
   // 列表容器距文档顶部的距离：window virtualizer 用它把窗口滚动换算成列表内偏移。
   const [scrollMargin, setScrollMargin] = useState(0);
-  const [rowHeight, setRowHeight] = useState(
-    compact ? ESTIMATED_COMPACT_ROW_HEIGHT : ESTIMATED_ROW_HEIGHT
+  const loadedRowCount = virtualRowCount(videos.length, columns);
+  // 未加载内容不提前撑高页面；只保留一个固定尾行承载加载反馈。
+  const hasTailRow = hasMore;
+  const virtualRowCountWithTail = loadedRowCount + (hasTailRow ? 1 : 0);
+  const getItemKey = useCallback(
+    (index: number) =>
+      index === loadedRowCount && hasTailRow
+        ? TAIL_ROW_KEY
+        : videos[index * columns]?.id ?? index,
+    [columns, hasTailRow, loadedRowCount, videos]
   );
-  const rowCount = virtualRowCount(videos.length, columns);
+  const estimateSize = useCallback(
+    (index: number) =>
+      index === loadedRowCount && hasTailRow
+        ? TAIL_ROW_HEIGHT
+        : compact
+        ? ESTIMATED_COMPACT_ROW_HEIGHT
+        : ESTIMATED_ROW_HEIGHT,
+    [compact, hasTailRow, loadedRowCount]
+  );
 
   const virtualizer = useWindowVirtualizer({
-    count: rowCount,
-    estimateSize: () => rowHeight,
+    count: virtualRowCountWithTail,
+    estimateSize,
     overscan: overscanRows,
     scrollMargin,
-    getItemKey: (index) => videos[index * columns]?.id ?? index,
+    getItemKey,
+    directDomUpdates: true,
+    directDomUpdatesMode: "transform",
   });
 
-  const measure = useCallback(() => {
+  const updateScrollMargin = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
 
     const rect = container.getBoundingClientRect();
+    containerWidthRef.current = rect.width;
     const nextMargin = rect.top + window.scrollY;
     setScrollMargin((current) =>
       Math.abs(current - nextMargin) < 1 ? current : nextMargin
     );
-
-    const row = container.querySelector<HTMLElement>(".video-grid--virtual-row");
-    if (!row) return;
-    const nextColumns = virtualGridColumns(window.getComputedStyle(row));
-    setColumns((current) => (current === nextColumns ? current : nextColumns));
-    const nextRowHeight = row.getBoundingClientRect().height;
-    setRowHeight((current) =>
-      nextRowHeight > 0 && Math.abs(current - nextRowHeight) >= 1
-        ? nextRowHeight
-        : current
-    );
   }, []);
 
-  // 布局阶段就要量出列数：首帧按单列渲染，浏览器绘制之前会被纠正过来。
+  // 容器位置只在挂载和真实布局变化时读取，不跟着虚拟列表的每次渲染读取。
   useLayoutEffect(() => {
-    measure();
-  });
+    updateScrollMargin();
+  }, [updateScrollMargin]);
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
     const observer =
-      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(([entry]) => {
+            const nextWidth = entry?.contentRect.width ?? 0;
+            if (
+              nextWidth <= 0 ||
+              Math.abs(containerWidthRef.current - nextWidth) < 1
+            ) {
+              return;
+            }
+            updateScrollMargin();
+          });
     observer?.observe(container);
-    window.addEventListener("resize", measure);
+    window.addEventListener("resize", updateScrollMargin);
     return () => {
       observer?.disconnect();
-      window.removeEventListener("resize", measure);
+      window.removeEventListener("resize", updateScrollMargin);
     };
-  }, [measure]);
+  }, [updateScrollMargin]);
 
-  // 列数变化会重排每一行的内容，之前测到的行高全部失效。
-  useEffect(() => {
+  // 只有断点或视图模式改变时，旧行的测量才真正失效。追加批次会保留旧缓存。
+  const layoutIdentity = `${columns}:${compact ? "compact" : "grid"}`;
+  const previousLayoutIdentityRef = useRef(layoutIdentity);
+  useLayoutEffect(() => {
+    if (previousLayoutIdentityRef.current === layoutIdentity) return;
+    previousLayoutIdentityRef.current = layoutIdentity;
     virtualizer.measure();
-  }, [columns, compact, virtualizer]);
+  }, [layoutIdentity, virtualizer]);
 
   const virtualRows = virtualizer.getVirtualItems();
-  const firstRow = virtualRows[0]?.index ?? 0;
   const lastRow = virtualRows[virtualRows.length - 1]?.index ?? -1;
 
   useEffect(() => {
-    if (lastRow < 0) return;
-    onRangeChange?.({
-      startIndex: firstRow * columns,
-      endIndex: Math.min((lastRow + 1) * columns, videos.length),
-      columns,
-    });
-  }, [columns, firstRow, lastRow, onRangeChange, videos.length]);
+    if (!onLoadMore || lastRow < 0) return;
+    if (
+      shouldLoadMore({
+        endIndex: Math.min((lastRow + 1) * columns, videos.length),
+        itemCount: videos.length,
+        columns,
+        hasMore,
+        loading: loadingMore,
+        prefetchRows,
+      })
+    ) {
+      onLoadMore();
+    }
+  }, [
+    columns,
+    hasMore,
+    lastRow,
+    loadingMore,
+    onLoadMore,
+    prefetchRows,
+    videos.length,
+  ]);
 
   const blockingRefresh = refreshMode === "blocking";
   const backgroundRefresh = refreshMode === "background";
@@ -128,13 +208,28 @@ export function VirtualVideoGrid({
     <div
       ref={containerRef}
       className={`video-grid-region ${blockingRefresh ? "is-busy" : ""}`}
-      aria-busy={blockingRefresh || backgroundRefresh || undefined}
+      aria-busy={
+        blockingRefresh || backgroundRefresh || loadingMore || undefined
+      }
     >
       <div
+        ref={virtualizer.containerRef}
         className="video-grid-virtual-canvas"
-        style={{ height: virtualizer.getTotalSize() }}
       >
         {virtualRows.map((virtualRow) => {
+          if (virtualRow.index === loadedRowCount && hasTailRow) {
+            return (
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                className="video-grid-virtual-tail"
+                style={{ height: TAIL_ROW_HEIGHT }}
+              >
+                {tailContent}
+              </div>
+            );
+          }
           const { start, end } = virtualRowRange(
             virtualRow.index,
             columns,
@@ -148,11 +243,6 @@ export function VirtualVideoGrid({
               className={`video-grid video-grid--virtual-row ${
                 compact ? "is-compact" : ""
               }`}
-              style={{
-                transform: `translateY(${
-                  virtualRow.start - virtualizer.options.scrollMargin
-                }px)`,
-              }}
             >
               {videos.slice(start, end).map((video, offset) => {
                 const index = start + offset;
@@ -174,7 +264,10 @@ export function VirtualVideoGrid({
       )}
       {backgroundRefresh && (
         <div className="video-grid-background-status" role="status">
-          <span className="video-grid-refresh-overlay__spinner" aria-hidden="true" />
+          <span
+            className="video-grid-refresh-overlay__spinner"
+            aria-hidden="true"
+          />
           <span>正在同步</span>
         </div>
       )}

--- a/src/data/videos.ts
+++ b/src/data/videos.ts
@@ -69,6 +69,86 @@ export async function fetchListing(
   return result;
 }
 
+export type VideoFeedKind = "listing" | "recommend" | "latest";
+
+export type VideoFeedCursor = {
+  feedToken: string;
+  position: number;
+};
+
+export type VideoFeedResponse = {
+  items: VideoItem[];
+  total: number;
+  feedToken: string;
+  nextCursor: number;
+  exhausted: boolean;
+};
+
+export class VideoFeedExpiredError extends Error {
+  constructor() {
+    super("Video feed expired");
+    this.name = "VideoFeedExpiredError";
+  }
+}
+
+/**
+ * Idempotent snapshot feed. A first response with more data creates an ordered
+ * server-side snapshot; later requests address it with a token and cursor.
+ * A result completed by the first response intentionally has no token.
+ */
+export async function fetchVideoFeed(
+  input: {
+    kind: VideoFeedKind;
+    cursor: VideoFeedCursor;
+    count: number;
+    q?: string;
+    tag?: string;
+    sort?: string;
+  },
+  options: { signal?: AbortSignal } = {}
+): Promise<VideoFeedResponse> {
+  const params = new URLSearchParams({
+    kind: input.kind,
+    cursor: String(input.cursor.position),
+    count: String(input.count),
+  });
+  if (input.cursor.feedToken) params.set("feedToken", input.cursor.feedToken);
+  if (input.q?.trim()) params.set("q", input.q.trim());
+  if (input.tag?.trim()) params.set("tag", input.tag.trim());
+  if (input.sort) params.set("sort", input.sort);
+
+  let result: VideoFeedResponse;
+  try {
+    result = await apiGet<VideoFeedResponse>(`/api/feed?${params.toString()}`, options);
+  } catch (error) {
+    if (error instanceof HTTPStatusError && error.status === 410) {
+      throw new VideoFeedExpiredError();
+    }
+    throw error;
+  }
+
+  if (
+    !result ||
+    !Array.isArray(result.items) ||
+    !Number.isInteger(result.total) ||
+    result.total < 0 ||
+    typeof result.feedToken !== "string" ||
+    result.feedToken.length > 128 ||
+    (input.cursor.feedToken.length > 0 &&
+      result.feedToken !== input.cursor.feedToken) ||
+    !Number.isInteger(result.nextCursor) ||
+    result.nextCursor < input.cursor.position ||
+    result.nextCursor > result.total ||
+    typeof result.exhausted !== "boolean" ||
+    (!result.exhausted && result.feedToken.length === 0) ||
+    (!result.exhausted && result.nextCursor <= input.cursor.position) ||
+    result.exhausted !== (result.nextCursor >= result.total)
+  ) {
+    throw new Error("Invalid /api/feed response");
+  }
+  return result;
+}
+
 export function fetchVideoDetail(id: string): Promise<VideoDetail | null> {
   return apiGet<VideoDetail>(`/api/video/${encodeURIComponent(id)}`).catch(
     () => null

--- a/src/lib/infiniteFeedSource.ts
+++ b/src/lib/infiniteFeedSource.ts
@@ -1,48 +1,39 @@
-import { fetchHomeVideos, fetchListing } from "@/data/videos";
+import {
+  fetchVideoFeed,
+  VideoFeedExpiredError,
+  type VideoFeedCursor,
+  type VideoFeedKind,
+} from "@/data/videos";
 import { infiniteListingKey } from "@/lib/infiniteListing";
 import type { SortKey, VideoItem } from "@/types";
 
 /**
- * 无限滚动的数据来源。累积、去重、游标推进由 useInfiniteListing 统一负责，
- * 各个 feed 只描述"第 N 批怎么取"。
+ * 无限滚动的数据来源。source 只描述逻辑 feed 和批次大小；快照 token、游标、
+ * 累积、缓存与取消统一由 useInfiniteListing 管理。
  */
 
-export type InfiniteFeedBatch = { items: VideoItem[]; total: number };
-
-export type InfiniteFeedSource = {
-  /** 同一个 key 代表同一条累积会话，变了就重新开始。 */
-  key: string;
-  /** 每批请求多少条。 */
-  batchSize: number;
-  /**
-   * 服务端轮换 feed 既没有 total、也永远返回满批，只能靠"整批都是已看过的
-   * 内容"判断转完了一圈。
-   */
-  stopOnDuplicateBatch?: boolean;
-  /**
-   * 是否可以用一次大请求把之前的进度补回来。轮换 feed 的游标在服务端且不
-   * 幂等，补回来的不是原来那些视频，因此不支持。
-   */
-  supportsRestore?: boolean;
-  fetchBatch: (
-    request: { offset: number; size: number },
-    options: { signal: AbortSignal }
-  ) => Promise<InfiniteFeedBatch>;
+export type InfiniteFeedRequest = {
+  cursor: VideoFeedCursor;
+  size: number;
 };
 
-/**
- * page/size 接口只能表达页边界上的区间，所以偏移量必须是批大小的整数倍；
- * 恢复现场时的大请求也因此被约束成批大小的整数倍。
- */
-export function listingPageFromOffset(
-  offset: number,
-  size: number
-): number | null {
-  if (!Number.isInteger(offset) || offset < 0) return null;
-  if (!Number.isInteger(size) || size <= 0) return null;
-  if (offset % size !== 0) return null;
-  return offset / size + 1;
-}
+export type InfiniteFeedBatch = {
+  items: VideoItem[];
+  total: number;
+  cursor: VideoFeedCursor;
+  exhausted: boolean;
+};
+
+export type InfiniteFeedSource = {
+  /** 同一个 key 代表同一个逻辑结果集；批次大小不是结果集身份的一部分。 */
+  key: string;
+  batchSize: number;
+  fetchBatch: (
+    request: InfiniteFeedRequest,
+    options: { signal: AbortSignal }
+  ) => Promise<InfiniteFeedBatch>;
+  isExpiredError: (error: unknown) => boolean;
+};
 
 export type ListingFeedQuery = {
   q: string;
@@ -51,64 +42,69 @@ export type ListingFeedQuery = {
   pageSize: number;
 };
 
-/** /api/list：真正的分页，有 total，可以恢复现场。 */
-export function listingFeedSource(query: ListingFeedQuery): InfiniteFeedSource {
+function snapshotFeedSource(input: {
+  key: string;
+  kind: VideoFeedKind;
+  batchSize: number;
+  q?: string;
+  tag?: string;
+  sort?: SortKey;
+}): InfiniteFeedSource {
   return {
-    key: `listing:${infiniteListingKey(query)}`,
-    batchSize: query.pageSize,
-    supportsRestore: true,
-    fetchBatch: (request, options) => {
-      const page = listingPageFromOffset(request.offset, request.size);
-      if (page === null) {
-        return Promise.reject(
-          new Error(
-            `Listing offset ${request.offset} is not aligned to size ${request.size}`
-          )
-        );
-      }
-      return fetchListing(
-        page,
-        request.size,
-        { q: query.q, tag: query.tag, sort: query.sort },
+    key: input.key,
+    batchSize: input.batchSize,
+    isExpiredError: (error) => error instanceof VideoFeedExpiredError,
+    fetchBatch: async (request, options) => {
+      const response = await fetchVideoFeed(
+        {
+          kind: input.kind,
+          cursor: request.cursor,
+          count: request.size,
+          q: input.q,
+          tag: input.tag,
+          sort: input.sort,
+        },
         { signal: options.signal }
       );
+      return {
+        items: response.items,
+        total: response.total,
+        cursor: {
+          feedToken: response.feedToken,
+          position: response.nextCursor,
+        },
+        exhausted: response.exhausted,
+      };
     },
   };
 }
 
-/** /api/home 单次上限，后端超过就直接 400。 */
+export function listingFeedSource(query: ListingFeedQuery): InfiniteFeedSource {
+  return snapshotFeedSource({
+    key: `listing:${infiniteListingKey(query)}`,
+    kind: "listing",
+    batchSize: query.pageSize,
+    q: query.q.trim(),
+    tag: query.tag.trim(),
+    sort: query.sort,
+  });
+}
+
 export const HOME_RECOMMENDATION_BATCH_SIZE = 12;
 
-/**
- * /api/home：整库随机轮换，游标由服务端按会话维护，请求里带不了偏移量。
- * 每次拿一批新的随机视频接到列表尾部，转完一圈后开始重复，此时收尾。
- */
 export function homeRecommendationFeedSource(): InfiniteFeedSource {
-  return {
+  return snapshotFeedSource({
     key: "home:recommend",
+    kind: "recommend",
     batchSize: HOME_RECOMMENDATION_BATCH_SIZE,
-    stopOnDuplicateBatch: true,
-    supportsRestore: false,
-    fetchBatch: async (request) => {
-      const items = await fetchHomeVideos(
-        Math.min(request.size, HOME_RECOMMENDATION_BATCH_SIZE)
-      );
-      // 轮换 feed 不知道总量，交给"整批重复"和"返回不足一批"两个收尾条件。
-      return { items, total: 0 };
-    },
-  };
+  });
 }
 
-/**
- * 首页"最新视频"走 /api/list?sort=latest 而不是 /api/home/latest：后者单次
- * 上限 12 条且只在最新 96 条里绕圈，撑不起无限滚动。
- */
 export function homeLatestFeedSource(pageSize: number): InfiniteFeedSource {
-  const source = listingFeedSource({
-    q: "",
-    tag: "",
+  return snapshotFeedSource({
+    key: "home:latest",
+    kind: "latest",
+    batchSize: pageSize,
     sort: "latest",
-    pageSize,
   });
-  return { ...source, key: `home:latest:${pageSize}` };
 }

--- a/src/lib/infiniteFeedSource.ts
+++ b/src/lib/infiniteFeedSource.ts
@@ -1,0 +1,114 @@
+import { fetchHomeVideos, fetchListing } from "@/data/videos";
+import { infiniteListingKey } from "@/lib/infiniteListing";
+import type { SortKey, VideoItem } from "@/types";
+
+/**
+ * 无限滚动的数据来源。累积、去重、游标推进由 useInfiniteListing 统一负责，
+ * 各个 feed 只描述"第 N 批怎么取"。
+ */
+
+export type InfiniteFeedBatch = { items: VideoItem[]; total: number };
+
+export type InfiniteFeedSource = {
+  /** 同一个 key 代表同一条累积会话，变了就重新开始。 */
+  key: string;
+  /** 每批请求多少条。 */
+  batchSize: number;
+  /**
+   * 服务端轮换 feed 既没有 total、也永远返回满批，只能靠"整批都是已看过的
+   * 内容"判断转完了一圈。
+   */
+  stopOnDuplicateBatch?: boolean;
+  /**
+   * 是否可以用一次大请求把之前的进度补回来。轮换 feed 的游标在服务端且不
+   * 幂等，补回来的不是原来那些视频，因此不支持。
+   */
+  supportsRestore?: boolean;
+  fetchBatch: (
+    request: { offset: number; size: number },
+    options: { signal: AbortSignal }
+  ) => Promise<InfiniteFeedBatch>;
+};
+
+/**
+ * page/size 接口只能表达页边界上的区间，所以偏移量必须是批大小的整数倍；
+ * 恢复现场时的大请求也因此被约束成批大小的整数倍。
+ */
+export function listingPageFromOffset(
+  offset: number,
+  size: number
+): number | null {
+  if (!Number.isInteger(offset) || offset < 0) return null;
+  if (!Number.isInteger(size) || size <= 0) return null;
+  if (offset % size !== 0) return null;
+  return offset / size + 1;
+}
+
+export type ListingFeedQuery = {
+  q: string;
+  tag: string;
+  sort: SortKey;
+  pageSize: number;
+};
+
+/** /api/list：真正的分页，有 total，可以恢复现场。 */
+export function listingFeedSource(query: ListingFeedQuery): InfiniteFeedSource {
+  return {
+    key: `listing:${infiniteListingKey(query)}`,
+    batchSize: query.pageSize,
+    supportsRestore: true,
+    fetchBatch: (request, options) => {
+      const page = listingPageFromOffset(request.offset, request.size);
+      if (page === null) {
+        return Promise.reject(
+          new Error(
+            `Listing offset ${request.offset} is not aligned to size ${request.size}`
+          )
+        );
+      }
+      return fetchListing(
+        page,
+        request.size,
+        { q: query.q, tag: query.tag, sort: query.sort },
+        { signal: options.signal }
+      );
+    },
+  };
+}
+
+/** /api/home 单次上限，后端超过就直接 400。 */
+export const HOME_RECOMMENDATION_BATCH_SIZE = 12;
+
+/**
+ * /api/home：整库随机轮换，游标由服务端按会话维护，请求里带不了偏移量。
+ * 每次拿一批新的随机视频接到列表尾部，转完一圈后开始重复，此时收尾。
+ */
+export function homeRecommendationFeedSource(): InfiniteFeedSource {
+  return {
+    key: "home:recommend",
+    batchSize: HOME_RECOMMENDATION_BATCH_SIZE,
+    stopOnDuplicateBatch: true,
+    supportsRestore: false,
+    fetchBatch: async (request) => {
+      const items = await fetchHomeVideos(
+        Math.min(request.size, HOME_RECOMMENDATION_BATCH_SIZE)
+      );
+      // 轮换 feed 不知道总量，交给"整批重复"和"返回不足一批"两个收尾条件。
+      return { items, total: 0 };
+    },
+  };
+}
+
+/**
+ * 首页"最新视频"走 /api/list?sort=latest 而不是 /api/home/latest：后者单次
+ * 上限 12 条且只在最新 96 条里绕圈，撑不起无限滚动。
+ */
+export function homeLatestFeedSource(pageSize: number): InfiniteFeedSource {
+  const source = listingFeedSource({
+    q: "",
+    tag: "",
+    sort: "latest",
+    pageSize,
+  });
+  return { ...source, key: `home:latest:${pageSize}` };
+}

--- a/src/lib/infiniteListing.ts
+++ b/src/lib/infiniteListing.ts
@@ -59,6 +59,8 @@ export type InfiniteListingAction =
       items: VideoItem[];
       total: number;
       receivedAt: number;
+      /** 服务端轮换 feed 没有终点，整批都是重复内容时就收尾。 */
+      stopOnDuplicateBatch?: boolean;
     }
   | { type: "load-failure"; requestID: number; error: Error };
 
@@ -157,9 +159,11 @@ export function infiniteListingReducer(
         requestedCount,
         exhausted: isListingExhausted({
           received: action.items.length,
+          added: items.length - state.items.length,
           batchSize: action.batchSize,
           requestedCount,
           total: action.total,
+          stopOnDuplicateBatch: action.stopOnDuplicateBatch,
         }),
         status: "ready",
         error: null,
@@ -178,28 +182,29 @@ export function infiniteListingReducer(
  */
 export function isListingExhausted(input: {
   received: number;
+  /** 去重后真正新增的条数。 */
+  added: number;
   batchSize: number;
   requestedCount: number;
   total: number;
+  /** 轮换 feed 没有 total，也永远返回满批，只能靠"整批都重复"收尾。 */
+  stopOnDuplicateBatch?: boolean;
 }): boolean {
   if (input.received < input.batchSize) return true;
+  if (input.stopOnDuplicateBatch && input.added === 0) return true;
   return input.total > 0 && input.requestedCount >= input.total;
 }
 
-export type InfiniteListingRequest = { page: number; size: number };
+export type InfiniteListingRequest = { offset: number; size: number };
 
-/**
- * 下一批的分页参数。偏移量必须是页大小的整数倍，否则 page/size 接口无法
- * 表达这个区间——恢复现场时的大请求也因此被约束成页大小的整数倍。
- */
+/** 下一批要取的区间；具体怎么翻页由各个 feed source 自己决定。 */
 export function nextListingRequest(
   state: InfiniteListingState
 ): InfiniteListingRequest | null {
   if (state.exhausted) return null;
-  const pageSize = state.pageSize;
-  if (!Number.isInteger(pageSize) || pageSize <= 0) return null;
-  if (state.requestedCount % pageSize !== 0) return null;
-  return { page: state.requestedCount / pageSize + 1, size: pageSize };
+  const size = state.pageSize;
+  if (!Number.isInteger(size) || size <= 0) return null;
+  return { offset: state.requestedCount, size };
 }
 
 export function infiniteListingHasMore(state: InfiniteListingState): boolean {

--- a/src/lib/infiniteListing.ts
+++ b/src/lib/infiniteListing.ts
@@ -1,0 +1,207 @@
+import type { SortKey, VideoItem } from "@/types";
+
+/**
+ * 无限滚动列表的纯状态层。分页游标按"已请求条目数"推进而不是按"已渲染条目数"，
+ * 否则后端去重/隐藏行会让偏移量漂移，越翻越错位。
+ */
+
+export type InfiniteListingStatus =
+  | "idle"
+  | "initial-loading"
+  | "ready"
+  | "loading-more"
+  | "error";
+
+export type InfiniteListingQuery = {
+  q: string;
+  tag: string;
+  sort: SortKey;
+  pageSize: number;
+};
+
+export type InfiniteListingState = {
+  key: string;
+  requestID: number;
+  pageSize: number;
+  items: VideoItem[];
+  total: number;
+  /** 已经向后端请求过的条目数，等于下一批的偏移量。 */
+  requestedCount: number;
+  /** 后端已经没有更多数据，停止再触发加载。 */
+  exhausted: boolean;
+  status: InfiniteListingStatus;
+  error: Error | null;
+  /** 最近一次真实响应的时间，缓存新鲜度以它为准。 */
+  receivedAt: number;
+};
+
+export type InfiniteListingAction =
+  | { type: "disable"; requestID: number }
+  | { type: "reset"; requestID: number; key: string; pageSize: number }
+  | {
+      type: "hydrate";
+      requestID: number;
+      key: string;
+      pageSize: number;
+      items: VideoItem[];
+      total: number;
+      requestedCount: number;
+      exhausted: boolean;
+      receivedAt: number;
+    }
+  | { type: "load-start"; requestID: number }
+  | {
+      type: "load-success";
+      requestID: number;
+      /** 本批请求时的偏移量，用于丢弃与当前游标不衔接的响应。 */
+      offset: number;
+      batchSize: number;
+      items: VideoItem[];
+      total: number;
+      receivedAt: number;
+    }
+  | { type: "load-failure"; requestID: number; error: Error };
+
+export function infiniteListingKey(query: InfiniteListingQuery): string {
+  return JSON.stringify([
+    query.q.trim(),
+    query.tag.trim(),
+    query.sort,
+    Number.isInteger(query.pageSize) && query.pageSize > 0 ? query.pageSize : 1,
+  ]);
+}
+
+export function emptyInfiniteListingState(
+  key: string,
+  pageSize: number
+): InfiniteListingState {
+  return {
+    key,
+    requestID: 0,
+    pageSize,
+    items: [],
+    total: 0,
+    requestedCount: 0,
+    exhausted: false,
+    status: "idle",
+    error: null,
+    receivedAt: 0,
+  };
+}
+
+/**
+ * 分页边界会随新入库/删除的视频移动，同一条视频可能出现在相邻两页里。
+ * 追加时按 id 去重，既修掉重复卡片，也让 StrictMode 的重复请求幂等。
+ */
+export function appendUniqueVideos(
+  previous: VideoItem[],
+  incoming: VideoItem[]
+): VideoItem[] {
+  if (incoming.length === 0) return previous;
+  const seen = new Set(previous.map((item) => item.id));
+  const fresh = incoming.filter((item) => {
+    if (!item || seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+  if (fresh.length === 0) return previous;
+  return [...previous, ...fresh];
+}
+
+export function infiniteListingReducer(
+  state: InfiniteListingState,
+  action: InfiniteListingAction
+): InfiniteListingState {
+  switch (action.type) {
+    case "disable":
+      return {
+        ...emptyInfiniteListingState(state.key, state.pageSize),
+        requestID: action.requestID,
+      };
+    case "reset":
+      return {
+        ...emptyInfiniteListingState(action.key, action.pageSize),
+        requestID: action.requestID,
+      };
+    case "hydrate":
+      return {
+        key: action.key,
+        requestID: action.requestID,
+        pageSize: action.pageSize,
+        items: action.items,
+        total: action.total,
+        requestedCount: action.requestedCount,
+        exhausted: action.exhausted,
+        status: "ready",
+        error: null,
+        receivedAt: action.receivedAt,
+      };
+    case "load-start":
+      return {
+        ...state,
+        requestID: action.requestID,
+        status: state.items.length > 0 ? "loading-more" : "initial-loading",
+        error: null,
+      };
+    case "load-success": {
+      if (action.requestID !== state.requestID) return state;
+      // 游标不衔接说明这批响应属于已经作废的加载序列。
+      if (action.offset !== state.requestedCount) return state;
+      const items = appendUniqueVideos(state.items, action.items);
+      const requestedCount = action.offset + action.batchSize;
+      const total = action.total > 0 ? action.total : state.total;
+      return {
+        ...state,
+        items,
+        total,
+        requestedCount,
+        exhausted: isListingExhausted({
+          received: action.items.length,
+          batchSize: action.batchSize,
+          requestedCount,
+          total: action.total,
+        }),
+        status: "ready",
+        error: null,
+        receivedAt: action.receivedAt,
+      };
+    }
+    case "load-failure":
+      if (action.requestID !== state.requestID) return state;
+      return { ...state, status: "error", error: action.error };
+  }
+}
+
+/**
+ * 两个终止条件缺一不可：total 只是查询时刻的计数，删除/隐藏后会虚高，
+ * 只靠它会在尾部反复请求空页；只靠"返回不足一页"则会漏掉整除的边界。
+ */
+export function isListingExhausted(input: {
+  received: number;
+  batchSize: number;
+  requestedCount: number;
+  total: number;
+}): boolean {
+  if (input.received < input.batchSize) return true;
+  return input.total > 0 && input.requestedCount >= input.total;
+}
+
+export type InfiniteListingRequest = { page: number; size: number };
+
+/**
+ * 下一批的分页参数。偏移量必须是页大小的整数倍，否则 page/size 接口无法
+ * 表达这个区间——恢复现场时的大请求也因此被约束成页大小的整数倍。
+ */
+export function nextListingRequest(
+  state: InfiniteListingState
+): InfiniteListingRequest | null {
+  if (state.exhausted) return null;
+  const pageSize = state.pageSize;
+  if (!Number.isInteger(pageSize) || pageSize <= 0) return null;
+  if (state.requestedCount % pageSize !== 0) return null;
+  return { page: state.requestedCount / pageSize + 1, size: pageSize };
+}
+
+export function infiniteListingHasMore(state: InfiniteListingState): boolean {
+  return !state.exhausted && state.status !== "error";
+}

--- a/src/lib/infiniteListing.ts
+++ b/src/lib/infiniteListing.ts
@@ -1,9 +1,5 @@
+import type { VideoFeedCursor } from "@/data/videos";
 import type { SortKey, VideoItem } from "@/types";
-
-/**
- * 无限滚动列表的纯状态层。分页游标按"已请求条目数"推进而不是按"已渲染条目数"，
- * 否则后端去重/隐藏行会让偏移量漂移，越翻越错位。
- */
 
 export type InfiniteListingStatus =
   | "idle"
@@ -16,7 +12,6 @@ export type InfiniteListingQuery = {
   q: string;
   tag: string;
   sort: SortKey;
-  pageSize: number;
 };
 
 export type InfiniteListingState = {
@@ -25,19 +20,24 @@ export type InfiniteListingState = {
   pageSize: number;
   items: VideoItem[];
   total: number;
-  /** 已经向后端请求过的条目数，等于下一批的偏移量。 */
+  feedToken: string;
+  /** 下一批在服务端快照中的位置；可能大于 items.length（快照项后来被删除）。 */
   requestedCount: number;
-  /** 后端已经没有更多数据，停止再触发加载。 */
   exhausted: boolean;
   status: InfiniteListingStatus;
   error: Error | null;
-  /** 最近一次真实响应的时间，缓存新鲜度以它为准。 */
   receivedAt: number;
 };
 
 export type InfiniteListingAction =
-  | { type: "disable"; requestID: number }
-  | { type: "reset"; requestID: number; key: string; pageSize: number }
+  | { type: "disable"; requestID: number; key: string; pageSize: number }
+  | {
+      type: "reset";
+      requestID: number;
+      key: string;
+      pageSize: number;
+      cursor?: VideoFeedCursor;
+    }
   | {
       type: "hydrate";
       requestID: number;
@@ -45,6 +45,7 @@ export type InfiniteListingAction =
       pageSize: number;
       items: VideoItem[];
       total: number;
+      feedToken: string;
       requestedCount: number;
       exhausted: boolean;
       receivedAt: number;
@@ -53,24 +54,36 @@ export type InfiniteListingAction =
   | {
       type: "load-success";
       requestID: number;
-      /** 本批请求时的偏移量，用于丢弃与当前游标不衔接的响应。 */
-      offset: number;
-      batchSize: number;
+      requestCursor: VideoFeedCursor;
+      cursor: VideoFeedCursor;
       items: VideoItem[];
       total: number;
+      exhausted: boolean;
       receivedAt: number;
-      /** 服务端轮换 feed 没有终点，整批都是重复内容时就收尾。 */
-      stopOnDuplicateBatch?: boolean;
     }
   | { type: "load-failure"; requestID: number; error: Error };
 
+/** Batch size is a transport concern, not part of a logical result-set key. */
 export function infiniteListingKey(query: InfiniteListingQuery): string {
-  return JSON.stringify([
-    query.q.trim(),
-    query.tag.trim(),
-    query.sort,
-    Number.isInteger(query.pageSize) && query.pageSize > 0 ? query.pageSize : 1,
-  ]);
+  return JSON.stringify([query.q.trim(), query.tag.trim(), query.sort]);
+}
+
+export function infiniteListingCacheMatchesRestore(input: {
+  cachedFeedToken: string;
+  cachedRequestedCount: number;
+  restoreFeedToken: string;
+  restoreCount: number;
+}): boolean {
+  if (
+    input.restoreFeedToken &&
+    input.cachedFeedToken !== input.restoreFeedToken
+  ) {
+    return false;
+  }
+  if (!Number.isInteger(input.restoreCount) || input.restoreCount <= 0) {
+    return true;
+  }
+  return input.cachedRequestedCount >= input.restoreCount;
 }
 
 export function emptyInfiniteListingState(
@@ -83,6 +96,7 @@ export function emptyInfiniteListingState(
     pageSize,
     items: [],
     total: 0,
+    feedToken: "",
     requestedCount: 0,
     exhausted: false,
     status: "idle",
@@ -91,10 +105,7 @@ export function emptyInfiniteListingState(
   };
 }
 
-/**
- * 分页边界会随新入库/删除的视频移动，同一条视频可能出现在相邻两页里。
- * 追加时按 id 去重，既修掉重复卡片，也让 StrictMode 的重复请求幂等。
- */
+/** Defensive identity merge; a correctly formed snapshot already has unique IDs. */
 export function appendUniqueVideos(
   previous: VideoItem[],
   incoming: VideoItem[]
@@ -106,8 +117,7 @@ export function appendUniqueVideos(
     seen.add(item.id);
     return true;
   });
-  if (fresh.length === 0) return previous;
-  return [...previous, ...fresh];
+  return fresh.length === 0 ? previous : [...previous, ...fresh];
 }
 
 export function infiniteListingReducer(
@@ -117,13 +127,15 @@ export function infiniteListingReducer(
   switch (action.type) {
     case "disable":
       return {
-        ...emptyInfiniteListingState(state.key, state.pageSize),
+        ...emptyInfiniteListingState(action.key, action.pageSize),
         requestID: action.requestID,
       };
     case "reset":
       return {
         ...emptyInfiniteListingState(action.key, action.pageSize),
         requestID: action.requestID,
+        feedToken: action.cursor?.feedToken ?? "",
+        requestedCount: action.cursor?.position ?? 0,
       };
     case "hydrate":
       return {
@@ -132,6 +144,7 @@ export function infiniteListingReducer(
         pageSize: action.pageSize,
         items: action.items,
         total: action.total,
+        feedToken: action.feedToken,
         requestedCount: action.requestedCount,
         exhausted: action.exhausted,
         status: "ready",
@@ -147,24 +160,20 @@ export function infiniteListingReducer(
       };
     case "load-success": {
       if (action.requestID !== state.requestID) return state;
-      // 游标不衔接说明这批响应属于已经作废的加载序列。
-      if (action.offset !== state.requestedCount) return state;
+      if (
+        action.requestCursor.feedToken !== state.feedToken ||
+        action.requestCursor.position !== state.requestedCount
+      ) {
+        return state;
+      }
       const items = appendUniqueVideos(state.items, action.items);
-      const requestedCount = action.offset + action.batchSize;
-      const total = action.total > 0 ? action.total : state.total;
       return {
         ...state,
         items,
-        total,
-        requestedCount,
-        exhausted: isListingExhausted({
-          received: action.items.length,
-          added: items.length - state.items.length,
-          batchSize: action.batchSize,
-          requestedCount,
-          total: action.total,
-          stopOnDuplicateBatch: action.stopOnDuplicateBatch,
-        }),
+        total: action.total,
+        feedToken: action.cursor.feedToken,
+        requestedCount: action.cursor.position,
+        exhausted: action.exhausted,
         status: "ready",
         error: null,
         receivedAt: action.receivedAt,
@@ -176,35 +185,23 @@ export function infiniteListingReducer(
   }
 }
 
-/**
- * 两个终止条件缺一不可：total 只是查询时刻的计数，删除/隐藏后会虚高，
- * 只靠它会在尾部反复请求空页；只靠"返回不足一页"则会漏掉整除的边界。
- */
-export function isListingExhausted(input: {
-  received: number;
-  /** 去重后真正新增的条数。 */
-  added: number;
-  batchSize: number;
-  requestedCount: number;
-  total: number;
-  /** 轮换 feed 没有 total，也永远返回满批，只能靠"整批都重复"收尾。 */
-  stopOnDuplicateBatch?: boolean;
-}): boolean {
-  if (input.received < input.batchSize) return true;
-  if (input.stopOnDuplicateBatch && input.added === 0) return true;
-  return input.total > 0 && input.requestedCount >= input.total;
-}
+export type InfiniteListingRequest = {
+  cursor: VideoFeedCursor;
+  size: number;
+};
 
-export type InfiniteListingRequest = { offset: number; size: number };
-
-/** 下一批要取的区间；具体怎么翻页由各个 feed source 自己决定。 */
 export function nextListingRequest(
   state: InfiniteListingState
 ): InfiniteListingRequest | null {
   if (state.exhausted) return null;
-  const size = state.pageSize;
-  if (!Number.isInteger(size) || size <= 0) return null;
-  return { offset: state.requestedCount, size };
+  if (!Number.isInteger(state.pageSize) || state.pageSize <= 0) return null;
+  return {
+    cursor: {
+      feedToken: state.feedToken,
+      position: state.requestedCount,
+    },
+    size: state.pageSize,
+  };
 }
 
 export function infiniteListingHasMore(state: InfiniteListingState): boolean {

--- a/src/lib/listingScrollRestore.ts
+++ b/src/lib/listingScrollRestore.ts
@@ -10,6 +10,8 @@ export const MAX_RESTORE_ITEMS = 240;
 
 export type ListingScrollEntry = {
   queryKey: string;
+  /** 服务端不可变快照；为空时恢复到同一查询的新快照。 */
+  feedToken: string;
   /** 保存现场时已经请求过的条目数。 */
   requestedCount: number;
   scrollY: number;
@@ -34,6 +36,8 @@ export function parseListingScrollEntry(
     if (
       !parsed ||
       typeof parsed.queryKey !== "string" ||
+      (parsed.feedToken !== undefined && typeof parsed.feedToken !== "string") ||
+      (typeof parsed.feedToken === "string" && parsed.feedToken.length > 128) ||
       !Number.isInteger(parsed.requestedCount) ||
       parsed.requestedCount <= 0 ||
       !Number.isFinite(parsed.scrollY) ||
@@ -43,6 +47,7 @@ export function parseListingScrollEntry(
     }
     return {
       queryKey: parsed.queryKey,
+      feedToken: parsed.feedToken ?? "",
       requestedCount: parsed.requestedCount,
       scrollY: parsed.scrollY,
     };
@@ -57,7 +62,9 @@ export function readListingScrollEntry(
 ): ListingScrollEntry | null {
   if (!storage || !historyKey) return null;
   try {
-    return parseListingScrollEntry(storage.getItem(listingScrollStorageKey(historyKey)));
+    return parseListingScrollEntry(
+      storage.getItem(listingScrollStorageKey(historyKey))
+    );
   } catch {
     // 隐私模式下读写 sessionStorage 会抛错，恢复失败只是回到列表顶部。
     return null;
@@ -93,8 +100,8 @@ export function clearListingScrollEntry(
 }
 
 /**
- * 恢复现场时首个请求要取多少条：把保存的进度向上取整到页大小的整数倍，
- * 这样后续分页游标仍然落在页边界上；超过上限就只补到上限。
+ * 恢复现场时首个请求要取多少条。显式 cursor 可以从任意位置继续，不再需要
+ * 为 page/size 接口凑整页；超过上限就只补到上限。
  * 返回 0 表示按普通首屏加载。
  */
 export function resolveRestoreCount(input: {
@@ -111,8 +118,7 @@ export function resolveRestoreCount(input: {
 
   const maxItems = input.maxItems ?? MAX_RESTORE_ITEMS;
   const capped = Math.min(entry.requestedCount, Math.max(maxItems, pageSize));
-  const rounded = Math.ceil(capped / pageSize) * pageSize;
-  return rounded > pageSize ? rounded : 0;
+  return capped > pageSize ? capped : 0;
 }
 
 export function resolveRestoreScrollY(
@@ -121,6 +127,14 @@ export function resolveRestoreScrollY(
 ): number {
   if (!entry || entry.queryKey !== queryKey) return 0;
   return entry.scrollY;
+}
+
+export function resolveRestoreFeedToken(
+  entry: ListingScrollEntry | null,
+  queryKey: string
+): string {
+  if (!entry || entry.queryKey !== queryKey) return "";
+  return entry.feedToken;
 }
 
 /**

--- a/src/lib/listingScrollRestore.ts
+++ b/src/lib/listingScrollRestore.ts
@@ -1,0 +1,151 @@
+/**
+ * 前进/后退时恢复无限滚动列表的现场。历史条目自己的 key 作为存储键，
+ * 所以"后退回列表"能拿回当时的滚动位置，而"重新点进列表"是干净的新会话。
+ */
+
+export const LISTING_SCROLL_STORAGE_PREFIX = "listing_scroll_v1:";
+
+/** 恢复现场时一次最多补回多少条，避免深滚后的返回打出一个超大请求。 */
+export const MAX_RESTORE_ITEMS = 240;
+
+export type ListingScrollEntry = {
+  queryKey: string;
+  /** 保存现场时已经请求过的条目数。 */
+  requestedCount: number;
+  scrollY: number;
+};
+
+export type ListingScrollStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+export function listingScrollStorageKey(historyKey: string): string {
+  return `${LISTING_SCROLL_STORAGE_PREFIX}${historyKey}`;
+}
+
+export function parseListingScrollEntry(
+  raw: string | null
+): ListingScrollEntry | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed.queryKey !== "string" ||
+      !Number.isInteger(parsed.requestedCount) ||
+      parsed.requestedCount <= 0 ||
+      !Number.isFinite(parsed.scrollY) ||
+      parsed.scrollY < 0
+    ) {
+      return null;
+    }
+    return {
+      queryKey: parsed.queryKey,
+      requestedCount: parsed.requestedCount,
+      scrollY: parsed.scrollY,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function readListingScrollEntry(
+  storage: ListingScrollStorage | null,
+  historyKey: string
+): ListingScrollEntry | null {
+  if (!storage || !historyKey) return null;
+  try {
+    return parseListingScrollEntry(storage.getItem(listingScrollStorageKey(historyKey)));
+  } catch {
+    // 隐私模式下读写 sessionStorage 会抛错，恢复失败只是回到列表顶部。
+    return null;
+  }
+}
+
+export function writeListingScrollEntry(
+  storage: ListingScrollStorage | null,
+  historyKey: string,
+  entry: ListingScrollEntry
+): void {
+  if (!storage || !historyKey) return;
+  try {
+    storage.setItem(
+      listingScrollStorageKey(historyKey),
+      JSON.stringify(entry)
+    );
+  } catch {
+    // 同上：写不进去只影响返回时的位置恢复。
+  }
+}
+
+export function clearListingScrollEntry(
+  storage: ListingScrollStorage | null,
+  historyKey: string
+): void {
+  if (!storage || !historyKey) return;
+  try {
+    storage.removeItem(listingScrollStorageKey(historyKey));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * 恢复现场时首个请求要取多少条：把保存的进度向上取整到页大小的整数倍，
+ * 这样后续分页游标仍然落在页边界上；超过上限就只补到上限。
+ * 返回 0 表示按普通首屏加载。
+ */
+export function resolveRestoreCount(input: {
+  entry: ListingScrollEntry | null;
+  queryKey: string;
+  pageSize: number;
+  maxItems?: number;
+}): number {
+  const { entry, queryKey } = input;
+  const pageSize =
+    Number.isInteger(input.pageSize) && input.pageSize > 0 ? input.pageSize : 0;
+  if (!entry || pageSize === 0) return 0;
+  if (entry.queryKey !== queryKey) return 0;
+
+  const maxItems = input.maxItems ?? MAX_RESTORE_ITEMS;
+  const capped = Math.min(entry.requestedCount, Math.max(maxItems, pageSize));
+  const rounded = Math.ceil(capped / pageSize) * pageSize;
+  return rounded > pageSize ? rounded : 0;
+}
+
+export function resolveRestoreScrollY(
+  entry: ListingScrollEntry | null,
+  queryKey: string
+): number {
+  if (!entry || entry.queryKey !== queryKey) return 0;
+  return entry.scrollY;
+}
+
+/**
+ * 内容还没长到目标位置时滚过去只会停在底部，之后再补的内容也不会把
+ * 视口推回原位。所以恢复动作要等文档高度够了才执行。
+ */
+export function canRestoreScrollY(input: {
+  targetScrollY: number;
+  documentHeight: number;
+  viewportHeight: number;
+}): boolean {
+  if (input.targetScrollY <= 0) return true;
+  return input.documentHeight - input.viewportHeight >= input.targetScrollY;
+}
+
+/**
+ * 保存的位置比恢复上限还深时（滚过 MAX_RESTORE_ITEMS 条之后返回），退而
+ * 求其次滚到能到达的最远处：停在已恢复内容的末尾，比停在顶部更接近原位，
+ * 继续往下滚也能无缝接上后续批次。
+ */
+export function resolveReachableScrollY(input: {
+  targetScrollY: number;
+  documentHeight: number;
+  viewportHeight: number;
+}): number {
+  const maxScrollY = Math.max(0, input.documentHeight - input.viewportHeight);
+  return Math.max(0, Math.min(input.targetScrollY, maxScrollY));
+}

--- a/src/lib/listingSearchParams.ts
+++ b/src/lib/listingSearchParams.ts
@@ -72,6 +72,26 @@ export function withListingView(
   return next;
 }
 
+export type HomeFeedKey = "recommend" | "latest";
+
+/** 首页推荐/最新两个 tab 记在 URL 里，前进后退才能回到原来那个 tab。 */
+export function readHomeFeed(params: URLSearchParams): HomeFeedKey {
+  return params.get("feed") === "latest" ? "latest" : "recommend";
+}
+
+export function withHomeFeed(
+  params: URLSearchParams,
+  feed: HomeFeedKey
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  if (feed === "latest") {
+    next.set("feed", "latest");
+  } else {
+    next.delete("feed");
+  }
+  return next;
+}
+
 export function withListingNavigation(
   params: URLSearchParams,
   patch: ListingNavigationPatch

--- a/src/lib/useInfiniteListing.ts
+++ b/src/lib/useInfiniteListing.ts
@@ -1,19 +1,18 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
-import { fetchListing } from "@/data/videos";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import {
   emptyInfiniteListingState,
   infiniteListingHasMore,
-  infiniteListingKey,
   infiniteListingReducer,
   nextListingRequest,
-  type InfiniteListingQuery,
   type InfiniteListingState,
 } from "@/lib/infiniteListing";
+import type { InfiniteFeedSource } from "@/lib/infiniteFeedSource";
 import type { VideoItem } from "@/types";
 
 /**
- * 无限滚动列表的数据层：只负责"按游标往后追加"和会话内的缓存，
- * 渲染窗口交给 VirtualVideoGrid，滚动现场交给 useListingScrollRestore。
+ * 无限滚动的数据层：按 feed source 描述的方式一批批往后取，负责累积、去重、
+ * 中断过期请求和会话内缓存。渲染窗口交给 VirtualVideoGrid，滚动现场交给
+ * useListingScrollRestore。
  */
 
 const INFINITE_LISTING_CACHE_TTL_MS = 60_000;
@@ -50,128 +49,105 @@ function writeInfiniteListingCache(entry: CachedInfiniteListing) {
   }
 }
 
-export function clearInfiniteListingCache() {
-  infiniteListingCache.clear();
+export function clearInfiniteListingCache(key?: string) {
+  if (key === undefined) {
+    infiniteListingCache.clear();
+    return;
+  }
+  infiniteListingCache.delete(key);
 }
 
 function cacheIsFresh(entry: CachedInfiniteListing, now: number): boolean {
   return now - entry.receivedAt < INFINITE_LISTING_CACHE_TTL_MS;
 }
 
-function normalizeQuery(query: InfiniteListingQuery): InfiniteListingQuery {
-  return {
-    q: query.q.trim(),
-    tag: query.tag.trim(),
-    sort: query.sort,
-    pageSize:
-      Number.isInteger(query.pageSize) && query.pageSize > 0
-        ? query.pageSize
-        : 1,
-  };
-}
-
 /**
- * 恢复现场的首个请求要对齐页边界，否则后续 page/size 分页无法接着这个偏移量走。
+ * 恢复现场的首个请求要对齐批边界，否则后续游标接不上（page/size 接口尤其
+ * 如此）。不支持恢复的 feed 一律按普通首屏来。
  */
-function initialBatchSize(restoreCount: number, pageSize: number): number {
-  if (!Number.isInteger(restoreCount) || restoreCount <= pageSize) {
-    return pageSize;
+function initialBatchSize(restoreCount: number, batchSize: number): number {
+  if (!Number.isInteger(restoreCount) || restoreCount <= batchSize) {
+    return batchSize;
   }
-  return Math.ceil(restoreCount / pageSize) * pageSize;
+  return Math.ceil(restoreCount / batchSize) * batchSize;
 }
 
 function errorValue(error: unknown): Error {
   return error instanceof Error ? error : new Error("视频列表加载失败");
 }
 
-function hydratedState(
-  key: string,
-  pageSize: number,
-  cached: CachedInfiniteListing
-): InfiniteListingState {
-  return {
-    key,
-    requestID: 0,
-    pageSize,
-    items: cached.items,
-    total: cached.total,
-    requestedCount: cached.requestedCount,
-    exhausted: cached.exhausted,
-    status: "ready",
-    error: null,
-    receivedAt: cached.receivedAt,
-  };
-}
-
 function initialState(
-  key: string,
-  query: InfiniteListingQuery,
+  source: InfiniteFeedSource,
   enabled: boolean
 ): InfiniteListingState {
-  const base = emptyInfiniteListingState(key, query.pageSize);
+  const base = emptyInfiniteListingState(source.key, source.batchSize);
   if (!enabled) return base;
-  const cached = infiniteListingCache.get(key) ?? null;
+  const cached = infiniteListingCache.get(source.key) ?? null;
   if (cached && cacheIsFresh(cached, Date.now())) {
-    return hydratedState(key, query.pageSize, cached);
+    return {
+      ...base,
+      items: cached.items,
+      total: cached.total,
+      requestedCount: cached.requestedCount,
+      exhausted: cached.exhausted,
+      status: "ready",
+      receivedAt: cached.receivedAt,
+    };
   }
   return { ...base, status: "initial-loading" };
 }
 
-export type UseInfiniteListingInput = InfiniteListingQuery & {
+export type UseInfiniteListingOptions = {
   enabled?: boolean;
   /** 后退回列表时要一次补回的条目数，0 表示普通首屏。 */
   restoreCount?: number;
 };
 
-export function useInfiniteListing(input: UseInfiniteListingInput) {
-  const enabled = input.enabled ?? true;
-  const query = useMemo(
-    () => normalizeQuery(input),
-    [input.q, input.tag, input.sort, input.pageSize]
-  );
-  const key = infiniteListingKey(query);
+export function useInfiniteListing(
+  source: InfiniteFeedSource,
+  options: UseInfiniteListingOptions = {}
+) {
+  const enabled = options.enabled ?? true;
+  const key = source.key;
+  const batchSize = source.batchSize;
   const [state, dispatch] = useReducer(infiniteListingReducer, undefined, () =>
-    initialState(key, query, enabled)
+    initialState(source, enabled)
   );
-  const [retryVersion, setRetryVersion] = useState(0);
+  const [reloadVersion, setReloadVersion] = useState(0);
 
   const nextRequestIDRef = useRef(0);
   const controllerRef = useRef<AbortController | null>(null);
   const stateRef = useRef(state);
-  const queryRef = useRef(query);
+  const sourceRef = useRef(source);
   const enabledRef = useRef(enabled);
-  const restoreCountRef = useRef(input.restoreCount ?? 0);
+  const restoreCountRef = useRef(options.restoreCount ?? 0);
   stateRef.current = state;
-  queryRef.current = query;
+  sourceRef.current = source;
   enabledRef.current = enabled;
-  restoreCountRef.current = input.restoreCount ?? 0;
+  restoreCountRef.current = options.restoreCount ?? 0;
 
   const sendRequest = useCallback(
     (
       requestID: number,
-      requestQuery: InfiniteListingQuery,
-      request: { page: number; size: number },
-      offset: number
+      feed: InfiniteFeedSource,
+      request: { offset: number; size: number }
     ) => {
       const controller = new AbortController();
       controllerRef.current = controller;
       dispatch({ type: "load-start", requestID });
-      fetchListing(
-        request.page,
-        request.size,
-        { q: requestQuery.q, tag: requestQuery.tag, sort: requestQuery.sort },
-        { signal: controller.signal }
-      )
+      feed
+        .fetchBatch(request, { signal: controller.signal })
         .then((result) => {
           if (controller.signal.aborted) return;
           dispatch({
             type: "load-success",
             requestID,
-            offset,
+            offset: request.offset,
             batchSize: request.size,
             items: result.items ?? [],
             total: result.total ?? 0,
             receivedAt: Date.now(),
+            stopOnDuplicateBatch: feed.stopOnDuplicateBatch,
           });
         })
         .catch((error) => {
@@ -198,7 +174,7 @@ export function useInfiniteListing(input: UseInfiniteListingInput) {
         type: "hydrate",
         requestID,
         key,
-        pageSize: query.pageSize,
+        pageSize: batchSize,
         items: cached.items,
         total: cached.total,
         requestedCount: cached.requestedCount,
@@ -208,19 +184,20 @@ export function useInfiniteListing(input: UseInfiniteListingInput) {
       return;
     }
 
-    dispatch({ type: "reset", requestID, key, pageSize: query.pageSize });
-    sendRequest(
-      requestID,
-      query,
-      { page: 1, size: initialBatchSize(restoreCountRef.current, query.pageSize) },
-      0
-    );
+    dispatch({ type: "reset", requestID, key, pageSize: batchSize });
+    const restoreCount = sourceRef.current.supportsRestore
+      ? restoreCountRef.current
+      : 0;
+    sendRequest(requestID, sourceRef.current, {
+      offset: 0,
+      size: initialBatchSize(restoreCount, batchSize),
+    });
 
     return () => {
       controllerRef.current?.abort();
       controllerRef.current = null;
     };
-  }, [enabled, key, query, retryVersion, sendRequest]);
+  }, [batchSize, enabled, key, reloadVersion, sendRequest]);
 
   // 会话内缓存以真实响应时间为准：hydrate 回来的状态不会自我续命。
   useEffect(() => {
@@ -237,40 +214,41 @@ export function useInfiniteListing(input: UseInfiniteListingInput) {
   }, [enabled, key, state]);
 
   const requestBatch = useCallback(
-    (options: { force?: boolean } = {}) => {
+    (batchOptions: { force?: boolean } = {}) => {
       if (!enabledRef.current) return;
       const current = stateRef.current;
       if (current.status === "initial-loading" || current.status === "loading-more") {
         return;
       }
-      if (!options.force && current.status === "error") return;
+      if (!batchOptions.force && current.status === "error") return;
       const request = nextListingRequest(current);
       if (!request) return;
-      sendRequest(
-        ++nextRequestIDRef.current,
-        queryRef.current,
-        request,
-        current.requestedCount
-      );
+      sendRequest(++nextRequestIDRef.current, sourceRef.current, request);
     },
     [sendRequest]
   );
 
   const loadMore = useCallback(() => requestBatch(), [requestBatch]);
 
+  const reload = useCallback(() => {
+    clearInfiniteListingCache(sourceRef.current.key);
+    setReloadVersion((version) => version + 1);
+  }, []);
+
   // 首屏失败要整段重来，尾部失败只重试失败的那一批，已加载内容保持不动。
   const retry = useCallback(() => {
     if (stateRef.current.items.length === 0) {
-      setRetryVersion((version) => version + 1);
+      reload();
       return;
     }
     requestBatch({ force: true });
-  }, [requestBatch]);
+  }, [reload, requestBatch]);
 
   const matchesQuery = state.key === key;
   const items = matchesQuery ? state.items : [];
   const initialLoading =
-    enabled && (!matchesQuery || (state.status === "initial-loading" && items.length === 0));
+    enabled &&
+    (!matchesQuery || (state.status === "initial-loading" && items.length === 0));
 
   return {
     items,
@@ -284,6 +262,7 @@ export function useInfiniteListing(input: UseInfiniteListingInput) {
     hasMore: matchesQuery && infiniteListingHasMore(state),
     requestedCount: matchesQuery ? state.requestedCount : 0,
     loadMore,
+    reload,
     retry,
   };
 }

--- a/src/lib/useInfiniteListing.ts
+++ b/src/lib/useInfiniteListing.ts
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { fetchListing } from "@/data/videos";
+import {
+  emptyInfiniteListingState,
+  infiniteListingHasMore,
+  infiniteListingKey,
+  infiniteListingReducer,
+  nextListingRequest,
+  type InfiniteListingQuery,
+  type InfiniteListingState,
+} from "@/lib/infiniteListing";
+import type { VideoItem } from "@/types";
+
+/**
+ * 无限滚动列表的数据层：只负责"按游标往后追加"和会话内的缓存，
+ * 渲染窗口交给 VirtualVideoGrid，滚动现场交给 useListingScrollRestore。
+ */
+
+const INFINITE_LISTING_CACHE_TTL_MS = 60_000;
+const INFINITE_LISTING_CACHE_MAX_ENTRIES = 8;
+
+type CachedInfiniteListing = {
+  key: string;
+  items: VideoItem[];
+  total: number;
+  requestedCount: number;
+  exhausted: boolean;
+  receivedAt: number;
+};
+
+const infiniteListingCache = new Map<string, CachedInfiniteListing>();
+
+function readInfiniteListingCache(key: string): CachedInfiniteListing | null {
+  const cached = infiniteListingCache.get(key) ?? null;
+  if (!cached) return null;
+  infiniteListingCache.delete(key);
+  infiniteListingCache.set(key, cached);
+  return cached;
+}
+
+function writeInfiniteListingCache(entry: CachedInfiniteListing) {
+  infiniteListingCache.delete(entry.key);
+  infiniteListingCache.set(entry.key, entry);
+  while (infiniteListingCache.size > INFINITE_LISTING_CACHE_MAX_ENTRIES) {
+    const oldestKey = infiniteListingCache.keys().next().value as
+      | string
+      | undefined;
+    if (!oldestKey) break;
+    infiniteListingCache.delete(oldestKey);
+  }
+}
+
+export function clearInfiniteListingCache() {
+  infiniteListingCache.clear();
+}
+
+function cacheIsFresh(entry: CachedInfiniteListing, now: number): boolean {
+  return now - entry.receivedAt < INFINITE_LISTING_CACHE_TTL_MS;
+}
+
+function normalizeQuery(query: InfiniteListingQuery): InfiniteListingQuery {
+  return {
+    q: query.q.trim(),
+    tag: query.tag.trim(),
+    sort: query.sort,
+    pageSize:
+      Number.isInteger(query.pageSize) && query.pageSize > 0
+        ? query.pageSize
+        : 1,
+  };
+}
+
+/**
+ * 恢复现场的首个请求要对齐页边界，否则后续 page/size 分页无法接着这个偏移量走。
+ */
+function initialBatchSize(restoreCount: number, pageSize: number): number {
+  if (!Number.isInteger(restoreCount) || restoreCount <= pageSize) {
+    return pageSize;
+  }
+  return Math.ceil(restoreCount / pageSize) * pageSize;
+}
+
+function errorValue(error: unknown): Error {
+  return error instanceof Error ? error : new Error("视频列表加载失败");
+}
+
+function hydratedState(
+  key: string,
+  pageSize: number,
+  cached: CachedInfiniteListing
+): InfiniteListingState {
+  return {
+    key,
+    requestID: 0,
+    pageSize,
+    items: cached.items,
+    total: cached.total,
+    requestedCount: cached.requestedCount,
+    exhausted: cached.exhausted,
+    status: "ready",
+    error: null,
+    receivedAt: cached.receivedAt,
+  };
+}
+
+function initialState(
+  key: string,
+  query: InfiniteListingQuery,
+  enabled: boolean
+): InfiniteListingState {
+  const base = emptyInfiniteListingState(key, query.pageSize);
+  if (!enabled) return base;
+  const cached = infiniteListingCache.get(key) ?? null;
+  if (cached && cacheIsFresh(cached, Date.now())) {
+    return hydratedState(key, query.pageSize, cached);
+  }
+  return { ...base, status: "initial-loading" };
+}
+
+export type UseInfiniteListingInput = InfiniteListingQuery & {
+  enabled?: boolean;
+  /** 后退回列表时要一次补回的条目数，0 表示普通首屏。 */
+  restoreCount?: number;
+};
+
+export function useInfiniteListing(input: UseInfiniteListingInput) {
+  const enabled = input.enabled ?? true;
+  const query = useMemo(
+    () => normalizeQuery(input),
+    [input.q, input.tag, input.sort, input.pageSize]
+  );
+  const key = infiniteListingKey(query);
+  const [state, dispatch] = useReducer(infiniteListingReducer, undefined, () =>
+    initialState(key, query, enabled)
+  );
+  const [retryVersion, setRetryVersion] = useState(0);
+
+  const nextRequestIDRef = useRef(0);
+  const controllerRef = useRef<AbortController | null>(null);
+  const stateRef = useRef(state);
+  const queryRef = useRef(query);
+  const enabledRef = useRef(enabled);
+  const restoreCountRef = useRef(input.restoreCount ?? 0);
+  stateRef.current = state;
+  queryRef.current = query;
+  enabledRef.current = enabled;
+  restoreCountRef.current = input.restoreCount ?? 0;
+
+  const sendRequest = useCallback(
+    (
+      requestID: number,
+      requestQuery: InfiniteListingQuery,
+      request: { page: number; size: number },
+      offset: number
+    ) => {
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      dispatch({ type: "load-start", requestID });
+      fetchListing(
+        request.page,
+        request.size,
+        { q: requestQuery.q, tag: requestQuery.tag, sort: requestQuery.sort },
+        { signal: controller.signal }
+      )
+        .then((result) => {
+          if (controller.signal.aborted) return;
+          dispatch({
+            type: "load-success",
+            requestID,
+            offset,
+            batchSize: request.size,
+            items: result.items ?? [],
+            total: result.total ?? 0,
+            receivedAt: Date.now(),
+          });
+        })
+        .catch((error) => {
+          if (controller.signal.aborted) return;
+          dispatch({ type: "load-failure", requestID, error: errorValue(error) });
+        });
+    },
+    []
+  );
+
+  useEffect(() => {
+    const requestID = ++nextRequestIDRef.current;
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+
+    if (!enabled) {
+      dispatch({ type: "disable", requestID });
+      return;
+    }
+
+    const cached = readInfiniteListingCache(key);
+    if (cached && cacheIsFresh(cached, Date.now())) {
+      dispatch({
+        type: "hydrate",
+        requestID,
+        key,
+        pageSize: query.pageSize,
+        items: cached.items,
+        total: cached.total,
+        requestedCount: cached.requestedCount,
+        exhausted: cached.exhausted,
+        receivedAt: cached.receivedAt,
+      });
+      return;
+    }
+
+    dispatch({ type: "reset", requestID, key, pageSize: query.pageSize });
+    sendRequest(
+      requestID,
+      query,
+      { page: 1, size: initialBatchSize(restoreCountRef.current, query.pageSize) },
+      0
+    );
+
+    return () => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, [enabled, key, query, retryVersion, sendRequest]);
+
+  // 会话内缓存以真实响应时间为准：hydrate 回来的状态不会自我续命。
+  useEffect(() => {
+    if (!enabled || state.key !== key) return;
+    if (state.status !== "ready" || state.items.length === 0) return;
+    writeInfiniteListingCache({
+      key,
+      items: state.items,
+      total: state.total,
+      requestedCount: state.requestedCount,
+      exhausted: state.exhausted,
+      receivedAt: state.receivedAt,
+    });
+  }, [enabled, key, state]);
+
+  const requestBatch = useCallback(
+    (options: { force?: boolean } = {}) => {
+      if (!enabledRef.current) return;
+      const current = stateRef.current;
+      if (current.status === "initial-loading" || current.status === "loading-more") {
+        return;
+      }
+      if (!options.force && current.status === "error") return;
+      const request = nextListingRequest(current);
+      if (!request) return;
+      sendRequest(
+        ++nextRequestIDRef.current,
+        queryRef.current,
+        request,
+        current.requestedCount
+      );
+    },
+    [sendRequest]
+  );
+
+  const loadMore = useCallback(() => requestBatch(), [requestBatch]);
+
+  // 首屏失败要整段重来，尾部失败只重试失败的那一批，已加载内容保持不动。
+  const retry = useCallback(() => {
+    if (stateRef.current.items.length === 0) {
+      setRetryVersion((version) => version + 1);
+      return;
+    }
+    requestBatch({ force: true });
+  }, [requestBatch]);
+
+  const matchesQuery = state.key === key;
+  const items = matchesQuery ? state.items : [];
+  const initialLoading =
+    enabled && (!matchesQuery || (state.status === "initial-loading" && items.length === 0));
+
+  return {
+    items,
+    total: matchesQuery ? state.total : 0,
+    status: state.status,
+    error: state.error,
+    initialLoading,
+    loadingMore: matchesQuery && state.status === "loading-more",
+    failed: matchesQuery && state.status === "error",
+    exhausted: matchesQuery && state.exhausted,
+    hasMore: matchesQuery && infiniteListingHasMore(state),
+    requestedCount: matchesQuery ? state.requestedCount : 0,
+    loadMore,
+    retry,
+  };
+}

--- a/src/lib/useInfiniteListing.ts
+++ b/src/lib/useInfiniteListing.ts
@@ -1,27 +1,30 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import type { VideoFeedCursor } from "@/data/videos";
 import {
   emptyInfiniteListingState,
+  infiniteListingCacheMatchesRestore,
   infiniteListingHasMore,
   infiniteListingReducer,
   nextListingRequest,
   type InfiniteListingState,
 } from "@/lib/infiniteListing";
-import type { InfiniteFeedSource } from "@/lib/infiniteFeedSource";
+import type {
+  InfiniteFeedRequest,
+  InfiniteFeedSource,
+} from "@/lib/infiniteFeedSource";
 import type { VideoItem } from "@/types";
-
-/**
- * 无限滚动的数据层：按 feed source 描述的方式一批批往后取，负责累积、去重、
- * 中断过期请求和会话内缓存。渲染窗口交给 VirtualVideoGrid，滚动现场交给
- * useListingScrollRestore。
- */
 
 const INFINITE_LISTING_CACHE_TTL_MS = 60_000;
 const INFINITE_LISTING_CACHE_MAX_ENTRIES = 8;
+const MAX_INITIAL_BATCH_SIZE = 240;
+
+const EMPTY_CURSOR: VideoFeedCursor = { feedToken: "", position: 0 };
 
 type CachedInfiniteListing = {
   key: string;
   items: VideoItem[];
   total: number;
+  feedToken: string;
   requestedCount: number;
   exhausted: boolean;
   receivedAt: number;
@@ -29,9 +32,26 @@ type CachedInfiniteListing = {
 
 const infiniteListingCache = new Map<string, CachedInfiniteListing>();
 
-function readInfiniteListingCache(key: string): CachedInfiniteListing | null {
+function readInfiniteListingCache(
+  key: string,
+  restore: { feedToken: string; count: number }
+): CachedInfiniteListing | null {
   const cached = infiniteListingCache.get(key) ?? null;
   if (!cached) return null;
+  if (!cacheIsFresh(cached, Date.now())) {
+    infiniteListingCache.delete(key);
+    return null;
+  }
+  if (
+    !infiniteListingCacheMatchesRestore({
+      cachedFeedToken: cached.feedToken,
+      cachedRequestedCount: cached.requestedCount,
+      restoreFeedToken: restore.feedToken,
+      restoreCount: restore.count,
+    })
+  ) {
+    return null;
+  }
   infiniteListingCache.delete(key);
   infiniteListingCache.set(key, cached);
   return cached;
@@ -61,15 +81,12 @@ function cacheIsFresh(entry: CachedInfiniteListing, now: number): boolean {
   return now - entry.receivedAt < INFINITE_LISTING_CACHE_TTL_MS;
 }
 
-/**
- * 恢复现场的首个请求要对齐批边界，否则后续游标接不上（page/size 接口尤其
- * 如此）。不支持恢复的 feed 一律按普通首屏来。
- */
 function initialBatchSize(restoreCount: number, batchSize: number): number {
-  if (!Number.isInteger(restoreCount) || restoreCount <= batchSize) {
-    return batchSize;
+  const normalizedBatch = Math.max(1, Math.floor(batchSize));
+  if (!Number.isInteger(restoreCount) || restoreCount <= normalizedBatch) {
+    return normalizedBatch;
   }
-  return Math.ceil(restoreCount / batchSize) * batchSize;
+  return Math.min(MAX_INITIAL_BATCH_SIZE, restoreCount);
 }
 
 function errorValue(error: unknown): Error {
@@ -78,16 +95,18 @@ function errorValue(error: unknown): Error {
 
 function initialState(
   source: InfiniteFeedSource,
-  enabled: boolean
+  enabled: boolean,
+  restore: { feedToken: string; count: number }
 ): InfiniteListingState {
   const base = emptyInfiniteListingState(source.key, source.batchSize);
   if (!enabled) return base;
-  const cached = infiniteListingCache.get(source.key) ?? null;
-  if (cached && cacheIsFresh(cached, Date.now())) {
+  const cached = readInfiniteListingCache(source.key, restore);
+  if (cached) {
     return {
       ...base,
       items: cached.items,
       total: cached.total,
+      feedToken: cached.feedToken,
       requestedCount: cached.requestedCount,
       exhausted: cached.exhausted,
       status: "ready",
@@ -99,8 +118,8 @@ function initialState(
 
 export type UseInfiniteListingOptions = {
   enabled?: boolean;
-  /** 后退回列表时要一次补回的条目数，0 表示普通首屏。 */
   restoreCount?: number;
+  restoreFeedToken?: string;
 };
 
 export function useInfiniteListing(
@@ -111,7 +130,10 @@ export function useInfiniteListing(
   const key = source.key;
   const batchSize = source.batchSize;
   const [state, dispatch] = useReducer(infiniteListingReducer, undefined, () =>
-    initialState(source, enabled)
+    initialState(source, enabled, {
+      feedToken: options.restoreFeedToken ?? "",
+      count: options.restoreCount ?? 0,
+    })
   );
   const [reloadVersion, setReloadVersion] = useState(0);
 
@@ -121,20 +143,24 @@ export function useInfiniteListing(
   const sourceRef = useRef(source);
   const enabledRef = useRef(enabled);
   const restoreCountRef = useRef(options.restoreCount ?? 0);
+  const restoreFeedTokenRef = useRef(options.restoreFeedToken ?? "");
+  const forceFreshRef = useRef(false);
   stateRef.current = state;
   sourceRef.current = source;
   enabledRef.current = enabled;
   restoreCountRef.current = options.restoreCount ?? 0;
+  restoreFeedTokenRef.current = options.restoreFeedToken ?? "";
 
   const sendRequest = useCallback(
-    (
+    function executeRequest(
       requestID: number,
       feed: InfiniteFeedSource,
-      request: { offset: number; size: number }
-    ) => {
+      request: InfiniteFeedRequest
+    ) {
       const controller = new AbortController();
       controllerRef.current = controller;
       dispatch({ type: "load-start", requestID });
+
       feed
         .fetchBatch(request, { signal: controller.signal })
         .then((result) => {
@@ -142,17 +168,44 @@ export function useInfiniteListing(
           dispatch({
             type: "load-success",
             requestID,
-            offset: request.offset,
-            batchSize: request.size,
+            requestCursor: request.cursor,
+            cursor: result.cursor,
             items: result.items ?? [],
             total: result.total ?? 0,
+            exhausted: result.exhausted,
             receivedAt: Date.now(),
-            stopOnDuplicateBatch: feed.stopOnDuplicateBatch,
           });
         })
         .catch((error) => {
           if (controller.signal.aborted) return;
+          if (request.cursor.feedToken && feed.isExpiredError(error)) {
+            clearInfiniteListingCache(feed.key);
+            if (controllerRef.current === controller) {
+              controllerRef.current = null;
+            }
+            const restartID = ++nextRequestIDRef.current;
+            const restoreCount = Math.max(
+              request.cursor.position + request.size,
+              stateRef.current.requestedCount
+            );
+            dispatch({
+              type: "reset",
+              requestID: restartID,
+              key: feed.key,
+              pageSize: feed.batchSize,
+            });
+            executeRequest(restartID, feed, {
+              cursor: EMPTY_CURSOR,
+              size: initialBatchSize(restoreCount, feed.batchSize),
+            });
+            return;
+          }
           dispatch({ type: "load-failure", requestID, error: errorValue(error) });
+        })
+        .finally(() => {
+          if (controllerRef.current === controller) {
+            controllerRef.current = null;
+          }
         });
     },
     []
@@ -164,12 +217,21 @@ export function useInfiniteListing(
     controllerRef.current = null;
 
     if (!enabled) {
-      dispatch({ type: "disable", requestID });
+      dispatch({ type: "disable", requestID, key, pageSize: batchSize });
       return;
     }
 
-    const cached = readInfiniteListingCache(key);
-    if (cached && cacheIsFresh(cached, Date.now())) {
+    const forceFresh = forceFreshRef.current;
+    forceFreshRef.current = false;
+    const restoreCount = restoreCountRef.current;
+    const restoreFeedToken = restoreFeedTokenRef.current;
+    const cached = forceFresh
+      ? null
+      : readInfiniteListingCache(key, {
+          feedToken: restoreFeedToken,
+          count: restoreCount,
+        });
+    if (cached) {
       dispatch({
         type: "hydrate",
         requestID,
@@ -177,6 +239,7 @@ export function useInfiniteListing(
         pageSize: batchSize,
         items: cached.items,
         total: cached.total,
+        feedToken: cached.feedToken,
         requestedCount: cached.requestedCount,
         exhausted: cached.exhausted,
         receivedAt: cached.receivedAt,
@@ -184,12 +247,18 @@ export function useInfiniteListing(
       return;
     }
 
-    dispatch({ type: "reset", requestID, key, pageSize: batchSize });
-    const restoreCount = sourceRef.current.supportsRestore
-      ? restoreCountRef.current
-      : 0;
+    const restoreCursor: VideoFeedCursor = forceFresh
+      ? EMPTY_CURSOR
+      : { feedToken: restoreFeedToken, position: 0 };
+    dispatch({
+      type: "reset",
+      requestID,
+      key,
+      pageSize: batchSize,
+      cursor: restoreCursor,
+    });
     sendRequest(requestID, sourceRef.current, {
-      offset: 0,
+      cursor: restoreCursor,
       size: initialBatchSize(restoreCount, batchSize),
     });
 
@@ -199,7 +268,6 @@ export function useInfiniteListing(
     };
   }, [batchSize, enabled, key, reloadVersion, sendRequest]);
 
-  // 会话内缓存以真实响应时间为准：hydrate 回来的状态不会自我续命。
   useEffect(() => {
     if (!enabled || state.key !== key) return;
     if (state.status !== "ready" || state.items.length === 0) return;
@@ -207,6 +275,7 @@ export function useInfiniteListing(
       key,
       items: state.items,
       total: state.total,
+      feedToken: state.feedToken,
       requestedCount: state.requestedCount,
       exhausted: state.exhausted,
       receivedAt: state.receivedAt,
@@ -216,6 +285,7 @@ export function useInfiniteListing(
   const requestBatch = useCallback(
     (batchOptions: { force?: boolean } = {}) => {
       if (!enabledRef.current) return;
+      if (controllerRef.current && !controllerRef.current.signal.aborted) return;
       const current = stateRef.current;
       if (current.status === "initial-loading" || current.status === "loading-more") {
         return;
@@ -231,11 +301,13 @@ export function useInfiniteListing(
   const loadMore = useCallback(() => requestBatch(), [requestBatch]);
 
   const reload = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    forceFreshRef.current = true;
     clearInfiniteListingCache(sourceRef.current.key);
     setReloadVersion((version) => version + 1);
   }, []);
 
-  // 首屏失败要整段重来，尾部失败只重试失败的那一批，已加载内容保持不动。
   const retry = useCallback(() => {
     if (stateRef.current.items.length === 0) {
       reload();
@@ -253,6 +325,7 @@ export function useInfiniteListing(
   return {
     items,
     total: matchesQuery ? state.total : 0,
+    feedToken: matchesQuery ? state.feedToken : "",
     status: state.status,
     error: state.error,
     initialLoading,

--- a/src/lib/useListingScrollRestore.ts
+++ b/src/lib/useListingScrollRestore.ts
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   canRestoreScrollY,
   readListingScrollEntry,
   resolveReachableScrollY,
   resolveRestoreCount,
+  resolveRestoreFeedToken,
   resolveRestoreScrollY,
   writeListingScrollEntry,
   type ListingScrollStorage,
@@ -30,7 +31,9 @@ function sessionStorageOrNull(): ListingScrollStorage | null {
 
 export type ListingRestoreTarget = {
   historyKey: string;
+  queryKey: string;
   count: number;
+  feedToken: string;
   scrollY: number;
 };
 
@@ -44,18 +47,24 @@ export function useListingRestoreTarget(input: {
   pageSize: number;
 }): ListingRestoreTarget {
   const targetRef = useRef<ListingRestoreTarget | null>(null);
-  if (!targetRef.current || targetRef.current.historyKey !== input.historyKey) {
+  if (
+    !targetRef.current ||
+    targetRef.current.historyKey !== input.historyKey ||
+    targetRef.current.queryKey !== input.queryKey
+  ) {
     const entry = readListingScrollEntry(
       sessionStorageOrNull(),
       input.historyKey
     );
     targetRef.current = {
       historyKey: input.historyKey,
+      queryKey: input.queryKey,
       count: resolveRestoreCount({
         entry,
         queryKey: input.queryKey,
         pageSize: input.pageSize,
       }),
+      feedToken: resolveRestoreFeedToken(entry, input.queryKey),
       scrollY: resolveRestoreScrollY(entry, input.queryKey),
     };
   }
@@ -67,29 +76,50 @@ export type UseListingScrollRestoreInput = {
   queryKey: string;
   /** 当前已经请求过的条目数，作为下次恢复的进度。 */
   requestedCount: number;
+  feedToken: string;
   itemCount: number;
+};
+
+type ListingScrollSession = {
+  identity: string;
+  historyKey: string;
+  queryKey: string;
+  feedToken: string;
+  requestedCount: number;
+  pendingScrollY: number;
+  lastScrollY: number;
 };
 
 export function useListingScrollRestore({
   target,
   queryKey,
   requestedCount,
+  feedToken,
   itemCount,
 }: UseListingScrollRestoreInput) {
   const historyKey = target.historyKey;
-  const pendingScrollYRef = useRef(target.scrollY);
-  const lastScrollYRef = useRef(target.scrollY);
-  const restoredHistoryKeyRef = useRef(historyKey);
+  const restoreIdentity = `${historyKey}\u0000${queryKey}`;
+  const sessionRef = useRef<ListingScrollSession | null>(null);
+  if (!sessionRef.current || sessionRef.current.identity !== restoreIdentity) {
+    sessionRef.current = {
+      identity: restoreIdentity,
+      historyKey,
+      queryKey,
+      feedToken,
+      requestedCount,
+      pendingScrollY: target.scrollY,
+      lastScrollY: target.scrollY,
+    };
+  } else {
+    // 请求进度可以变化很多次；滚动监听器始终读取同一个会话对象的最新值。
+    sessionRef.current.feedToken = feedToken;
+    sessionRef.current.requestedCount = requestedCount;
+  }
+  const session = sessionRef.current;
   const [restoring, setRestoring] = useState(target.scrollY > 0);
 
-  if (restoredHistoryKeyRef.current !== historyKey) {
-    restoredHistoryKeyRef.current = historyKey;
-    pendingScrollYRef.current = target.scrollY;
-    lastScrollYRef.current = target.scrollY;
-  }
-
   useEffect(() => {
-    const targetScrollY = pendingScrollYRef.current;
+    const targetScrollY = session.pendingScrollY;
     if (targetScrollY <= 0) {
       setRestoring(false);
       return;
@@ -100,8 +130,8 @@ export function useListingScrollRestore({
     let frame = 0;
     let handle = 0;
     const finish = (restoredScrollY: number) => {
-      pendingScrollYRef.current = 0;
-      lastScrollYRef.current = restoredScrollY;
+      session.pendingScrollY = 0;
+      session.lastScrollY = restoredScrollY;
       setRestoring(false);
     };
     const attempt = () => {
@@ -133,49 +163,45 @@ export function useListingScrollRestore({
     handle = window.requestAnimationFrame(attempt);
 
     return () => window.cancelAnimationFrame(handle);
-  }, [historyKey, itemCount]);
-
-  const save = useCallback(
-    (scrollY: number) => {
-      // 还没恢复完就落盘，会把保存的位置覆盖成恢复前的 0。
-      if (pendingScrollYRef.current > 0) return;
-      if (requestedCount <= 0) return;
-      writeListingScrollEntry(sessionStorageOrNull(), historyKey, {
-        queryKey,
-        requestedCount,
-        scrollY: Math.max(0, Math.round(scrollY)),
-      });
-    },
-    [historyKey, queryKey, requestedCount]
-  );
+  }, [itemCount, restoreIdentity, session]);
 
   useEffect(() => {
-    let ticking = false;
-    let live = true;
+    let lastPersistedSignature = "";
+
+    const persist = () => {
+      // 还没恢复完就落盘，会把保存的位置覆盖成恢复前的 0。
+      if (session.pendingScrollY > 0 || session.requestedCount <= 0) return;
+      const scrollY = Math.max(0, Math.round(session.lastScrollY));
+      const signature = `${session.feedToken}\u0000${session.requestedCount}\u0000${scrollY}`;
+      if (signature === lastPersistedSignature) return;
+      writeListingScrollEntry(sessionStorageOrNull(), session.historyKey, {
+        queryKey: session.queryKey,
+        feedToken: session.feedToken,
+        requestedCount: session.requestedCount,
+        scrollY,
+      });
+      lastPersistedSignature = signature;
+    };
+
     const handleScroll = () => {
       // 位置要在滚动事件里同步记下：卸载时列表 DOM 已经被详情页顶掉，
       // 那时再读 window.scrollY 拿到的是被浏览器压缩过的值。
-      lastScrollYRef.current = Math.max(0, Math.round(window.scrollY));
-      if (ticking) return;
-      ticking = true;
-      window.requestAnimationFrame(() => {
-        ticking = false;
-        if (!live) return;
-        save(lastScrollYRef.current);
-      });
+      session.lastScrollY = Math.max(0, Math.round(window.scrollY));
     };
-    const handlePageHide = () => save(window.scrollY);
+    const handlePageHide = () => {
+      session.lastScrollY = Math.max(0, Math.round(window.scrollY));
+      persist();
+    };
 
     window.addEventListener("scroll", handleScroll, { passive: true });
     window.addEventListener("pagehide", handlePageHide);
     return () => {
-      live = false;
       window.removeEventListener("scroll", handleScroll);
       window.removeEventListener("pagehide", handlePageHide);
       // 离开列表页（例如进详情页）时把最后的位置落盘，后退才能回到原处。
-      save(lastScrollYRef.current);
+      persist();
     };
-  }, [save]);
+  }, [restoreIdentity, session]);
 
   return { restoring };
 }

--- a/src/lib/useListingScrollRestore.ts
+++ b/src/lib/useListingScrollRestore.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  canRestoreScrollY,
+  readListingScrollEntry,
+  resolveReachableScrollY,
+  resolveRestoreCount,
+  resolveRestoreScrollY,
+  writeListingScrollEntry,
+  type ListingScrollStorage,
+} from "@/lib/listingScrollRestore";
+
+/**
+ * 无限滚动列表的前进/后退现场恢复。历史条目的 key 是存储键，因此"后退"
+ * 拿回的是那一条历史自己的进度，重新进入列表则是干净的新会话。
+ *
+ * 拆成两个 hook 是因为存在先后依赖：要补回多少条必须在数据层发起第一个
+ * 请求之前就确定，而落盘进度又依赖数据层已经请求到的条数。
+ */
+
+// 内容还没渲染够时滚不到目标位置，按帧重试；超过上限就放弃，避免死循环。
+const RESTORE_MAX_FRAMES = 90;
+
+function sessionStorageOrNull(): ListingScrollStorage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export type ListingRestoreTarget = {
+  historyKey: string;
+  count: number;
+  scrollY: number;
+};
+
+/**
+ * 解析当前历史条目要恢复的进度。在渲染期读取（而不是 effect）：数据层的
+ * 首个请求就发生在这次渲染之后，晚一拍就会先打一个只有首屏的请求。
+ */
+export function useListingRestoreTarget(input: {
+  historyKey: string;
+  queryKey: string;
+  pageSize: number;
+}): ListingRestoreTarget {
+  const targetRef = useRef<ListingRestoreTarget | null>(null);
+  if (!targetRef.current || targetRef.current.historyKey !== input.historyKey) {
+    const entry = readListingScrollEntry(
+      sessionStorageOrNull(),
+      input.historyKey
+    );
+    targetRef.current = {
+      historyKey: input.historyKey,
+      count: resolveRestoreCount({
+        entry,
+        queryKey: input.queryKey,
+        pageSize: input.pageSize,
+      }),
+      scrollY: resolveRestoreScrollY(entry, input.queryKey),
+    };
+  }
+  return targetRef.current;
+}
+
+export type UseListingScrollRestoreInput = {
+  target: ListingRestoreTarget;
+  queryKey: string;
+  /** 当前已经请求过的条目数，作为下次恢复的进度。 */
+  requestedCount: number;
+  itemCount: number;
+};
+
+export function useListingScrollRestore({
+  target,
+  queryKey,
+  requestedCount,
+  itemCount,
+}: UseListingScrollRestoreInput) {
+  const historyKey = target.historyKey;
+  const pendingScrollYRef = useRef(target.scrollY);
+  const lastScrollYRef = useRef(target.scrollY);
+  const restoredHistoryKeyRef = useRef(historyKey);
+  const [restoring, setRestoring] = useState(target.scrollY > 0);
+
+  if (restoredHistoryKeyRef.current !== historyKey) {
+    restoredHistoryKeyRef.current = historyKey;
+    pendingScrollYRef.current = target.scrollY;
+    lastScrollYRef.current = target.scrollY;
+  }
+
+  useEffect(() => {
+    const targetScrollY = pendingScrollYRef.current;
+    if (targetScrollY <= 0) {
+      setRestoring(false);
+      return;
+    }
+    setRestoring(true);
+    if (itemCount === 0) return;
+
+    let frame = 0;
+    let handle = 0;
+    const finish = (restoredScrollY: number) => {
+      pendingScrollYRef.current = 0;
+      lastScrollYRef.current = restoredScrollY;
+      setRestoring(false);
+    };
+    const attempt = () => {
+      if (
+        canRestoreScrollY({
+          targetScrollY,
+          documentHeight: document.documentElement.scrollHeight,
+          viewportHeight: window.innerHeight,
+        })
+      ) {
+        window.scrollTo(0, targetScrollY);
+        finish(targetScrollY);
+        return;
+      }
+      frame += 1;
+      if (frame >= RESTORE_MAX_FRAMES) {
+        // 保存的位置比恢复上限更深时，停在能到达的最远处而不是回到顶部。
+        const reachable = resolveReachableScrollY({
+          targetScrollY,
+          documentHeight: document.documentElement.scrollHeight,
+          viewportHeight: window.innerHeight,
+        });
+        window.scrollTo(0, reachable);
+        finish(reachable);
+        return;
+      }
+      handle = window.requestAnimationFrame(attempt);
+    };
+    handle = window.requestAnimationFrame(attempt);
+
+    return () => window.cancelAnimationFrame(handle);
+  }, [historyKey, itemCount]);
+
+  const save = useCallback(
+    (scrollY: number) => {
+      // 还没恢复完就落盘，会把保存的位置覆盖成恢复前的 0。
+      if (pendingScrollYRef.current > 0) return;
+      if (requestedCount <= 0) return;
+      writeListingScrollEntry(sessionStorageOrNull(), historyKey, {
+        queryKey,
+        requestedCount,
+        scrollY: Math.max(0, Math.round(scrollY)),
+      });
+    },
+    [historyKey, queryKey, requestedCount]
+  );
+
+  useEffect(() => {
+    let ticking = false;
+    let live = true;
+    const handleScroll = () => {
+      // 位置要在滚动事件里同步记下：卸载时列表 DOM 已经被详情页顶掉，
+      // 那时再读 window.scrollY 拿到的是被浏览器压缩过的值。
+      lastScrollYRef.current = Math.max(0, Math.round(window.scrollY));
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        ticking = false;
+        if (!live) return;
+        save(lastScrollYRef.current);
+      });
+    };
+    const handlePageHide = () => save(window.scrollY);
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("pagehide", handlePageHide);
+    return () => {
+      live = false;
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("pagehide", handlePageHide);
+      // 离开列表页（例如进详情页）时把最后的位置落盘，后退才能回到原处。
+      save(lastScrollYRef.current);
+    };
+  }, [save]);
+
+  return { restoring };
+}

--- a/src/lib/virtualGrid.ts
+++ b/src/lib/virtualGrid.ts
@@ -9,20 +9,16 @@ function toCount(value: number): number {
   return Math.floor(value);
 }
 
-/**
- * 从计算样式里读出列数。只有 grid 容器才会把 grid-template-columns 解析成
- * 逐条轨道宽度；compact 视图是 flex 列表，此时 grid-template-columns 仍是
- * 未解析的 "repeat(4, minmax(0, 1fr))"，按空格数它会被误读成 3 列，所以
- * 必须先看 display。
- */
-export function virtualGridColumns(style: {
-  display: string;
-  gridTemplateColumns: string;
+/** 与视频网格 CSS 断点一致；首帧即可按正确列数折行。 */
+export function virtualGridColumns(input: {
+  compact: boolean;
+  mobile: boolean;
+  tablet: boolean;
 }): number {
-  if (!style.display?.includes("grid")) return 1;
-  const trimmed = style.gridTemplateColumns?.trim() ?? "";
-  if (!trimmed || trimmed === "none" || trimmed.includes("(")) return 1;
-  return Math.max(1, trimmed.split(/\s+/).filter(Boolean).length);
+  if (input.compact) return 1;
+  if (input.mobile) return 2;
+  if (input.tablet) return 3;
+  return 4;
 }
 
 /** 虚拟单元是"整行"，行数决定 virtualizer 的 count。 */

--- a/src/lib/virtualGrid.ts
+++ b/src/lib/virtualGrid.ts
@@ -1,0 +1,69 @@
+/**
+ * 虚拟网格的纯计算层：把"一维的视频列表"折成"二维的行"，以及决定何时
+ * 续下一批。窗口本身由 @tanstack/react-virtual 负责，这里只留可以在没有
+ * 浏览器的单元测试里覆盖到每个分支的算术。
+ */
+
+function toCount(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+
+/**
+ * 从计算样式里读出列数。只有 grid 容器才会把 grid-template-columns 解析成
+ * 逐条轨道宽度；compact 视图是 flex 列表，此时 grid-template-columns 仍是
+ * 未解析的 "repeat(4, minmax(0, 1fr))"，按空格数它会被误读成 3 列，所以
+ * 必须先看 display。
+ */
+export function virtualGridColumns(style: {
+  display: string;
+  gridTemplateColumns: string;
+}): number {
+  if (!style.display?.includes("grid")) return 1;
+  const trimmed = style.gridTemplateColumns?.trim() ?? "";
+  if (!trimmed || trimmed === "none" || trimmed.includes("(")) return 1;
+  return Math.max(1, trimmed.split(/\s+/).filter(Boolean).length);
+}
+
+/** 虚拟单元是"整行"，行数决定 virtualizer 的 count。 */
+export function virtualRowCount(itemCount: number, columns: number): number {
+  const items = toCount(itemCount);
+  if (items === 0) return 0;
+  return Math.ceil(items / Math.max(1, toCount(columns) || 1));
+}
+
+/** 某一行覆盖的下标区间 [start, end)，末行不足一整行时按实际条数收口。 */
+export function virtualRowRange(
+  rowIndex: number,
+  columns: number,
+  itemCount: number
+): { start: number; end: number } {
+  const items = toCount(itemCount);
+  const perRow = Math.max(1, toCount(columns) || 1);
+  const row = Number.isFinite(rowIndex) ? Math.floor(rowIndex) : -1;
+  if (row < 0 || items === 0) return { start: 0, end: 0 };
+  const start = Math.min(row * perRow, items);
+  return { start, end: Math.min(start + perRow, items) };
+}
+
+export type LoadMoreInput = {
+  /** 当前渲染窗口的结束下标（不含）。 */
+  endIndex: number;
+  itemCount: number;
+  columns: number;
+  hasMore: boolean;
+  loading: boolean;
+  /** 距列表尾部还有几行时开始预取。 */
+  prefetchRows?: number;
+};
+
+/**
+ * 加载更多的触发条件直接来自渲染窗口，而不是另加一个哨兵节点：
+ * 虚拟列表里哨兵本身可能被回收，两套机制也会各自漂移。
+ */
+export function shouldLoadMore(input: LoadMoreInput): boolean {
+  if (!input.hasMore || input.loading) return false;
+  const columns = Math.max(1, toCount(input.columns) || 1);
+  const prefetchRows = Math.max(1, toCount(input.prefetchRows ?? 1) || 1);
+  return input.endIndex >= toCount(input.itemCount) - prefetchRows * columns;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,20 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { RefreshCw } from "lucide-react";
 import { useLocation, useSearchParams } from "react-router";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
 import { AppShell } from "@/components/AppShell";
 import { HomeFeedTabs } from "@/components/HomeFeedTabs";
+import { InfiniteFeedStatus } from "@/components/InfiniteFeedStatus";
 import { ListingLoadError } from "@/components/ListingLoadError";
 import { Pagination } from "@/components/Pagination";
 import { PromoStrip } from "@/components/PromoStrip";
 import { SearchPanel } from "@/components/SearchPanel";
-import { SortToolbar } from "@/components/SortToolbar";
+import { SortToolbar, type ViewMode } from "@/components/SortToolbar";
 import { TagCloud } from "@/components/TagCloud";
 import { VideoGrid } from "@/components/VideoGrid";
-import {
-  VirtualVideoGrid,
-  type VirtualGridRange,
-} from "@/components/VirtualVideoGrid";
+import { VirtualVideoGrid } from "@/components/VirtualVideoGrid";
 import {
   homeLatestFeedSource,
   homeRecommendationFeedSource,
@@ -28,6 +26,7 @@ import {
   withListingNavigation,
   withListingPage,
   withListingView,
+  type HomeFeedKey,
 } from "@/lib/listingSearchParams";
 import { MOBILE_VIDEO_PAGE_SIZE, useIsMobile } from "@/lib/responsive";
 import { useInfiniteListing } from "@/lib/useInfiniteListing";
@@ -36,19 +35,13 @@ import {
   useListingRestoreTarget,
   useListingScrollRestore,
 } from "@/lib/useListingScrollRestore";
-import { shouldLoadMore } from "@/lib/virtualGrid";
+import type { SortKey } from "@/types";
 
 const HOME_SEARCH_DESKTOP_PAGE_SIZE = 20;
 const HOME_FEED_DESKTOP_BATCH_SIZE = 20;
 
 // 距列表尾部还有两行时就续下一批，滚动到底之前数据已经在路上。
 const PREFETCH_ROWS = 2;
-
-const EMPTY_RANGE: VirtualGridRange = {
-  startIndex: 0,
-  endIndex: 0,
-  columns: 1,
-};
 
 export default function HomePage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -92,8 +85,8 @@ export default function HomePage() {
   const previousSearchPageSizeRef = useRef(searchPageSize);
   const searchScrollOnCommitRef = useRef(false);
 
-  // 两个推荐 tab 都是无限滚动。随机推荐走服务端轮换 feed，最新视频走真正
-  // 分页的列表接口。
+  // 两个推荐 tab 都通过不可变快照无限滚动：随机推荐在建快照时洗牌，最新
+  // 视频按确定顺序冻结，后续请求只按 token/cursor 读取同一份结果集。
   const feedBatchSize = isMobile
     ? MOBILE_VIDEO_PAGE_SIZE
     : HOME_FEED_DESKTOP_BATCH_SIZE;
@@ -112,17 +105,18 @@ export default function HomePage() {
   const homeFeed = useInfiniteListing(feedSource, {
     enabled: !hasActiveFilter,
     restoreCount: restoreTarget.count,
+    restoreFeedToken: restoreTarget.feedToken,
   });
   useListingScrollRestore({
     target: restoreTarget,
     queryKey: feedSource.key,
     requestedCount: hasActiveFilter ? 0 : homeFeed.requestedCount,
+    feedToken: hasActiveFilter ? "" : homeFeed.feedToken,
     itemCount: homeFeed.items.length,
   });
 
   const feedItems = homeFeed.items;
   const feedHasContent = feedItems.length > 0;
-  const [range, setRange] = useState<VirtualGridRange>(EMPTY_RANGE);
   const previousFeedKeyRef = useRef(feedSource.key);
 
   useEffect(() => {
@@ -159,40 +153,6 @@ export default function HomePage() {
     window.scrollTo({ top: 0, behavior: "auto" });
   }, [feedSource.key]);
 
-  const handleRangeChange = useCallback((next: VirtualGridRange) => {
-    setRange((current) =>
-      current.startIndex === next.startIndex &&
-      current.endIndex === next.endIndex &&
-      current.columns === next.columns
-        ? current
-        : next
-    );
-  }, []);
-
-  const { loadMore, loadingMore, hasMore } = homeFeed;
-  useEffect(() => {
-    if (hasActiveFilter) return;
-    if (
-      shouldLoadMore({
-        endIndex: range.endIndex,
-        itemCount: feedItems.length,
-        columns: range.columns,
-        hasMore,
-        loading: loadingMore,
-        prefetchRows: PREFETCH_ROWS,
-      })
-    ) {
-      loadMore();
-    }
-  }, [
-    feedItems.length,
-    hasActiveFilter,
-    hasMore,
-    loadMore,
-    loadingMore,
-    range,
-  ]);
-
   const reloadFeed = homeFeed.reload;
   const refreshHome = useCallback(() => {
     window.scrollTo({ top: 0, behavior: "auto" });
@@ -206,6 +166,44 @@ export default function HomePage() {
   const displayedSearchPage = searchSnapshot?.query.page ?? searchPage;
   const showRefresh = !hasActiveFilter && feed === "recommend";
   const refreshing = showRefresh && homeFeed.initialLoading;
+
+  const handleSearchSortChange = useCallback(
+    (nextSort: SortKey) => {
+      searchScrollOnCommitRef.current = true;
+      setSearchParams(
+        (current) =>
+          withListingNavigation(current, { sort: nextSort, page: 1 }),
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const handleSearchViewChange = useCallback(
+    (nextView: ViewMode) => {
+      setSearchParams((current) => withListingView(current, nextView), {
+        replace: true,
+      });
+    },
+    [setSearchParams]
+  );
+
+  const handleSearchPageChange = useCallback(
+    (nextPage: number) => {
+      searchScrollOnCommitRef.current = true;
+      setSearchParams((current) => withListingPage(current, nextPage));
+    },
+    [setSearchParams]
+  );
+
+  const handleFeedChange = useCallback(
+    (nextFeed: HomeFeedKey) => {
+      setSearchParams((current) => withHomeFeed(current, nextFeed), {
+        replace: true,
+      });
+    },
+    [setSearchParams]
+  );
 
   return (
     <AppShell mobileAutoHideNav>
@@ -230,21 +228,8 @@ export default function HomePage() {
             sort={displayedSearchSort}
             view={searchView}
             sortDisabled={searchResult.initialLoading || searchResult.transitioning}
-            onSortChange={(nextSort) => {
-              searchScrollOnCommitRef.current = true;
-              setSearchParams(
-                withListingNavigation(searchParams, {
-                  sort: nextSort,
-                  page: 1,
-                }),
-                { replace: true }
-              );
-            }}
-            onViewChange={(nextView) => {
-              setSearchParams(withListingView(searchParams, nextView), {
-                replace: true,
-              });
-            }}
+            onSortChange={handleSearchSortChange}
+            onViewChange={handleSearchViewChange}
           />
 
           {searchShowSkeleton ? (
@@ -298,10 +283,7 @@ export default function HomePage() {
               total={searchSnapshot.total}
               disabled={searchResult.transitioning}
               pendingPage={searchResult.transitioning ? searchPage : undefined}
-              onChange={(nextPage) => {
-                searchScrollOnCommitRef.current = true;
-                setSearchParams(withListingPage(searchParams, nextPage));
-              }}
+              onChange={handleSearchPageChange}
             />
           )}
         </div>
@@ -309,15 +291,11 @@ export default function HomePage() {
         <div className="container page-section home-primary-section">
           <HomeFeedTabs
             feed={feed}
-            onChange={(nextFeed) => {
-              setSearchParams(withHomeFeed(searchParams, nextFeed), {
-                replace: true,
-              });
-            }}
+            onChange={handleFeedChange}
           />
 
           {homeFeed.initialLoading && !feedHasContent ? (
-            <VideoGrid videos={[]} loading skeletonCount={feedBatchSize} />
+            <VideoGrid videos={[]} loading skeletonCount={feedSource.batchSize} />
           ) : homeFeed.failed && !feedHasContent ? (
             <ListingLoadError
               hasContent={false}
@@ -336,27 +314,22 @@ export default function HomePage() {
                 videos={feedItems}
                 eagerCount={eagerCount}
                 highPriorityCount={1}
-                onRangeChange={handleRangeChange}
+                key={`${feedSource.key}:${homeFeed.feedToken}`}
+                hasMore={homeFeed.hasMore}
+                loadingMore={homeFeed.loadingMore}
+                prefetchRows={PREFETCH_ROWS}
+                tailContent={
+                  homeFeed.loadingMore ? (
+                    <InfiniteFeedStatus state="loading" />
+                  ) : undefined
+                }
+                onLoadMore={homeFeed.loadMore}
               />
 
               {homeFeed.failed ? (
                 <ListingLoadError hasContent onRetry={homeFeed.retry} />
-              ) : homeFeed.loadingMore ? (
-                <div
-                  className="listing-infinite-status"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <span
-                    className="video-grid-refresh-overlay__spinner"
-                    aria-hidden="true"
-                  />
-                  <span>正在加载更多</span>
-                </div>
               ) : homeFeed.exhausted ? (
-                <div className="listing-infinite-status listing-infinite-status--end">
-                  没有更多了
-                </div>
+                <InfiniteFeedStatus state="end" />
               ) : null}
             </>
           )}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,40 +1,58 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
-import { useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
 import { AppShell } from "@/components/AppShell";
+import { HomeFeedTabs } from "@/components/HomeFeedTabs";
 import { ListingLoadError } from "@/components/ListingLoadError";
 import { Pagination } from "@/components/Pagination";
 import { PromoStrip } from "@/components/PromoStrip";
 import { SearchPanel } from "@/components/SearchPanel";
-import { SectionHeader } from "@/components/SectionHeader";
 import { SortToolbar } from "@/components/SortToolbar";
 import { TagCloud } from "@/components/TagCloud";
 import { VideoGrid } from "@/components/VideoGrid";
-import { fetchHomeVideos, fetchLatestHomeVideos } from "@/data/videos";
 import {
+  VirtualVideoGrid,
+  type VirtualGridRange,
+} from "@/components/VirtualVideoGrid";
+import {
+  homeLatestFeedSource,
+  homeRecommendationFeedSource,
+} from "@/lib/infiniteFeedSource";
+import {
+  readHomeFeed,
   readListingPage,
   readListingSort,
   readListingView,
+  withHomeFeed,
   withListingNavigation,
   withListingPage,
   withListingView,
 } from "@/lib/listingSearchParams";
 import { MOBILE_VIDEO_PAGE_SIZE, useIsMobile } from "@/lib/responsive";
+import { useInfiniteListing } from "@/lib/useInfiniteListing";
 import { useListingQuery } from "@/lib/useListingQuery";
-import type { VideoItem } from "@/types";
+import {
+  useListingRestoreTarget,
+  useListingScrollRestore,
+} from "@/lib/useListingScrollRestore";
+import { shouldLoadMore } from "@/lib/virtualGrid";
 
-const DESKTOP_COUNT = 12;
-const MOBILE_COUNT = 8;
 const HOME_SEARCH_DESKTOP_PAGE_SIZE = 20;
+const HOME_FEED_DESKTOP_BATCH_SIZE = 20;
 
-// 首页推荐接口每次请求都会推进会话轮换游标。模块级快照因此在 SPA 会话内
-// 保持稳定，只有用户主动刷新、浏览器整页刷新或响应式布局需要补足卡片时才更新。
-let cachedRanking: VideoItem[] | null = null;
-let cachedLatest: VideoItem[] | null = null;
+// 距列表尾部还有两行时就续下一批，滚动到底之前数据已经在路上。
+const PREFETCH_ROWS = 2;
+
+const EMPTY_RANGE: VirtualGridRange = {
+  startIndex: 0,
+  endIndex: 0,
+  columns: 1,
+};
 
 export default function HomePage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
   const activeSearchQuery = searchParams.get("q")?.trim() ?? "";
   const activeTag = searchParams.get("tag")?.trim() ?? "";
   const hasActiveSearch = activeSearchQuery.length > 0;
@@ -43,8 +61,11 @@ export default function HomePage() {
   const searchPage = readListingPage(searchParams);
   const searchSort = readListingSort(searchParams);
   const searchView = readListingView(searchParams);
+  const feed = readHomeFeed(searchParams);
   const isMobile = useIsMobile();
-  const displayCount = isMobile ? MOBILE_COUNT : DESKTOP_COUNT;
+  const eagerCount = isMobile ? 2 : 4;
+
+  // 搜索和标签结果仍然分页：这类结果常常需要定位到具体某一页。
   const searchPageSize = isMobile
     ? MOBILE_VIDEO_PAGE_SIZE
     : HOME_SEARCH_DESKTOP_PAGE_SIZE;
@@ -68,82 +89,41 @@ export default function HomePage() {
     searchResult.phase === "error" && searchHasContent;
   const searchShowEmptyError =
     searchResult.phase === "error" && !searchHasContent;
-  const eagerCount = isMobile ? 2 : 4;
-
-  const [rankingVideos, setRankingVideos] = useState<VideoItem[]>(cachedRanking ?? []);
-  const [latestVideos, setLatestVideos] = useState<VideoItem[]>(cachedLatest ?? []);
-  const [rankingLoading, setRankingLoading] = useState(cachedRanking === null);
-  const [rankingError, setRankingError] = useState(false);
-  const [rankingRevalidating, setRankingRevalidating] = useState(false);
-  const [latestLoading, setLatestLoading] = useState(cachedLatest === null);
-  const [latestError, setLatestError] = useState(false);
-  const [latestRevalidating, setLatestRevalidating] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
-  const homeRequestVersion = useRef(0);
-  const rankingRequestVersion = useRef(0);
-  const latestRequestVersion = useRef(0);
-  const displayCountRef = useRef(displayCount);
-  const previousDisplayCountRef = useRef(displayCount);
   const previousSearchPageSizeRef = useRef(searchPageSize);
   const searchScrollOnCommitRef = useRef(false);
-  displayCountRef.current = displayCount;
 
-  const loadRanking = useCallback(async (background: boolean) => {
-    const requestVersion = ++rankingRequestVersion.current;
-    const hasCachedContent = cachedRanking !== null;
-    setRankingLoading(!hasCachedContent);
-    setRankingRevalidating(background && hasCachedContent);
-    setRankingError(false);
-    try {
-      const rankingItems = await fetchHomeVideos(DESKTOP_COUNT);
-      if (requestVersion !== rankingRequestVersion.current) return;
-      cachedRanking = rankingItems;
-      setRankingVideos(rankingItems);
-      setRankingError(false);
-    } catch {
-      if (requestVersion !== rankingRequestVersion.current) return;
-      setRankingError(true);
-    } finally {
-      if (requestVersion === rankingRequestVersion.current) {
-        setRankingLoading(false);
-        setRankingRevalidating(false);
-      }
-    }
-  }, []);
+  // 两个推荐 tab 都是无限滚动。随机推荐走服务端轮换 feed，最新视频走真正
+  // 分页的列表接口。
+  const feedBatchSize = isMobile
+    ? MOBILE_VIDEO_PAGE_SIZE
+    : HOME_FEED_DESKTOP_BATCH_SIZE;
+  const feedSource = useMemo(
+    () =>
+      feed === "latest"
+        ? homeLatestFeedSource(feedBatchSize)
+        : homeRecommendationFeedSource(),
+    [feed, feedBatchSize]
+  );
+  const restoreTarget = useListingRestoreTarget({
+    historyKey: location.key,
+    queryKey: feedSource.key,
+    pageSize: feedSource.batchSize,
+  });
+  const homeFeed = useInfiniteListing(feedSource, {
+    enabled: !hasActiveFilter,
+    restoreCount: restoreTarget.count,
+  });
+  useListingScrollRestore({
+    target: restoreTarget,
+    queryKey: feedSource.key,
+    requestedCount: hasActiveFilter ? 0 : homeFeed.requestedCount,
+    itemCount: homeFeed.items.length,
+  });
 
-  const loadLatest = useCallback(async (background: boolean) => {
-    const requestVersion = ++latestRequestVersion.current;
-    const hasCachedContent = cachedLatest !== null;
-    setLatestLoading(!hasCachedContent);
-    setLatestRevalidating(background && hasCachedContent);
-    setLatestError(false);
-    try {
-      const latestItems = await fetchLatestHomeVideos(displayCountRef.current);
-      if (requestVersion !== latestRequestVersion.current) return;
-      cachedLatest = latestItems;
-      setLatestVideos(latestItems);
-      setLatestError(false);
-    } catch {
-      if (requestVersion !== latestRequestVersion.current) return;
-      setLatestError(true);
-    } finally {
-      if (requestVersion === latestRequestVersion.current) {
-        setLatestLoading(false);
-        setLatestRevalidating(false);
-      }
-    }
-  }, []);
-
-  const refreshRanking = useCallback(() => loadRanking(true), [loadRanking]);
-  const refreshLatest = useCallback(() => loadLatest(true), [loadLatest]);
-
-  const refreshHome = useCallback(async () => {
-    const requestVersion = ++homeRequestVersion.current;
-    setRefreshing(true);
-    await Promise.allSettled([loadRanking(false), loadLatest(false)]);
-    if (requestVersion !== homeRequestVersion.current) return;
-    setRefreshing(false);
-  }, [loadLatest, loadRanking]);
+  const feedItems = homeFeed.items;
+  const feedHasContent = feedItems.length > 0;
+  const [range, setRange] = useState<VirtualGridRange>(EMPTY_RANGE);
+  const previousFeedKeyRef = useRef(feedSource.key);
 
   useEffect(() => {
     document.title = activeSearchQuery
@@ -152,52 +132,6 @@ export default function HomePage() {
       ? `标签 ${activeTag}`
       : "首页";
   }, [activeSearchQuery, activeTag]);
-
-  useEffect(() => {
-    if (cachedRanking === null) {
-      void loadRanking(false);
-    }
-
-    if (cachedLatest === null) {
-      void loadLatest(false);
-    } else if (cachedLatest.length < displayCountRef.current) {
-      void loadLatest(true);
-    } else {
-      setLatestVideos(cachedLatest);
-      setLatestLoading(false);
-    }
-
-    return () => {
-      homeRequestVersion.current += 1;
-      rankingRequestVersion.current += 1;
-      latestRequestVersion.current += 1;
-    };
-  }, [loadLatest, loadRanking]);
-
-  useEffect(() => {
-    if (hasActiveFilter) return;
-    const previousCount = previousDisplayCountRef.current;
-    if (displayCount <= previousCount) {
-      previousDisplayCountRef.current = displayCount;
-      return;
-    }
-    if (latestVideos.length >= displayCount) {
-      previousDisplayCountRef.current = displayCount;
-      return;
-    }
-    if (refreshing || latestLoading || latestRevalidating) return;
-
-    previousDisplayCountRef.current = displayCount;
-    void refreshLatest();
-  }, [
-    displayCount,
-    hasActiveFilter,
-    latestLoading,
-    latestRevalidating,
-    latestVideos.length,
-    refreshLatest,
-    refreshing,
-  ]);
 
   useEffect(() => {
     if (previousSearchPageSizeRef.current === searchPageSize) return;
@@ -217,17 +151,61 @@ export default function HomePage() {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, [searchResult.key, searchSnapshot?.key]);
 
-  const ranking = rankingVideos.slice(0, displayCount);
-  const latest = latestVideos.slice(0, displayCount);
-  const homeLoading = rankingLoading || latestLoading;
-  const hasAnyVideos = ranking.length > 0 || latest.length > 0;
-  const hasHomeError = rankingError || latestError;
-  const showEmptyHome = !homeLoading && !hasHomeError && !hasAnyVideos;
+  // 换 tab 是一次全新的列表，回到顶部再开始累积。平滑滚动会被虚拟列表的
+  // 行高补偿打断而停在半路，所以直接落到顶部。
+  useEffect(() => {
+    if (previousFeedKeyRef.current === feedSource.key) return;
+    previousFeedKeyRef.current = feedSource.key;
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }, [feedSource.key]);
+
+  const handleRangeChange = useCallback((next: VirtualGridRange) => {
+    setRange((current) =>
+      current.startIndex === next.startIndex &&
+      current.endIndex === next.endIndex &&
+      current.columns === next.columns
+        ? current
+        : next
+    );
+  }, []);
+
+  const { loadMore, loadingMore, hasMore } = homeFeed;
+  useEffect(() => {
+    if (hasActiveFilter) return;
+    if (
+      shouldLoadMore({
+        endIndex: range.endIndex,
+        itemCount: feedItems.length,
+        columns: range.columns,
+        hasMore,
+        loading: loadingMore,
+        prefetchRows: PREFETCH_ROWS,
+      })
+    ) {
+      loadMore();
+    }
+  }, [
+    feedItems.length,
+    hasActiveFilter,
+    hasMore,
+    loadMore,
+    loadingMore,
+    range,
+  ]);
+
+  const reloadFeed = homeFeed.reload;
+  const refreshHome = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "auto" });
+    reloadFeed();
+  }, [reloadFeed]);
+
   const displayedSearchSort =
     searchResult.phase === "error" && searchSnapshot
       ? searchSnapshot.query.sort
       : searchSort;
   const displayedSearchPage = searchSnapshot?.query.page ?? searchPage;
+  const showRefresh = !hasActiveFilter && feed === "recommend";
+  const refreshing = showRefresh && homeFeed.initialLoading;
 
   return (
     <AppShell mobileAutoHideNav>
@@ -239,7 +217,7 @@ export default function HomePage() {
           placeholder=""
           className="search-panel--public search-panel--transparent"
         />
-        {hasAnyVideos || hasActiveFilter ? (
+        {feedHasContent || hasActiveFilter ? (
           <TagCloud linkBasePath="/" />
         ) : (
           <div className="tag-cloud-container is-reserved" aria-hidden="true" />
@@ -327,67 +305,65 @@ export default function HomePage() {
             />
           )}
         </div>
-      ) : showEmptyHome ? (
-        <div className="container page-section home-primary-section">
-          <AdminEmptyVisual
-            variant="empty"
-            text="当前库中没有视频"
-            className="admin-empty-state admin-empty-state--plain home-empty-state"
-          />
-        </div>
       ) : (
-        <>
-          <div className="container page-section home-primary-section">
-            <SectionHeader title="随机推荐" />
-            {rankingError && ranking.length > 0 && (
-              <ListingLoadError
-                hasContent
-                onRetry={() => void refreshRanking()}
-              />
-            )}
-            <VideoGrid
-              videos={ranking}
-              loading={rankingLoading}
-              refreshMode={
-                refreshing && !rankingLoading
-                  ? "blocking"
-                  : rankingRevalidating
-                  ? "background"
-                  : undefined
-              }
-              emptyText={rankingError ? "随机推荐加载失败，请刷新重试" : undefined}
-              eagerCount={eagerCount}
-              highPriorityCount={1}
-              skeletonCount={displayCount}
-            />
-          </div>
+        <div className="container page-section home-primary-section">
+          <HomeFeedTabs
+            feed={feed}
+            onChange={(nextFeed) => {
+              setSearchParams(withHomeFeed(searchParams, nextFeed), {
+                replace: true,
+              });
+            }}
+          />
 
-          <div className="container page-section">
-            <SectionHeader title="最新视频" />
-            {latestError && latest.length > 0 && (
-              <ListingLoadError
-                hasContent
-                onRetry={() => void refreshLatest()}
-              />
-            )}
-            <VideoGrid
-              videos={latest}
-              loading={latestLoading}
-              refreshMode={
-                refreshing && !latestLoading
-                  ? "blocking"
-                  : latestRevalidating
-                  ? "background"
-                  : undefined
-              }
-              emptyText={latestError ? "最新视频加载失败，请刷新重试" : undefined}
-              skeletonCount={displayCount}
+          {homeFeed.initialLoading && !feedHasContent ? (
+            <VideoGrid videos={[]} loading skeletonCount={feedBatchSize} />
+          ) : homeFeed.failed && !feedHasContent ? (
+            <ListingLoadError
+              hasContent={false}
+              onRetry={homeFeed.retry}
+              emptyClassName="admin-empty-state admin-empty-state--plain home-empty-state"
             />
-          </div>
-        </>
+          ) : !feedHasContent ? (
+            <AdminEmptyVisual
+              variant="empty"
+              text="当前库中没有视频"
+              className="admin-empty-state admin-empty-state--plain home-empty-state"
+            />
+          ) : (
+            <>
+              <VirtualVideoGrid
+                videos={feedItems}
+                eagerCount={eagerCount}
+                highPriorityCount={1}
+                onRangeChange={handleRangeChange}
+              />
+
+              {homeFeed.failed ? (
+                <ListingLoadError hasContent onRetry={homeFeed.retry} />
+              ) : homeFeed.loadingMore ? (
+                <div
+                  className="listing-infinite-status"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span
+                    className="video-grid-refresh-overlay__spinner"
+                    aria-hidden="true"
+                  />
+                  <span>正在加载更多</span>
+                </div>
+              ) : homeFeed.exhausted ? (
+                <div className="listing-infinite-status listing-infinite-status--end">
+                  没有更多了
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
       )}
 
-      {!hasActiveFilter && (
+      {showRefresh && (
         <button
           type="button"
           className={`home-refresh ${refreshing ? "is-refreshing" : ""}`}

--- a/src/pages/ListingPage.tsx
+++ b/src/pages/ListingPage.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useRef } from "react";
-import { useSearchParams } from "react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation, useSearchParams } from "react-router";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
 import { AppShell } from "@/components/AppShell";
 import { ListingLoadError } from "@/components/ListingLoadError";
-import { Pagination } from "@/components/Pagination";
 import { PromoStrip } from "@/components/PromoStrip";
 import { SearchPanel } from "@/components/SearchPanel";
 import { SortToolbar } from "@/components/SortToolbar";
 import { TagCloud } from "@/components/TagCloud";
 import { VideoGrid } from "@/components/VideoGrid";
 import {
-  readListingPage,
+  VirtualVideoGrid,
+  type VirtualGridRange,
+} from "@/components/VirtualVideoGrid";
+import { infiniteListingKey } from "@/lib/infiniteListing";
+import {
   readListingSort,
   readListingView,
   withListingNavigation,
@@ -18,37 +21,63 @@ import {
   withListingView,
 } from "@/lib/listingSearchParams";
 import { MOBILE_VIDEO_PAGE_SIZE, useIsMobile } from "@/lib/responsive";
-import { useListingQuery } from "@/lib/useListingQuery";
+import { useInfiniteListing } from "@/lib/useInfiniteListing";
+import {
+  useListingRestoreTarget,
+  useListingScrollRestore,
+} from "@/lib/useListingScrollRestore";
+import { shouldLoadMore } from "@/lib/virtualGrid";
 
 const DESKTOP_PAGE_SIZE = 20;
 
+// 距列表尾部还有两行时就续下一批，滚动到底之前数据已经在路上。
+const PREFETCH_ROWS = 2;
+
+const EMPTY_RANGE: VirtualGridRange = {
+  startIndex: 0,
+  endIndex: 0,
+  columns: 1,
+};
+
 export default function ListingPage() {
   const [params, setParams] = useSearchParams();
+  const location = useLocation();
   const keyword = params.get("q") ?? "";
   const tag = params.get("tag") ?? "";
   const sort = readListingSort(params);
-  const page = readListingPage(params);
   const view = readListingView(params);
   const isMobile = useIsMobile();
   const pageSize = isMobile ? MOBILE_VIDEO_PAGE_SIZE : DESKTOP_PAGE_SIZE;
-  const result = useListingQuery({
+  const queryKey = infiniteListingKey({ q: keyword, tag, sort, pageSize });
+
+  const restoreTarget = useListingRestoreTarget({
+    historyKey: location.key,
+    queryKey,
+    pageSize,
+  });
+  const listing = useInfiniteListing({
     q: keyword,
     tag,
     sort,
-    page,
     pageSize,
+    restoreCount: restoreTarget.count,
   });
-  const snapshot = result.snapshot;
-  const items = snapshot?.items ?? [];
+  useListingScrollRestore({
+    target: restoreTarget,
+    queryKey,
+    requestedCount: listing.requestedCount,
+    itemCount: listing.items.length,
+  });
+
+  const items = listing.items;
   const hasContent = items.length > 0;
-  const showSkeleton =
-    result.initialLoading || (result.transitioning && !hasContent);
-  const showContentError = result.phase === "error" && hasContent;
-  const showEmptyError = result.phase === "error" && !hasContent;
+  const showSkeleton = listing.initialLoading && !hasContent;
+  const showEmptyError = listing.failed && !hasContent;
+  const showTailError = listing.failed && hasContent;
   const hasActiveFilter = keyword.trim().length > 0 || tag.trim().length > 0;
   const eagerCount = isMobile ? 2 : 4;
-  const scrollOnCommitRef = useRef(false);
-  const previousPageSizeRef = useRef(pageSize);
+  const [range, setRange] = useState<VirtualGridRange>(EMPTY_RANGE);
+  const previousQueryKeyRef = useRef(queryKey);
 
   useEffect(() => {
     document.title = keyword
@@ -58,27 +87,45 @@ export default function ListingPage() {
       : "视频列表";
   }, [keyword, tag]);
 
+  // 无限滚动没有页码，旧链接里的 page 参数只会让 URL 与实际内容不符。
   useEffect(() => {
-    if (previousPageSizeRef.current === pageSize) return;
-    previousPageSizeRef.current = pageSize;
-    if (page === 1) return;
+    if (!params.has("page")) return;
     setParams((current) => withListingPage(current, 1), { replace: true });
-  }, [page, pageSize, setParams]);
+  }, [params, setParams]);
 
+  // 换排序/换标签是一次全新的列表，回到顶部再开始累积。平滑滚动会被虚拟
+  // 列表的行高补偿打断而停在半路，所以直接落到顶部。
+  useEffect(() => {
+    if (previousQueryKeyRef.current === queryKey) return;
+    previousQueryKeyRef.current = queryKey;
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }, [queryKey]);
+
+  const handleRangeChange = useCallback((next: VirtualGridRange) => {
+    setRange((current) =>
+      current.startIndex === next.startIndex &&
+      current.endIndex === next.endIndex &&
+      current.columns === next.columns
+        ? current
+        : next
+    );
+  }, []);
+
+  const { loadMore, loadingMore, hasMore } = listing;
   useEffect(() => {
     if (
-      !scrollOnCommitRef.current ||
-      snapshot?.key !== result.key
+      shouldLoadMore({
+        endIndex: range.endIndex,
+        itemCount: items.length,
+        columns: range.columns,
+        hasMore,
+        loading: loadingMore,
+        prefetchRows: PREFETCH_ROWS,
+      })
     ) {
-      return;
+      loadMore();
     }
-    scrollOnCommitRef.current = false;
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  }, [result.key, snapshot?.key]);
-
-  const displayedSort =
-    result.phase === "error" && snapshot ? snapshot.query.sort : sort;
-  const displayedPage = snapshot?.query.page ?? page;
+  }, [hasMore, items.length, loadMore, loadingMore, range]);
 
   return (
     <AppShell>
@@ -94,11 +141,10 @@ export default function ListingPage() {
 
       <div className="container page-section listing-primary-section">
         <SortToolbar
-          sort={displayedSort}
+          sort={sort}
           view={view}
-          sortDisabled={result.initialLoading || result.transitioning}
+          sortDisabled={listing.initialLoading}
           onSortChange={(nextSort) => {
-            scrollOnCommitRef.current = true;
             setParams(
               withListingNavigation(params, { sort: nextSort, page: 1 }),
               { replace: true }
@@ -119,10 +165,10 @@ export default function ListingPage() {
         ) : showEmptyError ? (
           <ListingLoadError
             hasContent={false}
-            onRetry={result.retry}
+            onRetry={listing.retry}
             emptyClassName="admin-empty-state admin-empty-state--plain listing-empty-state"
           />
-        ) : snapshot && items.length === 0 ? (
+        ) : !hasContent ? (
           <AdminEmptyVisual
             variant={hasActiveFilter ? "no-results" : "empty"}
             text={hasActiveFilter ? "未查询到" : "当前库中没有视频"}
@@ -130,41 +176,34 @@ export default function ListingPage() {
           />
         ) : (
           <>
-            {showContentError && (
-              <ListingLoadError
-                hasContent
-                displayedPage={displayedPage}
-                onRetry={result.retry}
-              />
-            )}
-            <VideoGrid
+            <VirtualVideoGrid
               videos={items}
               compact={view === "compact"}
-              refreshMode={
-                result.transitioning
-                  ? "blocking"
-                  : result.revalidating
-                  ? "background"
-                  : undefined
-              }
               eagerCount={eagerCount}
               highPriorityCount={1}
+              onRangeChange={handleRangeChange}
             />
-          </>
-        )}
 
-        {snapshot && (
-          <Pagination
-            page={displayedPage}
-            pageSize={snapshot.query.pageSize}
-            total={snapshot.total}
-            disabled={result.transitioning}
-            pendingPage={result.transitioning ? page : undefined}
-            onChange={(nextPage) => {
-              scrollOnCommitRef.current = true;
-              setParams(withListingPage(params, nextPage));
-            }}
-          />
+            {showTailError ? (
+              <ListingLoadError hasContent onRetry={listing.retry} />
+            ) : loadingMore ? (
+              <div
+                className="listing-infinite-status"
+                role="status"
+                aria-live="polite"
+              >
+                <span
+                  className="video-grid-refresh-overlay__spinner"
+                  aria-hidden="true"
+                />
+                <span>正在加载更多</span>
+              </div>
+            ) : listing.exhausted ? (
+              <div className="listing-infinite-status listing-infinite-status--end">
+                没有更多了
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </AppShell>

--- a/src/pages/ListingPage.tsx
+++ b/src/pages/ListingPage.tsx
@@ -1,17 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocation, useSearchParams } from "react-router";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
 import { AppShell } from "@/components/AppShell";
+import { InfiniteFeedStatus } from "@/components/InfiniteFeedStatus";
 import { ListingLoadError } from "@/components/ListingLoadError";
 import { PromoStrip } from "@/components/PromoStrip";
 import { SearchPanel } from "@/components/SearchPanel";
-import { SortToolbar } from "@/components/SortToolbar";
+import { SortToolbar, type ViewMode } from "@/components/SortToolbar";
 import { TagCloud } from "@/components/TagCloud";
 import { VideoGrid } from "@/components/VideoGrid";
-import {
-  VirtualVideoGrid,
-  type VirtualGridRange,
-} from "@/components/VirtualVideoGrid";
+import { VirtualVideoGrid } from "@/components/VirtualVideoGrid";
 import { listingFeedSource } from "@/lib/infiniteFeedSource";
 import {
   readListingSort,
@@ -26,18 +24,12 @@ import {
   useListingRestoreTarget,
   useListingScrollRestore,
 } from "@/lib/useListingScrollRestore";
-import { shouldLoadMore } from "@/lib/virtualGrid";
+import type { SortKey } from "@/types";
 
 const DESKTOP_PAGE_SIZE = 20;
 
 // 距列表尾部还有两行时就续下一批，滚动到底之前数据已经在路上。
 const PREFETCH_ROWS = 2;
-
-const EMPTY_RANGE: VirtualGridRange = {
-  startIndex: 0,
-  endIndex: 0,
-  columns: 1,
-};
 
 export default function ListingPage() {
   const [params, setParams] = useSearchParams();
@@ -61,11 +53,13 @@ export default function ListingPage() {
   });
   const listing = useInfiniteListing(source, {
     restoreCount: restoreTarget.count,
+    restoreFeedToken: restoreTarget.feedToken,
   });
   useListingScrollRestore({
     target: restoreTarget,
     queryKey,
     requestedCount: listing.requestedCount,
+    feedToken: listing.feedToken,
     itemCount: listing.items.length,
   });
 
@@ -76,7 +70,6 @@ export default function ListingPage() {
   const showTailError = listing.failed && hasContent;
   const hasActiveFilter = keyword.trim().length > 0 || tag.trim().length > 0;
   const eagerCount = isMobile ? 2 : 4;
-  const [range, setRange] = useState<VirtualGridRange>(EMPTY_RANGE);
   const previousQueryKeyRef = useRef(queryKey);
 
   useEffect(() => {
@@ -101,31 +94,27 @@ export default function ListingPage() {
     window.scrollTo({ top: 0, behavior: "auto" });
   }, [queryKey]);
 
-  const handleRangeChange = useCallback((next: VirtualGridRange) => {
-    setRange((current) =>
-      current.startIndex === next.startIndex &&
-      current.endIndex === next.endIndex &&
-      current.columns === next.columns
-        ? current
-        : next
-    );
-  }, []);
+  const handleSortChange = useCallback(
+    (nextSort: SortKey) => {
+      setParams(
+        (current) =>
+          withListingNavigation(current, { sort: nextSort, page: 1 }),
+        { replace: true }
+      );
+    },
+    [setParams]
+  );
 
-  const { loadMore, loadingMore, hasMore } = listing;
-  useEffect(() => {
-    if (
-      shouldLoadMore({
-        endIndex: range.endIndex,
-        itemCount: items.length,
-        columns: range.columns,
-        hasMore,
-        loading: loadingMore,
-        prefetchRows: PREFETCH_ROWS,
-      })
-    ) {
-      loadMore();
-    }
-  }, [hasMore, items.length, loadMore, loadingMore, range]);
+  const handleViewChange = useCallback(
+    (nextView: ViewMode) => {
+      setParams((current) => withListingView(current, nextView), {
+        replace: true,
+      });
+    },
+    [setParams]
+  );
+
+  const { loadingMore } = listing;
 
   return (
     <AppShell>
@@ -144,15 +133,8 @@ export default function ListingPage() {
           sort={sort}
           view={view}
           sortDisabled={listing.initialLoading}
-          onSortChange={(nextSort) => {
-            setParams(
-              withListingNavigation(params, { sort: nextSort, page: 1 }),
-              { replace: true }
-            );
-          }}
-          onViewChange={(nextView) => {
-            setParams(withListingView(params, nextView), { replace: true });
-          }}
+          onSortChange={handleSortChange}
+          onViewChange={handleViewChange}
         />
 
         {showSkeleton ? (
@@ -178,30 +160,23 @@ export default function ListingPage() {
           <>
             <VirtualVideoGrid
               videos={items}
+              key={`${queryKey}:${listing.feedToken}`}
               compact={view === "compact"}
               eagerCount={eagerCount}
               highPriorityCount={1}
-              onRangeChange={handleRangeChange}
+              hasMore={listing.hasMore}
+              loadingMore={loadingMore}
+              prefetchRows={PREFETCH_ROWS}
+              tailContent={
+                loadingMore ? <InfiniteFeedStatus state="loading" /> : undefined
+              }
+              onLoadMore={listing.loadMore}
             />
 
             {showTailError ? (
               <ListingLoadError hasContent onRetry={listing.retry} />
-            ) : loadingMore ? (
-              <div
-                className="listing-infinite-status"
-                role="status"
-                aria-live="polite"
-              >
-                <span
-                  className="video-grid-refresh-overlay__spinner"
-                  aria-hidden="true"
-                />
-                <span>正在加载更多</span>
-              </div>
             ) : listing.exhausted ? (
-              <div className="listing-infinite-status listing-infinite-status--end">
-                没有更多了
-              </div>
+              <InfiniteFeedStatus state="end" />
             ) : null}
           </>
         )}

--- a/src/pages/ListingPage.tsx
+++ b/src/pages/ListingPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useSearchParams } from "react-router";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
 import { AppShell } from "@/components/AppShell";
@@ -12,7 +12,7 @@ import {
   VirtualVideoGrid,
   type VirtualGridRange,
 } from "@/components/VirtualVideoGrid";
-import { infiniteListingKey } from "@/lib/infiniteListing";
+import { listingFeedSource } from "@/lib/infiniteFeedSource";
 import {
   readListingSort,
   readListingView,
@@ -48,18 +48,18 @@ export default function ListingPage() {
   const view = readListingView(params);
   const isMobile = useIsMobile();
   const pageSize = isMobile ? MOBILE_VIDEO_PAGE_SIZE : DESKTOP_PAGE_SIZE;
-  const queryKey = infiniteListingKey({ q: keyword, tag, sort, pageSize });
+  const source = useMemo(
+    () => listingFeedSource({ q: keyword, tag, sort, pageSize }),
+    [keyword, tag, sort, pageSize]
+  );
+  const queryKey = source.key;
 
   const restoreTarget = useListingRestoreTarget({
     historyKey: location.key,
     queryKey,
     pageSize,
   });
-  const listing = useInfiniteListing({
-    q: keyword,
-    tag,
-    sort,
-    pageSize,
+  const listing = useInfiniteListing(source, {
     restoreCount: restoreTarget.count,
   });
   useListingScrollRestore({

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -57,6 +57,22 @@
   padding: 72px 16px 24px;
 }
 
+/* 无限滚动列表尾部的加载中 / 到底提示 */
+.listing-infinite-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 56px;
+  padding: var(--space-4) 0;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}
+
+.listing-infinite-status--end {
+  color: var(--text-faint);
+}
+
 /* =========================================================
  * Section header
  * ========================================================= */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -57,6 +57,55 @@
   padding: 72px 16px 24px;
 }
 
+/* 首页推荐/最新的 tab 栏 */
+.home-feed-tabs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  margin: var(--space-3) 0 var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.home-feed-tabs__tab {
+  position: relative;
+  padding: 0 2px 10px;
+  background: transparent;
+  font-size: var(--font-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--text-muted);
+  transition: color var(--transition-fast);
+}
+
+.home-feed-tabs__tab:hover {
+  color: var(--text-strong);
+}
+
+.home-feed-tabs__tab.is-active {
+  color: var(--text-strong);
+}
+
+.home-feed-tabs__tab.is-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--accent-gradient);
+}
+
+@media (max-width: 640px) {
+  .home-feed-tabs {
+    gap: var(--space-4);
+    margin-top: var(--space-2);
+  }
+
+  .home-feed-tabs__tab {
+    font-size: var(--font-md);
+  }
+}
+
 /* 无限滚动列表尾部的加载中 / 到底提示 */
 .listing-infinite-status {
   display: flex;

--- a/src/styles/video-card.css
+++ b/src/styles/video-card.css
@@ -36,6 +36,14 @@
   padding-bottom: var(--space-4);
 }
 
+/* 未加载内容不提前撑高，只用固定尾行承载加载反馈。 */
+.video-grid-virtual-tail {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+}
+
 .video-grid--virtual-row.is-compact {
   padding-bottom: var(--space-2);
 }

--- a/src/styles/video-card.css
+++ b/src/styles/video-card.css
@@ -20,6 +20,26 @@
   }
 }
 
+/* ----- 虚拟滚动 ----- */
+/* 占位容器撑出完整列表的高度，行在其中按测量位置绝对定位。 */
+.video-grid-virtual-canvas {
+  position: relative;
+  width: 100%;
+}
+
+.video-grid--virtual-row {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  /* 行之间的间距由行自身的下内边距提供，这样测到的行高已经含间距。 */
+  padding-bottom: var(--space-4);
+}
+
+.video-grid--virtual-row.is-compact {
+  padding-bottom: var(--space-2);
+}
+
 /* ----- Compact 列表视图 ----- */
 .video-grid.is-compact {
   display: flex;
@@ -848,6 +868,10 @@
   .video-grid.is-compact .video-card__link {
     grid-template-columns: 130px minmax(0, 1fr);
     gap: 4px var(--space-2);
+  }
+
+  .video-grid--virtual-row:not(.is-compact) {
+    padding-bottom: 10px;
   }
 
   .video-grid-loading.is-compact .skeleton-card {

--- a/tests/homeFeedTabs.test.ts
+++ b/tests/homeFeedTabs.test.ts
@@ -14,6 +14,10 @@ const tabsSource = readFileSync(
   new URL("../src/components/HomeFeedTabs.tsx", import.meta.url),
   "utf8"
 );
+const infiniteFeedStatusSource = readFileSync(
+  new URL("../src/components/InfiniteFeedStatus.tsx", import.meta.url),
+  "utf8"
+);
 const layoutCss = readFileSync(
   new URL("../src/styles/layout.css", import.meta.url),
   "utf8"
@@ -66,7 +70,7 @@ test("switching tabs replaces the history entry and restarts at the top", () => 
   assert.match(homePageSource, /const feed = readHomeFeed\(searchParams\)/);
   assert.match(
     homePageSource,
-    /setSearchParams\(withHomeFeed\(searchParams, nextFeed\), \{\s*replace: true,\s*\}\)/
+    /setSearchParams\(\(current\) => withHomeFeed\(current, nextFeed\), \{\s*replace: true,\s*\}\)/
   );
   assert.match(
     homePageSource,
@@ -81,11 +85,13 @@ test("each home tab scrolls infinitely through its own feed source", () => {
   );
   assert.match(
     homePageSource,
-    /shouldLoadMore\(\{[\s\S]*?endIndex: range\.endIndex,[\s\S]*?itemCount: feedItems\.length,[\s\S]*?hasMore,[\s\S]*?loading: loadingMore,/
+    /<VirtualVideoGrid[\s\S]*?videos=\{feedItems\}[\s\S]*?hasMore=\{homeFeed\.hasMore\}[\s\S]*?loadingMore=\{homeFeed\.loadingMore\}[\s\S]*?prefetchRows=\{PREFETCH_ROWS\}[\s\S]*?onLoadMore=\{homeFeed\.loadMore\}/
   );
-  assert.match(homePageSource, /if \(hasActiveFilter\) return;\s*if \(\s*shouldLoadMore/);
-  assert.match(homePageSource, /正在加载更多/);
-  assert.match(homePageSource, /没有更多了/);
+  assert.doesNotMatch(homePageSource, /setRange|onRangeChange|shouldLoadMore/);
+  assert.match(homePageSource, /<InfiniteFeedStatus state="loading" \/>/);
+  assert.match(homePageSource, /<InfiniteFeedStatus state="end" \/>/);
+  assert.match(infiniteFeedStatusSource, /正在加载更多/);
+  assert.match(infiniteFeedStatusSource, /没有更多了/);
 });
 
 test("search and tag results keep their pagination", () => {

--- a/tests/homeFeedTabs.test.ts
+++ b/tests/homeFeedTabs.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  readHomeFeed,
+  withHomeFeed,
+} from "../src/lib/listingSearchParams.ts";
+
+const homePageSource = readFileSync(
+  new URL("../src/pages/HomePage.tsx", import.meta.url),
+  "utf8"
+);
+const tabsSource = readFileSync(
+  new URL("../src/components/HomeFeedTabs.tsx", import.meta.url),
+  "utf8"
+);
+const layoutCss = readFileSync(
+  new URL("../src/styles/layout.css", import.meta.url),
+  "utf8"
+);
+
+function ruleBody(css: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`));
+  assert.ok(match, `Expected CSS rule for ${selector}`);
+  return match[1];
+}
+
+test("the active home tab lives in the URL so history can restore it", () => {
+  assert.equal(readHomeFeed(new URLSearchParams("")), "recommend");
+  assert.equal(readHomeFeed(new URLSearchParams("feed=latest")), "latest");
+  assert.equal(
+    readHomeFeed(new URLSearchParams("feed=whatever")),
+    "recommend",
+    "无法识别的值回落到默认 tab"
+  );
+
+  const latest = withHomeFeed(new URLSearchParams("q=猫"), "latest");
+  assert.equal(latest.get("feed"), "latest");
+  assert.equal(latest.get("q"), "猫", "切 tab 不能丢掉其它查询参数");
+  assert.equal(
+    withHomeFeed(latest, "recommend").get("feed"),
+    null,
+    "默认 tab 不写进 URL"
+  );
+});
+
+test("the home tabs are an accessible tab list with the random feed first", () => {
+  assert.match(
+    tabsSource,
+    /\{ key: "recommend", label: "随机推荐" \},\s*\{ key: "latest", label: "最新视频" \}/
+  );
+  assert.match(tabsSource, /role="tablist"/);
+  assert.match(tabsSource, /role="tab"/);
+  assert.match(tabsSource, /aria-selected=\{active\}/);
+  assert.match(tabsSource, /className=\{`home-feed-tabs__tab \$\{active \? "is-active" : ""\}`\}/);
+
+  const tabs = ruleBody(layoutCss, ".home-feed-tabs");
+  assert.match(tabs, /display\s*:\s*flex/);
+  assert.match(tabs, /border-bottom\s*:\s*1px solid var\(--border-subtle\)/);
+  const activeUnderline = ruleBody(layoutCss, ".home-feed-tabs__tab.is-active::after");
+  assert.match(activeUnderline, /background\s*:\s*var\(--accent-gradient\)/);
+});
+
+test("switching tabs replaces the history entry and restarts at the top", () => {
+  assert.match(homePageSource, /const feed = readHomeFeed\(searchParams\)/);
+  assert.match(
+    homePageSource,
+    /setSearchParams\(withHomeFeed\(searchParams, nextFeed\), \{\s*replace: true,\s*\}\)/
+  );
+  assert.match(
+    homePageSource,
+    /if \(previousFeedKeyRef\.current === feedSource\.key\) return;[\s\S]*?window\.scrollTo\(\{ top: 0, behavior: "auto" \}\)/
+  );
+});
+
+test("each home tab scrolls infinitely through its own feed source", () => {
+  assert.match(
+    homePageSource,
+    /feed === "latest"\s*\? homeLatestFeedSource\(feedBatchSize\)\s*:\s*homeRecommendationFeedSource\(\)/
+  );
+  assert.match(
+    homePageSource,
+    /shouldLoadMore\(\{[\s\S]*?endIndex: range\.endIndex,[\s\S]*?itemCount: feedItems\.length,[\s\S]*?hasMore,[\s\S]*?loading: loadingMore,/
+  );
+  assert.match(homePageSource, /if \(hasActiveFilter\) return;\s*if \(\s*shouldLoadMore/);
+  assert.match(homePageSource, /正在加载更多/);
+  assert.match(homePageSource, /没有更多了/);
+});
+
+test("search and tag results keep their pagination", () => {
+  assert.match(
+    homePageSource,
+    /const searchResult = useListingQuery\([\s\S]*?page: searchPage,[\s\S]*?pageSize: searchPageSize/
+  );
+  assert.match(homePageSource, /<Pagination[\s\S]*?page=\{displayedSearchPage\}/);
+  // 搜索结果仍然分页，推荐流才是无限滚动。
+  assert.match(
+    homePageSource,
+    /<VideoGrid\s+videos=\{searchItems\}/
+  );
+});

--- a/tests/homeRefreshButton.test.ts
+++ b/tests/homeRefreshButton.test.ts
@@ -40,17 +40,26 @@ function ruleBody(css: string, selector: string): string {
 
 test("home page refresh button shares back-to-top slot until back-to-top is visible", () => {
   assert.match(homePageSource, /import \{ RefreshCw \} from "lucide-react"/);
-  assert.match(homePageSource, /let cachedLatest: VideoItem\[\] \| null = null;/);
-  assert.match(homePageSource, /const refreshHome = useCallback\(async \(\) =>/);
-  assert.match(homePageSource, /fetchHomeVideos\(DESKTOP_COUNT\)/);
-  assert.match(homePageSource, /fetchLatestHomeVideos\(displayCountRef\.current\)/);
-  assert.match(homePageSource, /const DESKTOP_COUNT = 12;/);
-  assert.match(homePageSource, /const MOBILE_COUNT = 8;/);
+  // 刷新只对随机推荐有意义：最新视频是时间序，重抽一轮没有区别。
+  assert.match(
+    homePageSource,
+    /const showRefresh = !hasActiveFilter && feed === "recommend";/
+  );
+  assert.match(homePageSource, /const refreshing = showRefresh && homeFeed\.initialLoading;/);
+  assert.match(homePageSource, /\{showRefresh && \(/);
+  assert.match(
+    homePageSource,
+    /const refreshHome = useCallback\(\(\) => \{\s*window\.scrollTo\(\{ top: 0, behavior: "auto" \}\);\s*reloadFeed\(\);/
+  );
   assert.match(homePageSource, /const HOME_SEARCH_DESKTOP_PAGE_SIZE = 20;/);
-  assert.match(homePageSource, /const displayCount = isMobile \? MOBILE_COUNT : DESKTOP_COUNT;/);
-  assert.match(homePageSource, /const displayCountRef = useRef\(displayCount\);/);
-  assert.match(homePageSource, /const previousDisplayCountRef = useRef\(displayCount\);/);
-  assert.match(homePageSource, /cachedLatest\.length < displayCountRef\.current/);
+  assert.match(homePageSource, /const HOME_FEED_DESKTOP_BATCH_SIZE = 20;/);
+  assert.match(
+    homePageSource,
+    /const feedBatchSize = isMobile\s*\? MOBILE_VIDEO_PAGE_SIZE\s*:\s*HOME_FEED_DESKTOP_BATCH_SIZE;/
+  );
+  // 推荐流的取数和缓存都收敛到共享的无限滚动 hook 里。
+  assert.doesNotMatch(homePageSource, /cachedRanking|cachedLatest/);
+  assert.doesNotMatch(homePageSource, /fetchHomeVideos|fetchLatestHomeVideos/);
   assert.doesNotMatch(homePageSource, /LATEST_POOL_SIZE|HOME_LATEST_CURSOR_KEY/);
   assert.doesNotMatch(homePageSource, /fetchListing\(1,\s*96/);
   assert.doesNotMatch(homePageSource, /HOME_RECENT_KEY/);
@@ -77,31 +86,16 @@ test("home page refresh button shares back-to-top slot until back-to-top is visi
   assert.match(backToTopSource, /onVisibilityChange\?\.\(nextVisible\)/);
 });
 
-test("home page reuses the cached latest batch when returning from detail", () => {
-  assert.match(homePageSource, /const \[latestVideos,\s*setLatestVideos\] = useState<VideoItem\[\]>\(cachedLatest \?\? \[\]\)/);
-  assert.match(homePageSource, /const \[latestLoading,\s*setLatestLoading\] = useState\(cachedLatest === null\)/);
-  assert.match(homePageSource, /if \(cachedRanking === null\) \{\s*void loadRanking\(false\);/);
-  assert.match(homePageSource, /if \(cachedLatest === null\) \{\s*void loadLatest\(false\);/);
-  assert.match(homePageSource, /else if \(cachedLatest\.length < displayCountRef\.current\) \{\s*void loadLatest\(true\);/);
-  assert.match(homePageSource, /setLatestVideos\(cachedLatest\)/);
+test("home page keeps its recommendation state in the shared feed session", () => {
+  // 返回首页时的续播、去重、中断过期请求都由 useInfiniteListing 负责，
+  // 页面自己不再维护模块级缓存和请求版本号。
+  assert.match(homePageSource, /const homeFeed = useInfiniteListing\(feedSource, \{/);
+  assert.match(homePageSource, /enabled: !hasActiveFilter,/);
+  assert.match(homePageSource, /restoreCount: restoreTarget\.count,/);
+  assert.doesNotMatch(homePageSource, /rankingRequestVersion|latestRequestVersion|homeRequestVersion/);
+  assert.doesNotMatch(homePageSource, /loadRanking|loadLatest|refreshLatest/);
   assert.doesNotMatch(homePageSource, /HOME_CACHE_TTL_MS|cacheIsFresh|cachedRankingAt|cachedLatestAt/);
   assert.doesNotMatch(homePageSource, /localStorage/);
-});
-
-test("widening the viewport refills only the latest section", () => {
-  const effectStart = homePageSource.indexOf(
-    "const previousCount = previousDisplayCountRef.current;"
-  );
-  const effectEnd = homePageSource.indexOf("  useEffect(() => {", effectStart);
-  assert.ok(effectStart >= 0 && effectEnd > effectStart);
-  const wideningEffect = homePageSource.slice(effectStart, effectEnd);
-
-  assert.match(homePageSource, /const rankingRequestVersion = useRef\(0\)/);
-  assert.match(homePageSource, /const latestRequestVersion = useRef\(0\)/);
-  assert.match(homePageSource, /const refreshLatest = useCallback\(\(\) => loadLatest\(true\), \[loadLatest\]\)/);
-  assert.match(wideningEffect, /latestLoading \|\| latestRevalidating/);
-  assert.match(wideningEffect, /void refreshLatest\(\)/);
-  assert.doesNotMatch(wideningEffect, /refreshHome|loadRanking|fetchHomeVideos/);
 });
 
 test("home page reserves tag cloud space while tags load and uses one empty library state", () => {
@@ -219,7 +213,6 @@ test("home page reserves tag cloud space while tags load and uses one empty libr
   assert.doesNotMatch(searchCss, /\.search-panel--uiverse \.search-panel__reset\.is-visible/);
   assert.doesNotMatch(searchCss, /\.search-panel--uiverse \.search-panel__submit\s*\{/);
 
-  assert.match(homePageSource, /const homeLoading = rankingLoading \|\| latestLoading/);
   assert.match(homePageSource, /import \{ AdminEmptyVisual \} from "@\/admin\/AdminEmptyVisual"/);
   assert.doesNotMatch(homePageSource, /const \[searchQuery, setSearchQuery\] = useState\(""\)/);
   assert.match(homePageSource, /const \[searchParams, setSearchParams\] = useSearchParams\(\)/);
@@ -247,17 +240,14 @@ test("home page reserves tag cloud space while tags load and uses one empty libr
   assert.match(homePageSource, /<Pagination[\s\S]*?page=\{displayedSearchPage\}[\s\S]*?pageSize=\{searchSnapshot\.query\.pageSize\}/);
   assert.match(homePageSource, /refreshMode=\{[\s\S]*?searchResult\.transitioning[\s\S]*?"blocking"[\s\S]*?searchResult\.revalidating[\s\S]*?"background"/);
   assert.match(homePageSource, /<ListingLoadError[\s\S]*?displayedPage=\{displayedSearchPage\}/);
-  assert.match(homePageSource, /const hasAnyVideos = ranking\.length > 0 \|\| latest\.length > 0/);
-  assert.match(homePageSource, /const \[latestError, setLatestError\] = useState\(false\)/);
-  assert.match(homePageSource, /const hasHomeError = rankingError \|\| latestError/);
-  assert.match(homePageSource, /const showEmptyHome = !homeLoading && !hasHomeError && !hasAnyVideos/);
-  assert.match(homePageSource, /const homeRequestVersion = useRef\(0\)/);
-  assert.match(homePageSource, /if \(requestVersion !== homeRequestVersion\.current\) return/);
-  assert.match(homePageSource, /emptyText=\{latestError \? "最新视频加载失败，请刷新重试" : undefined\}/);
-  assert.doesNotMatch(homePageSource, /cachedRanking = null;\s*setRankingVideos\(\[\]\);\s*setRankingError\(true\)/);
-  assert.match(homePageSource, /\{hasAnyVideos \|\| hasActiveFilter \? \([\s\S]*?<TagCloud linkBasePath="\/" \/>[\s\S]*?<div className="tag-cloud-container is-reserved" aria-hidden="true" \/>/);
-  assert.match(homePageSource, /<SectionHeader title="随机推荐" \/>/);
-  assert.match(homePageSource, /<SectionHeader title="最新视频" \/>/);
+  assert.match(homePageSource, /const feedHasContent = feedItems\.length > 0/);
+  assert.match(
+    homePageSource,
+    /\{feedHasContent \|\| hasActiveFilter \? \([\s\S]*?<TagCloud linkBasePath="\/" \/>[\s\S]*?<div className="tag-cloud-container is-reserved" aria-hidden="true" \/>/
+  );
+  // 两个推荐列表改成一个 tab 栏，不再各占一个 section。
+  assert.match(homePageSource, /<HomeFeedTabs\s+feed=\{feed\}/);
+  assert.doesNotMatch(homePageSource, /<SectionHeader/);
   assert.doesNotMatch(homePageSource, /随机展示/);
   assert.doesNotMatch(homePageSource, /共 \$\{latest\.length\} 个/);
   assert.match(homePageSource, /className="container page-section home-discovery-section"/);

--- a/tests/homeRefreshButton.test.ts
+++ b/tests/homeRefreshButton.test.ts
@@ -112,7 +112,7 @@ test("home page reserves tag cloud space while tags load and uses one empty libr
   assert.match(tagCloudSource, /type TagCloudProps = \{/);
   assert.match(tagCloudSource, /linkBasePath\?: string;/);
   assert.match(tagCloudSource, /onTagSelect\?: \(\) => void;/);
-  assert.match(tagCloudSource, /export function TagCloud\(\{ linkBasePath = "\/list", onTagSelect \}: TagCloudProps\)/);
+  assert.match(tagCloudSource, /export const TagCloud = memo\(function TagCloud\(\{[\s\S]*?linkBasePath = "\/list",[\s\S]*?onTagSelect,[\s\S]*?\}: TagCloudProps\)/);
   assert.match(tagCloudSource, /to=\{buildTagHref\(tag\.label\)\}/);
   assert.match(tagCloudSource, /onClick=\{onTagSelect\}/);
   assert.match(tagCloudSource, /const \[hasMoreRight, setHasMoreRight\] = useState\(false\)/);
@@ -233,8 +233,8 @@ test("home page reserves tag cloud space while tags load and uses one empty libr
   assert.match(homePageSource, /const hasActiveFilter = hasActiveSearch \|\| hasActiveTag/);
   assert.doesNotMatch(homePageSource, /搜索结果：/);
   assert.match(homePageSource, /<SortToolbar[\s\S]*?sort=\{displayedSearchSort\}[\s\S]*?view=\{searchView\}/);
-  assert.match(homePageSource, /withListingNavigation\(searchParams,[\s\S]*?sort: nextSort,[\s\S]*?page: 1/);
-  assert.match(homePageSource, /withListingView\(searchParams, nextView\)/);
+  assert.match(homePageSource, /withListingNavigation\(current, \{ sort: nextSort, page: 1 \}\)/);
+  assert.match(homePageSource, /withListingView\(current, nextView\)/);
   assert.match(homePageSource, /compact=\{searchView === "compact"\}/);
   assert.match(homePageSource, /variant="no-results"[\s\S]*?text="未查询到"[\s\S]*?className="admin-empty-state admin-empty-state--plain home-empty-state"/);
   assert.match(homePageSource, /<Pagination[\s\S]*?page=\{displayedSearchPage\}[\s\S]*?pageSize=\{searchSnapshot\.query\.pageSize\}/);

--- a/tests/infiniteFeedSource.test.ts
+++ b/tests/infiniteFeedSource.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HOME_RECOMMENDATION_BATCH_SIZE,
+  homeLatestFeedSource,
+  homeRecommendationFeedSource,
+  listingFeedSource,
+  listingPageFromOffset,
+} from "../src/lib/infiniteFeedSource.ts";
+
+function stubFetch(
+  t: { after: (fn: () => void) => void },
+  respond: (path: string) => unknown
+) {
+  const requested: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const path = String(input);
+    requested.push(path);
+    return new Response(JSON.stringify(respond(path)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  return requested;
+}
+
+test("a page/size offset only maps to a page on a batch boundary", () => {
+  assert.equal(listingPageFromOffset(0, 20), 1);
+  assert.equal(listingPageFromOffset(20, 20), 2);
+  assert.equal(listingPageFromOffset(120, 20), 7);
+  assert.equal(
+    listingPageFromOffset(25, 20),
+    null,
+    "错位的偏移量用 page/size 表达不了，必须暴露出来而不是悄悄取整"
+  );
+  assert.equal(listingPageFromOffset(-20, 20), null);
+  assert.equal(listingPageFromOffset(20, 0), null);
+});
+
+test("the listing feed asks the list endpoint for the matching page", async (t) => {
+  const requested = stubFetch(t, () => ({ items: [{ id: "v1" }], total: 90 }));
+  const source = listingFeedSource({
+    q: "猫",
+    tag: "剧情",
+    sort: "latest",
+    pageSize: 20,
+  });
+
+  assert.equal(source.batchSize, 20);
+  assert.equal(source.supportsRestore, true);
+  assert.equal(source.stopOnDuplicateBatch, undefined);
+
+  const batch = await source.fetchBatch(
+    { offset: 40, size: 20 },
+    { signal: new AbortController().signal }
+  );
+
+  assert.deepEqual(batch, { items: [{ id: "v1" }], total: 90 });
+  assert.equal(requested.length, 1);
+  assert.match(requested[0], /^\/api\/list\?/);
+  const query = new URLSearchParams(requested[0].split("?")[1]);
+  assert.equal(query.get("page"), "3");
+  assert.equal(query.get("size"), "20");
+  assert.equal(query.get("q"), "猫");
+  assert.equal(query.get("tag"), "剧情");
+  assert.equal(query.get("sort"), "latest");
+});
+
+test("a misaligned listing offset fails loudly instead of silently skipping videos", async (t) => {
+  const requested = stubFetch(t, () => ({ items: [], total: 0 }));
+  const source = listingFeedSource({ q: "", tag: "", sort: "hot", pageSize: 20 });
+
+  await assert.rejects(
+    source.fetchBatch(
+      { offset: 25, size: 20 },
+      { signal: new AbortController().signal }
+    ),
+    /not aligned/
+  );
+  assert.equal(requested.length, 0);
+});
+
+test("the random recommendation feed rotates within the server's per-request cap", async (t) => {
+  const requested = stubFetch(t, () => [{ id: "r1" }]);
+  const source = homeRecommendationFeedSource();
+
+  assert.equal(source.batchSize, HOME_RECOMMENDATION_BATCH_SIZE);
+  // 轮换游标在服务端且不幂等，补不回原来那批视频。
+  assert.equal(source.supportsRestore, false);
+  assert.equal(source.stopOnDuplicateBatch, true);
+
+  const batch = await source.fetchBatch(
+    { offset: 240, size: 40 },
+    { signal: new AbortController().signal }
+  );
+
+  assert.deepEqual(batch, { items: [{ id: "r1" }], total: 0 });
+  assert.deepEqual(
+    requested,
+    [`/api/home?count=${HOME_RECOMMENDATION_BATCH_SIZE}`],
+    "超过后端单次上限会被直接拒绝，这里必须先夹住"
+  );
+});
+
+test("the home latest feed pages through the list endpoint, not the capped home rotation", async (t) => {
+  const requested = stubFetch(t, () => ({ items: [], total: 300 }));
+  const source = homeLatestFeedSource(20);
+
+  assert.equal(source.key, "home:latest:20");
+  assert.notEqual(
+    source.key,
+    listingFeedSource({ q: "", tag: "", sort: "latest", pageSize: 20 }).key,
+    "首页和列表页各自累积，互不干扰"
+  );
+  assert.equal(source.supportsRestore, true);
+
+  await source.fetchBatch(
+    { offset: 60, size: 20 },
+    { signal: new AbortController().signal }
+  );
+
+  // /api/home/latest 单次上限 12 条且只在最新 96 条里绕圈，撑不起无限滚动。
+  assert.equal(requested.length, 1);
+  assert.doesNotMatch(requested[0], /\/api\/home/);
+  const query = new URLSearchParams(requested[0].split("?")[1]);
+  assert.equal(query.get("page"), "4");
+  assert.equal(query.get("sort"), "latest");
+});

--- a/tests/infiniteFeedSource.test.ts
+++ b/tests/infiniteFeedSource.test.ts
@@ -5,19 +5,22 @@ import {
   homeLatestFeedSource,
   homeRecommendationFeedSource,
   listingFeedSource,
-  listingPageFromOffset,
 } from "../src/lib/infiniteFeedSource.ts";
+
+type RecordedRequest = { path: string; init?: RequestInit };
 
 function stubFetch(
   t: { after: (fn: () => void) => void },
-  respond: (path: string) => unknown
+  respond: (path: string, init?: RequestInit) => unknown
 ) {
-  const requested: string[] = [];
+  const requested: RecordedRequest[] = [];
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (input: RequestInfo | URL) => {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const path = String(input);
-    requested.push(path);
-    return new Response(JSON.stringify(respond(path)), {
+    requested.push({ path, init });
+    const response = await respond(path, init);
+    if (response instanceof Response) return response;
+    return new Response(JSON.stringify(response), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -28,105 +31,196 @@ function stubFetch(
   return requested;
 }
 
-test("a page/size offset only maps to a page on a batch boundary", () => {
-  assert.equal(listingPageFromOffset(0, 20), 1);
-  assert.equal(listingPageFromOffset(20, 20), 2);
-  assert.equal(listingPageFromOffset(120, 20), 7);
-  assert.equal(
-    listingPageFromOffset(25, 20),
-    null,
-    "错位的偏移量用 page/size 表达不了，必须暴露出来而不是悄悄取整"
-  );
-  assert.equal(listingPageFromOffset(-20, 20), null);
-  assert.equal(listingPageFromOffset(20, 0), null);
-});
+function feedResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    items: [{ id: "v1" }],
+    total: 90,
+    feedToken: "snapshot-token",
+    nextCursor: 20,
+    exhausted: false,
+    ...overrides,
+  };
+}
 
-test("the listing feed asks the list endpoint for the matching page", async (t) => {
-  const requested = stubFetch(t, () => ({ items: [{ id: "v1" }], total: 90 }));
+test("the listing feed creates a filtered snapshot instead of translating offsets to pages", async (t) => {
+  const requested = stubFetch(t, () => feedResponse());
   const source = listingFeedSource({
-    q: "猫",
-    tag: "剧情",
+    q: " 猫 ",
+    tag: " 剧情 ",
     sort: "latest",
     pageSize: 20,
   });
 
   assert.equal(source.batchSize, 20);
-  assert.equal(source.supportsRestore, true);
-  assert.equal(source.stopOnDuplicateBatch, undefined);
+  assert.equal(
+    source.key,
+    listingFeedSource({ q: "猫", tag: "剧情", sort: "latest", pageSize: 14 }).key,
+    "响应式批次大小不能改变逻辑列表身份"
+  );
 
   const batch = await source.fetchBatch(
-    { offset: 40, size: 20 },
+    { cursor: { feedToken: "", position: 0 }, size: 20 },
     { signal: new AbortController().signal }
   );
 
-  assert.deepEqual(batch, { items: [{ id: "v1" }], total: 90 });
+  assert.deepEqual(batch, {
+    items: [{ id: "v1" }],
+    total: 90,
+    cursor: { feedToken: "snapshot-token", position: 20 },
+    exhausted: false,
+  });
   assert.equal(requested.length, 1);
-  assert.match(requested[0], /^\/api\/list\?/);
-  const query = new URLSearchParams(requested[0].split("?")[1]);
-  assert.equal(query.get("page"), "3");
-  assert.equal(query.get("size"), "20");
+  assert.match(requested[0].path, /^\/api\/feed\?/);
+  const query = new URLSearchParams(requested[0].path.split("?")[1]);
+  assert.equal(query.get("kind"), "listing");
+  assert.equal(query.get("cursor"), "0");
+  assert.equal(query.get("count"), "20");
   assert.equal(query.get("q"), "猫");
   assert.equal(query.get("tag"), "剧情");
   assert.equal(query.get("sort"), "latest");
+  assert.equal(query.has("page"), false);
 });
 
-test("a misaligned listing offset fails loudly instead of silently skipping videos", async (t) => {
-  const requested = stubFetch(t, () => ({ items: [], total: 0 }));
+test("later batches explicitly address the same token and cursor", async (t) => {
+  const requested = stubFetch(t, () =>
+    feedResponse({ items: [{ id: "v3" }], nextCursor: 60 })
+  );
   const source = listingFeedSource({ q: "", tag: "", sort: "hot", pageSize: 20 });
 
-  await assert.rejects(
-    source.fetchBatch(
-      { offset: 25, size: 20 },
-      { signal: new AbortController().signal }
-    ),
-    /not aligned/
-  );
-  assert.equal(requested.length, 0);
-});
-
-test("the random recommendation feed rotates within the server's per-request cap", async (t) => {
-  const requested = stubFetch(t, () => [{ id: "r1" }]);
-  const source = homeRecommendationFeedSource();
-
-  assert.equal(source.batchSize, HOME_RECOMMENDATION_BATCH_SIZE);
-  // 轮换游标在服务端且不幂等，补不回原来那批视频。
-  assert.equal(source.supportsRestore, false);
-  assert.equal(source.stopOnDuplicateBatch, true);
-
-  const batch = await source.fetchBatch(
-    { offset: 240, size: 40 },
+  await source.fetchBatch(
+    { cursor: { feedToken: "snapshot-token", position: 40 }, size: 20 },
     { signal: new AbortController().signal }
   );
 
-  assert.deepEqual(batch, { items: [{ id: "r1" }], total: 0 });
-  assert.deepEqual(
-    requested,
-    [`/api/home?count=${HOME_RECOMMENDATION_BATCH_SIZE}`],
-    "超过后端单次上限会被直接拒绝，这里必须先夹住"
+  const query = new URLSearchParams(requested[0].path.split("?")[1]);
+  assert.equal(query.get("feedToken"), "snapshot-token");
+  assert.equal(query.get("cursor"), "40");
+  assert.equal(query.get("count"), "20");
+});
+
+test("a feed completed by its first batch does not need a snapshot token", async (t) => {
+  stubFetch(t, () =>
+    feedResponse({
+      items: [{ id: "only-result" }],
+      total: 1,
+      feedToken: "",
+      nextCursor: 1,
+      exhausted: true,
+    })
+  );
+  const source = listingFeedSource({
+    q: "only-result",
+    tag: "",
+    sort: "latest",
+    pageSize: 20,
+  });
+
+  const batch = await source.fetchBatch(
+    { cursor: { feedToken: "", position: 0 }, size: 20 },
+    { signal: new AbortController().signal }
+  );
+
+  assert.equal(batch.exhausted, true);
+  assert.deepEqual(batch.cursor, { feedToken: "", position: 1 });
+});
+
+test("a feed with another batch still requires a snapshot token", async (t) => {
+  stubFetch(t, () => feedResponse({ feedToken: "" }));
+  const source = listingFeedSource({
+    q: "",
+    tag: "",
+    sort: "latest",
+    pageSize: 20,
+  });
+
+  await assert.rejects(
+    source.fetchBatch(
+      { cursor: { feedToken: "", position: 0 }, size: 20 },
+      { signal: new AbortController().signal }
+    ),
+    /Invalid \/api\/feed response/
   );
 });
 
-test("the home latest feed pages through the list endpoint, not the capped home rotation", async (t) => {
-  const requested = stubFetch(t, () => ({ items: [], total: 300 }));
+test("the random recommendation feed is a restorable shuffled snapshot", async (t) => {
+  const requested = stubFetch(t, () =>
+    feedResponse({ total: 300, nextCursor: 48 })
+  );
+  const source = homeRecommendationFeedSource();
+
+  assert.equal(source.key, "home:recommend");
+  assert.equal(source.batchSize, HOME_RECOMMENDATION_BATCH_SIZE);
+  await source.fetchBatch(
+    { cursor: { feedToken: "snapshot-token", position: 36 }, size: 12 },
+    { signal: new AbortController().signal }
+  );
+
+  const query = new URLSearchParams(requested[0].path.split("?")[1]);
+  assert.equal(query.get("kind"), "recommend");
+  assert.equal(query.get("feedToken"), "snapshot-token");
+  assert.equal(query.get("cursor"), "36");
+  assert.equal(query.get("count"), "12");
+  assert.doesNotMatch(requested[0].path, /\/api\/home/);
+});
+
+test("the home latest feed keeps its identity when its responsive batch changes", async (t) => {
+  const requested = stubFetch(t, () =>
+    feedResponse({ items: [], total: 300, nextCursor: 80 })
+  );
   const source = homeLatestFeedSource(20);
 
-  assert.equal(source.key, "home:latest:20");
+  assert.equal(source.key, "home:latest");
+  assert.equal(source.key, homeLatestFeedSource(14).key);
   assert.notEqual(
     source.key,
     listingFeedSource({ q: "", tag: "", sort: "latest", pageSize: 20 }).key,
     "首页和列表页各自累积，互不干扰"
   );
-  assert.equal(source.supportsRestore, true);
 
   await source.fetchBatch(
-    { offset: 60, size: 20 },
+    { cursor: { feedToken: "snapshot-token", position: 60 }, size: 20 },
     { signal: new AbortController().signal }
   );
-
-  // /api/home/latest 单次上限 12 条且只在最新 96 条里绕圈，撑不起无限滚动。
-  assert.equal(requested.length, 1);
-  assert.doesNotMatch(requested[0], /\/api\/home/);
-  const query = new URLSearchParams(requested[0].split("?")[1]);
-  assert.equal(query.get("page"), "4");
+  const query = new URLSearchParams(requested[0].path.split("?")[1]);
+  assert.equal(query.get("kind"), "latest");
   assert.equal(query.get("sort"), "latest");
+});
+
+test("an expired snapshot is exposed as a feed-specific error", async (t) => {
+  stubFetch(t, () => new Response("expired", { status: 410 }));
+  const source = homeLatestFeedSource(20);
+
+  const error = await source
+    .fetchBatch(
+      { cursor: { feedToken: "expired-token", position: 20 }, size: 20 },
+      { signal: new AbortController().signal }
+    )
+    .then(
+      () => null,
+      (reason) => reason
+    );
+  assert.ok(error instanceof Error);
+  assert.equal(source.isExpiredError(error), true);
+});
+
+test("aborting a discarded feed request reaches the actual fetch", async (t) => {
+  let fetchSignal: AbortSignal | undefined;
+  stubFetch(t, (_path, init) => {
+    fetchSignal = init?.signal ?? undefined;
+    return new Promise((_resolve, reject) => {
+      fetchSignal?.addEventListener("abort", () => reject(fetchSignal?.reason), {
+        once: true,
+      });
+    });
+  });
+  const source = homeRecommendationFeedSource();
+  const controller = new AbortController();
+  const request = source.fetchBatch(
+    { cursor: { feedToken: "", position: 0 }, size: 12 },
+    { signal: controller.signal }
+  );
+  controller.abort(new DOMException("discarded", "AbortError"));
+
+  await assert.rejects(request, { name: "AbortError" });
+  assert.equal(fetchSignal?.aborted, true);
 });

--- a/tests/infiniteListing.test.ts
+++ b/tests/infiniteListing.test.ts
@@ -3,16 +3,17 @@ import test from "node:test";
 import {
   appendUniqueVideos,
   emptyInfiniteListingState,
+  infiniteListingCacheMatchesRestore,
   infiniteListingHasMore,
   infiniteListingKey,
   infiniteListingReducer,
-  isListingExhausted,
   nextListingRequest,
   type InfiniteListingState,
 } from "../src/lib/infiniteListing.ts";
 import type { VideoItem } from "../src/types.ts";
 
-const KEY = infiniteListingKey({ q: "", tag: "", sort: "hot", pageSize: 20 });
+const KEY = infiniteListingKey({ q: "", tag: "", sort: "hot" });
+const FEED_TOKEN = "feed-token";
 
 function videos(from: number, count: number): VideoItem[] {
   return Array.from(
@@ -27,6 +28,7 @@ function loaded(overrides: Partial<InfiniteListingState> = {}): InfiniteListingS
     requestID: 1,
     items: videos(0, 20),
     total: 100,
+    feedToken: FEED_TOKEN,
     requestedCount: 20,
     status: "ready",
     receivedAt: 1_000,
@@ -34,18 +36,60 @@ function loaded(overrides: Partial<InfiniteListingState> = {}): InfiniteListingS
   };
 }
 
-test("the listing key normalizes whitespace so equivalent queries share one session", () => {
+test("the listing key normalizes whitespace and contains only logical filters", () => {
   assert.equal(
-    infiniteListingKey({ q: " 猫 ", tag: " 剧情 ", sort: "latest", pageSize: 20 }),
-    infiniteListingKey({ q: "猫", tag: "剧情", sort: "latest", pageSize: 20 })
+    infiniteListingKey({ q: " 猫 ", tag: " 剧情 ", sort: "latest" }),
+    infiniteListingKey({ q: "猫", tag: "剧情", sort: "latest" })
   );
   assert.notEqual(
-    infiniteListingKey({ q: "", tag: "", sort: "latest", pageSize: 20 }),
-    infiniteListingKey({ q: "", tag: "", sort: "latest", pageSize: 14 })
+    infiniteListingKey({ q: "", tag: "", sort: "latest" }),
+    infiniteListingKey({ q: "", tag: "", sort: "hot" })
   );
 });
 
-test("appending drops ids that are already on screen", () => {
+test("history restoration only accepts a compatible snapshot cache", () => {
+  assert.equal(
+    infiniteListingCacheMatchesRestore({
+      cachedFeedToken: "snapshot-a",
+      cachedRequestedCount: 80,
+      restoreFeedToken: "snapshot-a",
+      restoreCount: 60,
+    }),
+    true
+  );
+  assert.equal(
+    infiniteListingCacheMatchesRestore({
+      cachedFeedToken: "snapshot-b",
+      cachedRequestedCount: 80,
+      restoreFeedToken: "snapshot-a",
+      restoreCount: 60,
+    }),
+    false,
+    "同一查询的新快照不能覆盖旧历史条目的内容"
+  );
+  assert.equal(
+    infiniteListingCacheMatchesRestore({
+      cachedFeedToken: "snapshot-a",
+      cachedRequestedCount: 20,
+      restoreFeedToken: "snapshot-a",
+      restoreCount: 60,
+    }),
+    false,
+    "缓存深度不足时必须按保存的 token 补回内容"
+  );
+  assert.equal(
+    infiniteListingCacheMatchesRestore({
+      cachedFeedToken: "snapshot-b",
+      cachedRequestedCount: 20,
+      restoreFeedToken: "",
+      restoreCount: 0,
+    }),
+    true,
+    "普通新会话仍可复用查询级缓存"
+  );
+});
+
+test("appending defensively drops ids that are already on screen", () => {
   const previous = videos(0, 3);
   const merged = appendUniqueVideos(previous, [
     ...videos(2, 1),
@@ -64,31 +108,35 @@ test("appending drops ids that are already on screen", () => {
   assert.strictEqual(appendUniqueVideos(previous, []), previous);
 });
 
-test("a batch that overlaps the previous page is deduplicated on append", () => {
+test("a successful batch adopts the server cursor independently of rendered item count", () => {
   const state = loaded();
-  // 列表期间新入库一条视频，第二页整体后移一位，边界那条会重复返回。
   const next = infiniteListingReducer(state, {
     type: "load-success",
     requestID: 1,
-    offset: 20,
-    batchSize: 20,
+    requestCursor: { feedToken: FEED_TOKEN, position: 20 },
+    cursor: { feedToken: FEED_TOKEN, position: 43 },
     items: [...videos(19, 1), ...videos(20, 19)],
     total: 100,
+    exhausted: false,
     receivedAt: 2_000,
   });
 
   assert.equal(next.items.length, 39);
   assert.equal(new Set(next.items.map((item) => item.id)).size, 39);
-  assert.equal(next.requestedCount, 40, "游标按请求条数推进，不受去重影响");
+  assert.equal(
+    next.requestedCount,
+    43,
+    "服务端可能跳过已隐藏的快照项，游标不能按收到或去重后的条数推算"
+  );
   assert.equal(next.exhausted, false);
   assert.equal(next.status, "ready");
 });
 
 test("loading starts as initial for an empty list and as load-more once items exist", () => {
-  const first = infiniteListingReducer(
-    emptyInfiniteListingState(KEY, 20),
-    { type: "load-start", requestID: 1 }
-  );
+  const first = infiniteListingReducer(emptyInfiniteListingState(KEY, 20), {
+    type: "load-start",
+    requestID: 1,
+  });
   assert.equal(first.status, "initial-loading");
 
   const more = infiniteListingReducer(loaded(), {
@@ -101,14 +149,14 @@ test("loading starts as initial for an empty list and as load-more once items ex
 
 test("stale responses cannot append to a newer request", () => {
   const state = loaded({ requestID: 5 });
-
   const lateSuccess = infiniteListingReducer(state, {
     type: "load-success",
     requestID: 4,
-    offset: 20,
-    batchSize: 20,
+    requestCursor: { feedToken: FEED_TOKEN, position: 20 },
+    cursor: { feedToken: FEED_TOKEN, position: 40 },
     items: videos(20, 20),
     total: 100,
+    exhausted: false,
     receivedAt: 2_000,
   });
   const lateFailure = infiniteListingReducer(state, {
@@ -121,66 +169,67 @@ test("stale responses cannot append to a newer request", () => {
   assert.strictEqual(lateFailure, state);
 });
 
-test("a response whose offset no longer matches the cursor is discarded", () => {
+test("a response for a different snapshot position is discarded", () => {
   const state = loaded({ requestID: 3, requestedCount: 40, items: videos(0, 40) });
-
-  const misaligned = infiniteListingReducer(state, {
+  const wrongPosition = infiniteListingReducer(state, {
     type: "load-success",
     requestID: 3,
-    offset: 20,
-    batchSize: 20,
+    requestCursor: { feedToken: FEED_TOKEN, position: 20 },
+    cursor: { feedToken: FEED_TOKEN, position: 40 },
     items: videos(20, 20),
     total: 100,
+    exhausted: false,
+    receivedAt: 2_000,
+  });
+  const wrongToken = infiniteListingReducer(state, {
+    type: "load-success",
+    requestID: 3,
+    requestCursor: { feedToken: "other-feed", position: 40 },
+    cursor: { feedToken: "other-feed", position: 60 },
+    items: videos(40, 20),
+    total: 100,
+    exhausted: false,
     receivedAt: 2_000,
   });
 
-  assert.strictEqual(misaligned, state);
+  assert.strictEqual(wrongPosition, state);
+  assert.strictEqual(wrongToken, state);
 });
 
-test("the list stops loading on a short page and on a reached total", () => {
-  const shortPage = infiniteListingReducer(loaded(), {
+test("exhaustion comes from the snapshot server, not short-page guesses", () => {
+  const skippedRows = infiniteListingReducer(loaded(), {
     type: "load-success",
     requestID: 1,
-    offset: 20,
-    batchSize: 20,
+    requestCursor: { feedToken: FEED_TOKEN, position: 20 },
+    cursor: { feedToken: FEED_TOKEN, position: 45 },
     items: videos(20, 7),
     total: 100,
+    exhausted: false,
     receivedAt: 2_000,
   });
-  assert.equal(shortPage.exhausted, true);
-  assert.equal(infiniteListingHasMore(shortPage), false);
-  assert.equal(nextListingRequest(shortPage), null);
+  assert.equal(skippedRows.exhausted, false);
+  assert.equal(infiniteListingHasMore(skippedRows), true);
 
-  const reachedTotal = infiniteListingReducer(loaded({ total: 40 }), {
+  const final = infiniteListingReducer(loaded(), {
     type: "load-success",
     requestID: 1,
-    offset: 20,
-    batchSize: 20,
-    items: videos(20, 20),
-    total: 40,
+    requestCursor: { feedToken: FEED_TOKEN, position: 20 },
+    cursor: { feedToken: FEED_TOKEN, position: 100 },
+    items: videos(20, 7),
+    total: 100,
+    exhausted: true,
     receivedAt: 2_000,
   });
-  assert.equal(reachedTotal.exhausted, true);
-
-  // total 只是查询时刻的计数，删除后会虚高；返回满页时不能提前收尾。
-  assert.equal(
-    isListingExhausted({
-      received: 20,
-      added: 20,
-      batchSize: 20,
-      requestedCount: 40,
-      total: 0,
-    }),
-    false
-  );
+  assert.equal(final.exhausted, true);
+  assert.equal(infiniteListingHasMore(final), false);
+  assert.equal(nextListingRequest(final), null);
 });
 
-test("a failed batch keeps the loaded items and stops auto-loading", () => {
-  const failed = infiniteListingReducer(loaded({ requestID: 2, status: "loading-more" }), {
-    type: "load-failure",
-    requestID: 2,
-    error: new Error("offline"),
-  });
+test("a failed batch keeps loaded items and stops automatic loading", () => {
+  const failed = infiniteListingReducer(
+    loaded({ requestID: 2, status: "loading-more" }),
+    { type: "load-failure", requestID: 2, error: new Error("offline") }
+  );
 
   assert.equal(failed.status, "error");
   assert.equal(failed.items.length, 20);
@@ -188,67 +237,24 @@ test("a failed batch keeps the loaded items and stops auto-loading", () => {
   assert.equal(infiniteListingHasMore(failed), false);
 });
 
-test("the next request continues from the requested count", () => {
-  assert.deepEqual(nextListingRequest(loaded()), { offset: 20, size: 20 });
-  assert.deepEqual(nextListingRequest(loaded({ requestedCount: 120 })), {
-    offset: 120,
+test("the next request carries the exact token and cursor with the current batch size", () => {
+  assert.deepEqual(nextListingRequest(loaded()), {
+    cursor: { feedToken: FEED_TOKEN, position: 20 },
     size: 20,
   });
-  assert.equal(nextListingRequest(loaded({ pageSize: 0 })), null);
-  assert.equal(
-    nextListingRequest(loaded({ exhausted: true })),
-    null,
-    "收尾之后不再有下一批"
+  assert.deepEqual(
+    nextListingRequest(loaded({ pageSize: 14, requestedCount: 120 })),
+    { cursor: { feedToken: FEED_TOKEN, position: 120 }, size: 14 }
   );
+  assert.equal(nextListingRequest(loaded({ pageSize: 0 })), null);
+  assert.equal(nextListingRequest(loaded({ exhausted: true })), null);
   assert.deepEqual(nextListingRequest(emptyInfiniteListingState(KEY, 14)), {
-    offset: 0,
+    cursor: { feedToken: "", position: 0 },
     size: 14,
   });
 });
 
-test("a rotating feed stops once a whole batch is already on screen", () => {
-  const rotating = loaded({ total: 0 });
-  const repeated = infiniteListingReducer(rotating, {
-    type: "load-success",
-    requestID: 1,
-    offset: 20,
-    batchSize: 20,
-    items: videos(0, 20),
-    total: 0,
-    receivedAt: 2_000,
-    stopOnDuplicateBatch: true,
-  });
-
-  assert.equal(repeated.items.length, 20, "整批都是重复内容，列表没有增长");
-  assert.equal(repeated.exhausted, true);
-
-  // 分页 feed 的页边界会随新入库内容移动，重复一整页不代表到底了。
-  const pagedRepeat = infiniteListingReducer(rotating, {
-    type: "load-success",
-    requestID: 1,
-    offset: 20,
-    batchSize: 20,
-    items: videos(0, 20),
-    total: 0,
-    receivedAt: 2_000,
-  });
-  assert.equal(pagedRepeat.exhausted, false);
-
-  assert.equal(
-    isListingExhausted({
-      received: 20,
-      added: 5,
-      batchSize: 20,
-      requestedCount: 40,
-      total: 0,
-      stopOnDuplicateBatch: true,
-    }),
-    false,
-    "还有新内容就继续转"
-  );
-});
-
-test("changing the query resets accumulation and cached content hydrates as ready", () => {
+test("changing the query resets accumulation and cached content hydrates with its snapshot", () => {
   const reset = infiniteListingReducer(loaded(), {
     type: "reset",
     requestID: 9,
@@ -258,6 +264,7 @@ test("changing the query resets accumulation and cached content hydrates as read
   assert.equal(reset.key, "other");
   assert.equal(reset.pageSize, 14);
   assert.equal(reset.items.length, 0);
+  assert.equal(reset.feedToken, "");
   assert.equal(reset.requestedCount, 0);
   assert.equal(reset.exhausted, false);
   assert.equal(reset.status, "idle");
@@ -266,25 +273,26 @@ test("changing the query resets accumulation and cached content hydrates as read
     type: "hydrate",
     requestID: 10,
     key: KEY,
-    pageSize: 20,
+    pageSize: 14,
     items: videos(0, 60),
     total: 100,
-    requestedCount: 60,
+    feedToken: FEED_TOKEN,
+    requestedCount: 63,
     exhausted: false,
     receivedAt: 5_000,
   });
   assert.equal(hydrated.status, "ready");
+  assert.equal(hydrated.pageSize, 14);
   assert.equal(hydrated.items.length, 60);
-  assert.equal(hydrated.requestedCount, 60);
-  assert.equal(
-    hydrated.receivedAt,
-    5_000,
-    "hydrate 保留原始响应时间，缓存不会自我续命"
-  );
+  assert.equal(hydrated.feedToken, FEED_TOKEN);
+  assert.equal(hydrated.requestedCount, 63);
+  assert.equal(hydrated.receivedAt, 5_000);
 
   const disabled = infiniteListingReducer(loaded(), {
     type: "disable",
     requestID: 11,
+    key: KEY,
+    pageSize: 20,
   });
   assert.equal(disabled.status, "idle");
   assert.equal(disabled.items.length, 0);

--- a/tests/infiniteListing.test.ts
+++ b/tests/infiniteListing.test.ts
@@ -166,6 +166,7 @@ test("the list stops loading on a short page and on a reached total", () => {
   assert.equal(
     isListingExhausted({
       received: 20,
+      added: 20,
       batchSize: 20,
       requestedCount: 40,
       total: 0,
@@ -187,22 +188,63 @@ test("a failed batch keeps the loaded items and stops auto-loading", () => {
   assert.equal(infiniteListingHasMore(failed), false);
 });
 
-test("the next request continues on a page boundary derived from requested count", () => {
-  assert.deepEqual(nextListingRequest(loaded()), { page: 2, size: 20 });
-  assert.deepEqual(
-    nextListingRequest(loaded({ requestedCount: 120 })),
-    { page: 7, size: 20 },
-    "恢复现场后的大请求也必须落在页边界上"
-  );
-  assert.equal(
-    nextListingRequest(loaded({ requestedCount: 25 })),
-    null,
-    "偏移量不是页大小整数倍时无法用 page/size 表达"
-  );
+test("the next request continues from the requested count", () => {
+  assert.deepEqual(nextListingRequest(loaded()), { offset: 20, size: 20 });
+  assert.deepEqual(nextListingRequest(loaded({ requestedCount: 120 })), {
+    offset: 120,
+    size: 20,
+  });
   assert.equal(nextListingRequest(loaded({ pageSize: 0 })), null);
-  assert.deepEqual(
-    nextListingRequest(emptyInfiniteListingState(KEY, 14)),
-    { page: 1, size: 14 }
+  assert.equal(
+    nextListingRequest(loaded({ exhausted: true })),
+    null,
+    "收尾之后不再有下一批"
+  );
+  assert.deepEqual(nextListingRequest(emptyInfiniteListingState(KEY, 14)), {
+    offset: 0,
+    size: 14,
+  });
+});
+
+test("a rotating feed stops once a whole batch is already on screen", () => {
+  const rotating = loaded({ total: 0 });
+  const repeated = infiniteListingReducer(rotating, {
+    type: "load-success",
+    requestID: 1,
+    offset: 20,
+    batchSize: 20,
+    items: videos(0, 20),
+    total: 0,
+    receivedAt: 2_000,
+    stopOnDuplicateBatch: true,
+  });
+
+  assert.equal(repeated.items.length, 20, "整批都是重复内容，列表没有增长");
+  assert.equal(repeated.exhausted, true);
+
+  // 分页 feed 的页边界会随新入库内容移动，重复一整页不代表到底了。
+  const pagedRepeat = infiniteListingReducer(rotating, {
+    type: "load-success",
+    requestID: 1,
+    offset: 20,
+    batchSize: 20,
+    items: videos(0, 20),
+    total: 0,
+    receivedAt: 2_000,
+  });
+  assert.equal(pagedRepeat.exhausted, false);
+
+  assert.equal(
+    isListingExhausted({
+      received: 20,
+      added: 5,
+      batchSize: 20,
+      requestedCount: 40,
+      total: 0,
+      stopOnDuplicateBatch: true,
+    }),
+    false,
+    "还有新内容就继续转"
   );
 });
 

--- a/tests/infiniteListing.test.ts
+++ b/tests/infiniteListing.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  appendUniqueVideos,
+  emptyInfiniteListingState,
+  infiniteListingHasMore,
+  infiniteListingKey,
+  infiniteListingReducer,
+  isListingExhausted,
+  nextListingRequest,
+  type InfiniteListingState,
+} from "../src/lib/infiniteListing.ts";
+import type { VideoItem } from "../src/types.ts";
+
+const KEY = infiniteListingKey({ q: "", tag: "", sort: "hot", pageSize: 20 });
+
+function videos(from: number, count: number): VideoItem[] {
+  return Array.from(
+    { length: count },
+    (_, index) => ({ id: `video-${from + index}` } as VideoItem)
+  );
+}
+
+function loaded(overrides: Partial<InfiniteListingState> = {}): InfiniteListingState {
+  return {
+    ...emptyInfiniteListingState(KEY, 20),
+    requestID: 1,
+    items: videos(0, 20),
+    total: 100,
+    requestedCount: 20,
+    status: "ready",
+    receivedAt: 1_000,
+    ...overrides,
+  };
+}
+
+test("the listing key normalizes whitespace so equivalent queries share one session", () => {
+  assert.equal(
+    infiniteListingKey({ q: " 猫 ", tag: " 剧情 ", sort: "latest", pageSize: 20 }),
+    infiniteListingKey({ q: "猫", tag: "剧情", sort: "latest", pageSize: 20 })
+  );
+  assert.notEqual(
+    infiniteListingKey({ q: "", tag: "", sort: "latest", pageSize: 20 }),
+    infiniteListingKey({ q: "", tag: "", sort: "latest", pageSize: 14 })
+  );
+});
+
+test("appending drops ids that are already on screen", () => {
+  const previous = videos(0, 3);
+  const merged = appendUniqueVideos(previous, [
+    ...videos(2, 1),
+    ...videos(3, 2),
+  ]);
+
+  assert.deepEqual(
+    merged.map((item) => item.id),
+    ["video-0", "video-1", "video-2", "video-3", "video-4"]
+  );
+  assert.strictEqual(
+    appendUniqueVideos(previous, videos(0, 3)),
+    previous,
+    "an all-duplicate batch must not create a new array"
+  );
+  assert.strictEqual(appendUniqueVideos(previous, []), previous);
+});
+
+test("a batch that overlaps the previous page is deduplicated on append", () => {
+  const state = loaded();
+  // 列表期间新入库一条视频，第二页整体后移一位，边界那条会重复返回。
+  const next = infiniteListingReducer(state, {
+    type: "load-success",
+    requestID: 1,
+    offset: 20,
+    batchSize: 20,
+    items: [...videos(19, 1), ...videos(20, 19)],
+    total: 100,
+    receivedAt: 2_000,
+  });
+
+  assert.equal(next.items.length, 39);
+  assert.equal(new Set(next.items.map((item) => item.id)).size, 39);
+  assert.equal(next.requestedCount, 40, "游标按请求条数推进，不受去重影响");
+  assert.equal(next.exhausted, false);
+  assert.equal(next.status, "ready");
+});
+
+test("loading starts as initial for an empty list and as load-more once items exist", () => {
+  const first = infiniteListingReducer(
+    emptyInfiniteListingState(KEY, 20),
+    { type: "load-start", requestID: 1 }
+  );
+  assert.equal(first.status, "initial-loading");
+
+  const more = infiniteListingReducer(loaded(), {
+    type: "load-start",
+    requestID: 2,
+  });
+  assert.equal(more.status, "loading-more");
+  assert.equal(more.items.length, 20, "已加载内容在加载下一批时保持可见");
+});
+
+test("stale responses cannot append to a newer request", () => {
+  const state = loaded({ requestID: 5 });
+
+  const lateSuccess = infiniteListingReducer(state, {
+    type: "load-success",
+    requestID: 4,
+    offset: 20,
+    batchSize: 20,
+    items: videos(20, 20),
+    total: 100,
+    receivedAt: 2_000,
+  });
+  const lateFailure = infiniteListingReducer(state, {
+    type: "load-failure",
+    requestID: 4,
+    error: new Error("late"),
+  });
+
+  assert.strictEqual(lateSuccess, state);
+  assert.strictEqual(lateFailure, state);
+});
+
+test("a response whose offset no longer matches the cursor is discarded", () => {
+  const state = loaded({ requestID: 3, requestedCount: 40, items: videos(0, 40) });
+
+  const misaligned = infiniteListingReducer(state, {
+    type: "load-success",
+    requestID: 3,
+    offset: 20,
+    batchSize: 20,
+    items: videos(20, 20),
+    total: 100,
+    receivedAt: 2_000,
+  });
+
+  assert.strictEqual(misaligned, state);
+});
+
+test("the list stops loading on a short page and on a reached total", () => {
+  const shortPage = infiniteListingReducer(loaded(), {
+    type: "load-success",
+    requestID: 1,
+    offset: 20,
+    batchSize: 20,
+    items: videos(20, 7),
+    total: 100,
+    receivedAt: 2_000,
+  });
+  assert.equal(shortPage.exhausted, true);
+  assert.equal(infiniteListingHasMore(shortPage), false);
+  assert.equal(nextListingRequest(shortPage), null);
+
+  const reachedTotal = infiniteListingReducer(loaded({ total: 40 }), {
+    type: "load-success",
+    requestID: 1,
+    offset: 20,
+    batchSize: 20,
+    items: videos(20, 20),
+    total: 40,
+    receivedAt: 2_000,
+  });
+  assert.equal(reachedTotal.exhausted, true);
+
+  // total 只是查询时刻的计数，删除后会虚高；返回满页时不能提前收尾。
+  assert.equal(
+    isListingExhausted({
+      received: 20,
+      batchSize: 20,
+      requestedCount: 40,
+      total: 0,
+    }),
+    false
+  );
+});
+
+test("a failed batch keeps the loaded items and stops auto-loading", () => {
+  const failed = infiniteListingReducer(loaded({ requestID: 2, status: "loading-more" }), {
+    type: "load-failure",
+    requestID: 2,
+    error: new Error("offline"),
+  });
+
+  assert.equal(failed.status, "error");
+  assert.equal(failed.items.length, 20);
+  assert.equal(failed.requestedCount, 20);
+  assert.equal(infiniteListingHasMore(failed), false);
+});
+
+test("the next request continues on a page boundary derived from requested count", () => {
+  assert.deepEqual(nextListingRequest(loaded()), { page: 2, size: 20 });
+  assert.deepEqual(
+    nextListingRequest(loaded({ requestedCount: 120 })),
+    { page: 7, size: 20 },
+    "恢复现场后的大请求也必须落在页边界上"
+  );
+  assert.equal(
+    nextListingRequest(loaded({ requestedCount: 25 })),
+    null,
+    "偏移量不是页大小整数倍时无法用 page/size 表达"
+  );
+  assert.equal(nextListingRequest(loaded({ pageSize: 0 })), null);
+  assert.deepEqual(
+    nextListingRequest(emptyInfiniteListingState(KEY, 14)),
+    { page: 1, size: 14 }
+  );
+});
+
+test("changing the query resets accumulation and cached content hydrates as ready", () => {
+  const reset = infiniteListingReducer(loaded(), {
+    type: "reset",
+    requestID: 9,
+    key: "other",
+    pageSize: 14,
+  });
+  assert.equal(reset.key, "other");
+  assert.equal(reset.pageSize, 14);
+  assert.equal(reset.items.length, 0);
+  assert.equal(reset.requestedCount, 0);
+  assert.equal(reset.exhausted, false);
+  assert.equal(reset.status, "idle");
+
+  const hydrated = infiniteListingReducer(emptyInfiniteListingState(KEY, 20), {
+    type: "hydrate",
+    requestID: 10,
+    key: KEY,
+    pageSize: 20,
+    items: videos(0, 60),
+    total: 100,
+    requestedCount: 60,
+    exhausted: false,
+    receivedAt: 5_000,
+  });
+  assert.equal(hydrated.status, "ready");
+  assert.equal(hydrated.items.length, 60);
+  assert.equal(hydrated.requestedCount, 60);
+  assert.equal(
+    hydrated.receivedAt,
+    5_000,
+    "hydrate 保留原始响应时间，缓存不会自我续命"
+  );
+
+  const disabled = infiniteListingReducer(loaded(), {
+    type: "disable",
+    requestID: 11,
+  });
+  assert.equal(disabled.status, "idle");
+  assert.equal(disabled.items.length, 0);
+});

--- a/tests/listSortOptions.test.ts
+++ b/tests/listSortOptions.test.ts
@@ -119,7 +119,10 @@ test("public video lists use fourteen mobile and twenty desktop items per batch"
   assert.match(responsiveSource, /export const MOBILE_VIDEO_PAGE_SIZE = 14;/);
   assert.match(listingPageSource, /const DESKTOP_PAGE_SIZE = 20;/);
   assert.match(listingPageSource, /const pageSize = isMobile \? MOBILE_VIDEO_PAGE_SIZE : DESKTOP_PAGE_SIZE;/);
-  assert.match(listingPageSource, /useInfiniteListing\(\{[\s\S]*?pageSize,/);
+  assert.match(
+    listingPageSource,
+    /listingFeedSource\(\{ q: keyword, tag, sort, pageSize \}\)/
+  );
   assert.match(listingPageSource, /skeletonCount=\{pageSize\}/);
 });
 

--- a/tests/listSortOptions.test.ts
+++ b/tests/listSortOptions.test.ts
@@ -18,6 +18,10 @@ const searchPanelSource = readFileSync(
   new URL("../src/components/SearchPanel.tsx", import.meta.url),
   "utf8"
 );
+const homePageSource = readFileSync(
+  new URL("../src/pages/HomePage.tsx", import.meta.url),
+  "utf8"
+);
 const listingQuerySource = readFileSync(
   new URL("../src/lib/useListingQuery.ts", import.meta.url),
   "utf8"
@@ -69,11 +73,16 @@ test("listing page keeps the public discovery layout and empty semantics", () =>
 
 test("public listing query control state is restored from the URL", () => {
   assert.match(listingPageSource, /const sort = readListingSort\(params\)/);
-  assert.match(listingPageSource, /const page = readListingPage\(params\)/);
   assert.match(listingPageSource, /const view = readListingView\(params\)/);
   assert.match(listingPageSource, /withListingNavigation\(params, \{ sort: nextSort, page: 1 \}\)/);
-  assert.match(listingPageSource, /withListingPage\(params, nextPage\)/);
   assert.match(listingPageSource, /withListingView\(params, nextView\)/);
+  // 列表页改为无限滚动后没有页码，旧链接里的 page 参数会被清掉。
+  assert.match(listingPageSource, /if \(!params\.has\("page"\)\) return;/);
+  assert.match(
+    listingPageSource,
+    /withListingPage\(current, 1\), \{ replace: true \}/
+  );
+  assert.doesNotMatch(listingPageSource, /<Pagination/);
   assert.doesNotMatch(listingPageSource, /sessionStorage|localStorage/);
 });
 
@@ -106,20 +115,20 @@ test("list search updates the shared listing query instead of rebuilding it", ()
   assert.doesNotMatch(searchPanelSource, /const sp = new URLSearchParams\(\)/);
 });
 
-test("public video lists use fourteen mobile and twenty desktop items per page", () => {
+test("public video lists use fourteen mobile and twenty desktop items per batch", () => {
   assert.match(responsiveSource, /export const MOBILE_VIDEO_PAGE_SIZE = 14;/);
   assert.match(listingPageSource, /const DESKTOP_PAGE_SIZE = 20;/);
   assert.match(listingPageSource, /const pageSize = isMobile \? MOBILE_VIDEO_PAGE_SIZE : DESKTOP_PAGE_SIZE;/);
-  assert.match(listingPageSource, /useListingQuery\(\{[\s\S]*?page,[\s\S]*?pageSize/);
+  assert.match(listingPageSource, /useInfiniteListing\(\{[\s\S]*?pageSize,/);
   assert.match(listingPageSource, /skeletonCount=\{pageSize\}/);
 });
 
-test("listing page uses one shared stale-while-revalidate query contract", () => {
-  assert.match(listingPageSource, /import \{ useListingQuery \} from "@\/lib\/useListingQuery"/);
-  assert.match(listingPageSource, /refreshMode=\{[\s\S]*?result\.transitioning[\s\S]*?"blocking"[\s\S]*?result\.revalidating[\s\S]*?"background"/);
-  assert.match(listingPageSource, /disabled=\{result\.transitioning\}/);
-  assert.match(listingPageSource, /<ListingLoadError[\s\S]*?displayedPage=\{displayedPage\}/);
-  assert.match(listingPageSource, /snapshot\?\.query\.page \?\? page/);
+test("home search keeps the shared stale-while-revalidate query contract", () => {
+  assert.match(homePageSource, /import \{ useListingQuery \} from "@\/lib\/useListingQuery"/);
+  assert.match(homePageSource, /refreshMode=\{[\s\S]*?searchResult\.transitioning[\s\S]*?"blocking"[\s\S]*?searchResult\.revalidating[\s\S]*?"background"/);
+  assert.match(homePageSource, /disabled=\{searchResult\.transitioning\}/);
+  assert.match(homePageSource, /<ListingLoadError[\s\S]*?displayedPage=\{displayedSearchPage\}/);
+  assert.match(homePageSource, /searchSnapshot\?\.query\.page \?\? searchPage/);
   assert.match(listingQuerySource, /const LISTING_CACHE_TTL_MS = 60_000/);
   assert.match(listingQuerySource, /const LISTING_CACHE_MAX_ENTRIES = 20/);
   assert.match(listingQuerySource, /function peekListingCache/);

--- a/tests/listSortOptions.test.ts
+++ b/tests/listSortOptions.test.ts
@@ -74,8 +74,8 @@ test("listing page keeps the public discovery layout and empty semantics", () =>
 test("public listing query control state is restored from the URL", () => {
   assert.match(listingPageSource, /const sort = readListingSort\(params\)/);
   assert.match(listingPageSource, /const view = readListingView\(params\)/);
-  assert.match(listingPageSource, /withListingNavigation\(params, \{ sort: nextSort, page: 1 \}\)/);
-  assert.match(listingPageSource, /withListingView\(params, nextView\)/);
+  assert.match(listingPageSource, /withListingNavigation\(current, \{ sort: nextSort, page: 1 \}\)/);
+  assert.match(listingPageSource, /withListingView\(current, nextView\)/);
   // 列表页改为无限滚动后没有页码，旧链接里的 page 参数会被清掉。
   assert.match(listingPageSource, /if \(!params\.has\("page"\)\) return;/);
   assert.match(

--- a/tests/listingInfiniteScroll.test.ts
+++ b/tests/listingInfiniteScroll.test.ts
@@ -145,16 +145,21 @@ test("the infinite listing hook keeps one in-flight batch per query", () => {
   );
   assert.match(
     infiniteListingHookSource,
-    /if \(!options\.force && current\.status === "error"\) return;/
+    /if \(!batchOptions\.force && current\.status === "error"\) return;/
   );
   // 首屏失败整段重来，尾部失败只重试失败的那一批。
   assert.match(
     infiniteListingHookSource,
-    /if \(stateRef\.current\.items\.length === 0\) \{\s*setRetryVersion\(\(version\) => version \+ 1\);\s*return;\s*\}\s*requestBatch\(\{ force: true \}\);/
+    /if \(stateRef\.current\.items\.length === 0\) \{\s*reload\(\);\s*return;\s*\}\s*requestBatch\(\{ force: true \}\);/
+  );
+  // 轮换 feed 的游标在服务端且不幂等，补回来的不是原来那批视频。
+  assert.match(
+    infiniteListingHookSource,
+    /const restoreCount = sourceRef\.current\.supportsRestore\s*\? restoreCountRef\.current\s*:\s*0;/
   );
   assert.match(
     infiniteListingHookSource,
-    /initialBatchSize\(restoreCountRef\.current, query\.pageSize\)/
+    /size: initialBatchSize\(restoreCount, batchSize\),/
   );
 });
 

--- a/tests/listingInfiniteScroll.test.ts
+++ b/tests/listingInfiniteScroll.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const listingPageSource = readFileSync(
+  new URL("../src/pages/ListingPage.tsx", import.meta.url),
+  "utf8"
+);
+const virtualGridSource = readFileSync(
+  new URL("../src/components/VirtualVideoGrid.tsx", import.meta.url),
+  "utf8"
+);
+const infiniteListingHookSource = readFileSync(
+  new URL("../src/lib/useInfiniteListing.ts", import.meta.url),
+  "utf8"
+);
+const scrollRestoreHookSource = readFileSync(
+  new URL("../src/lib/useListingScrollRestore.ts", import.meta.url),
+  "utf8"
+);
+const layoutCss = readFileSync(
+  new URL("../src/styles/layout.css", import.meta.url),
+  "utf8"
+);
+const videoCardCss = readFileSync(
+  new URL("../src/styles/video-card.css", import.meta.url),
+  "utf8"
+);
+
+function ruleBody(css: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`));
+  assert.ok(match, `Expected CSS rule for ${selector}`);
+  return match[1];
+}
+
+test("the listing page renders its videos through the virtual grid", () => {
+  assert.match(
+    listingPageSource,
+    /<VirtualVideoGrid\s+videos=\{items\}[\s\S]*?onRangeChange=\{handleRangeChange\}/
+  );
+  // 骨架屏之外不再整页渲染列表。
+  assert.doesNotMatch(
+    listingPageSource,
+    /<VideoGrid\s+videos=\{items\}/
+  );
+});
+
+test("scrolling near the end of the rendered window loads the next batch", () => {
+  assert.match(
+    listingPageSource,
+    /shouldLoadMore\(\{[\s\S]*?endIndex: range\.endIndex,[\s\S]*?itemCount: items\.length,[\s\S]*?columns: range\.columns,[\s\S]*?hasMore,[\s\S]*?loading: loadingMore,[\s\S]*?prefetchRows: PREFETCH_ROWS,[\s\S]*?\}\)/
+  );
+  assert.match(listingPageSource, /loadMore\(\);/);
+  assert.match(listingPageSource, /const PREFETCH_ROWS = 2;/);
+});
+
+test("the listing page shows loading, end and tail-error states for infinite scroll", () => {
+  assert.match(listingPageSource, /\{showTailError \? \(/);
+  assert.match(
+    listingPageSource,
+    /<ListingLoadError hasContent onRetry=\{listing\.retry\} \/>/
+  );
+  assert.match(
+    listingPageSource,
+    /className="listing-infinite-status"[\s\S]*?role="status"[\s\S]*?aria-live="polite"[\s\S]*?正在加载更多/
+  );
+  assert.match(
+    listingPageSource,
+    /listing\.exhausted \? \([\s\S]*?listing-infinite-status--end[\s\S]*?没有更多了/
+  );
+
+  const status = ruleBody(layoutCss, ".listing-infinite-status");
+  assert.match(status, /display\s*:\s*flex/);
+  assert.match(status, /justify-content\s*:\s*center/);
+});
+
+test("the virtual grid renders whole rows through the window virtualizer", () => {
+  assert.match(
+    virtualGridSource,
+    /import \{ useWindowVirtualizer \} from "@tanstack\/react-virtual"/
+  );
+  assert.match(
+    virtualGridSource,
+    /useWindowVirtualizer\(\{[\s\S]*?count: rowCount,[\s\S]*?estimateSize: \(\) => rowHeight,[\s\S]*?overscan: overscanRows,[\s\S]*?scrollMargin,/
+  );
+  assert.match(
+    virtualGridSource,
+    /const \{ start, end \} = virtualRowRange\(\s*virtualRow\.index,\s*columns,\s*videos\.length\s*\)/
+  );
+  // 卡片的加载优先级按列表里的绝对下标判断，而不是行内偏移。
+  assert.match(virtualGridSource, /const index = start \+ offset;/);
+  assert.match(virtualGridSource, /eager=\{index < eagerCount\}/);
+  assert.match(virtualGridSource, /highPriority=\{index < highPriorityCount\}/);
+});
+
+test("the virtual canvas keeps the scrollbar as tall as the whole list", () => {
+  assert.match(
+    virtualGridSource,
+    /className="video-grid-virtual-canvas"\s*style=\{\{ height: virtualizer\.getTotalSize\(\) \}\}/
+  );
+  assert.match(
+    virtualGridSource,
+    /transform: `translateY\(\$\{\s*virtualRow\.start - virtualizer\.options\.scrollMargin\s*\}px\)`/
+  );
+
+  const canvas = ruleBody(videoCardCss, ".video-grid-virtual-canvas");
+  assert.match(canvas, /position\s*:\s*relative/);
+  const row = ruleBody(videoCardCss, ".video-grid--virtual-row");
+  assert.match(row, /position\s*:\s*absolute/);
+  // 行间距做进行自身的下内边距，测到的行高才等于"行 + 间距"。
+  assert.match(row, /padding-bottom\s*:\s*var\(--space-4\)/);
+});
+
+test("row heights and column counts are measured from the real layout", () => {
+  assert.match(virtualGridSource, /ref=\{virtualizer\.measureElement\}/);
+  assert.match(virtualGridSource, /data-index=\{virtualRow\.index\}/);
+  assert.match(
+    virtualGridSource,
+    /virtualGridColumns\(window\.getComputedStyle\(row\)\)/
+  );
+  assert.match(virtualGridSource, /const nextMargin = rect\.top \+ window\.scrollY;/);
+  assert.match(virtualGridSource, /new ResizeObserver\(measure\)/);
+  assert.match(virtualGridSource, /observer\?\.disconnect\(\)/);
+  assert.match(
+    virtualGridSource,
+    /window\.removeEventListener\("resize", measure\)/
+  );
+  // 列数变了每行内容都会重排，之前测到的行高必须作废。
+  assert.match(
+    virtualGridSource,
+    /virtualizer\.measure\(\);\s*\}, \[columns, compact, virtualizer\]\)/
+  );
+});
+
+test("the infinite listing hook keeps one in-flight batch per query", () => {
+  assert.match(
+    infiniteListingHookSource,
+    /const INFINITE_LISTING_CACHE_TTL_MS = 60_000/
+  );
+  assert.match(infiniteListingHookSource, /controllerRef\.current\?\.abort\(\)/);
+  assert.match(
+    infiniteListingHookSource,
+    /if \(current\.status === "initial-loading" \|\| current\.status === "loading-more"\) \{\s*return;\s*\}/
+  );
+  assert.match(
+    infiniteListingHookSource,
+    /if \(!options\.force && current\.status === "error"\) return;/
+  );
+  // 首屏失败整段重来，尾部失败只重试失败的那一批。
+  assert.match(
+    infiniteListingHookSource,
+    /if \(stateRef\.current\.items\.length === 0\) \{\s*setRetryVersion\(\(version\) => version \+ 1\);\s*return;\s*\}\s*requestBatch\(\{ force: true \}\);/
+  );
+  assert.match(
+    infiniteListingHookSource,
+    /initialBatchSize\(restoreCountRef\.current, query\.pageSize\)/
+  );
+});
+
+test("browser history navigation restores both the loaded batches and the position", () => {
+  assert.match(listingPageSource, /historyKey: location\.key/);
+  assert.match(listingPageSource, /restoreCount: restoreTarget\.count/);
+  assert.match(
+    listingPageSource,
+    /useListingScrollRestore\(\{[\s\S]*?target: restoreTarget,[\s\S]*?requestedCount: listing\.requestedCount,[\s\S]*?itemCount: listing\.items\.length,/
+  );
+  // 恢复条数必须在数据层发起首个请求之前解析，所以在渲染期读取。
+  assert.match(
+    scrollRestoreHookSource,
+    /if \(!targetRef\.current \|\| targetRef\.current\.historyKey !== input\.historyKey\)/
+  );
+  assert.match(scrollRestoreHookSource, /canRestoreScrollY\(\{/);
+  assert.match(scrollRestoreHookSource, /window\.scrollTo\(0, targetScrollY\)/);
+  assert.match(scrollRestoreHookSource, /if \(pendingScrollYRef\.current > 0\) return;/);
+  assert.match(
+    scrollRestoreHookSource,
+    /window\.addEventListener\("pagehide", handlePageHide\)/
+  );
+  // 卸载时列表 DOM 已被详情页顶掉，window.scrollY 会被压缩，只能用滚动时记下的值。
+  assert.match(
+    scrollRestoreHookSource,
+    /lastScrollYRef\.current = Math\.max\(0, Math\.round\(window\.scrollY\)\);/
+  );
+  assert.match(scrollRestoreHookSource, /save\(lastScrollYRef\.current\);/);
+});

--- a/tests/listingInfiniteScroll.test.ts
+++ b/tests/listingInfiniteScroll.test.ts
@@ -10,12 +10,32 @@ const virtualGridSource = readFileSync(
   new URL("../src/components/VirtualVideoGrid.tsx", import.meta.url),
   "utf8"
 );
+const infiniteFeedStatusSource = readFileSync(
+  new URL("../src/components/InfiniteFeedStatus.tsx", import.meta.url),
+  "utf8"
+);
 const infiniteListingHookSource = readFileSync(
   new URL("../src/lib/useInfiniteListing.ts", import.meta.url),
   "utf8"
 );
 const scrollRestoreHookSource = readFileSync(
   new URL("../src/lib/useListingScrollRestore.ts", import.meta.url),
+  "utf8"
+);
+const videoCardSource = readFileSync(
+  new URL("../src/components/VideoCard.tsx", import.meta.url),
+  "utf8"
+);
+const searchPanelSource = readFileSync(
+  new URL("../src/components/SearchPanel.tsx", import.meta.url),
+  "utf8"
+);
+const tagCloudSource = readFileSync(
+  new URL("../src/components/TagCloud.tsx", import.meta.url),
+  "utf8"
+);
+const sortToolbarSource = readFileSync(
+  new URL("../src/components/SortToolbar.tsx", import.meta.url),
   "utf8"
 );
 const layoutCss = readFileSync(
@@ -37,7 +57,7 @@ function ruleBody(css: string, selector: string): string {
 test("the listing page renders its videos through the virtual grid", () => {
   assert.match(
     listingPageSource,
-    /<VirtualVideoGrid\s+videos=\{items\}[\s\S]*?onRangeChange=\{handleRangeChange\}/
+    /<VirtualVideoGrid\s+videos=\{items\}[\s\S]*?onLoadMore=\{listing\.loadMore\}/
   );
   // 骨架屏之外不再整页渲染列表。
   assert.doesNotMatch(
@@ -48,10 +68,11 @@ test("the listing page renders its videos through the virtual grid", () => {
 
 test("scrolling near the end of the rendered window loads the next batch", () => {
   assert.match(
-    listingPageSource,
-    /shouldLoadMore\(\{[\s\S]*?endIndex: range\.endIndex,[\s\S]*?itemCount: items\.length,[\s\S]*?columns: range\.columns,[\s\S]*?hasMore,[\s\S]*?loading: loadingMore,[\s\S]*?prefetchRows: PREFETCH_ROWS,[\s\S]*?\}\)/
+    virtualGridSource,
+    /shouldLoadMore\(\{[\s\S]*?endIndex: Math\.min\(\(lastRow \+ 1\) \* columns, videos\.length\),[\s\S]*?itemCount: videos\.length,[\s\S]*?loading: loadingMore,[\s\S]*?prefetchRows,[\s\S]*?\}\)/
   );
-  assert.match(listingPageSource, /loadMore\(\);/);
+  assert.match(virtualGridSource, /onLoadMore\(\);/);
+  assert.match(listingPageSource, /onLoadMore=\{listing\.loadMore\}/);
   assert.match(listingPageSource, /const PREFETCH_ROWS = 2;/);
 });
 
@@ -61,14 +82,13 @@ test("the listing page shows loading, end and tail-error states for infinite scr
     listingPageSource,
     /<ListingLoadError hasContent onRetry=\{listing\.retry\} \/>/
   );
+  assert.match(listingPageSource, /<InfiniteFeedStatus state="loading" \/>/);
+  assert.match(listingPageSource, /listing\.exhausted \? \(\s*<InfiniteFeedStatus state="end" \/>/);
   assert.match(
-    listingPageSource,
+    infiniteFeedStatusSource,
     /className="listing-infinite-status"[\s\S]*?role="status"[\s\S]*?aria-live="polite"[\s\S]*?正在加载更多/
   );
-  assert.match(
-    listingPageSource,
-    /listing\.exhausted \? \([\s\S]*?listing-infinite-status--end[\s\S]*?没有更多了/
-  );
+  assert.match(infiniteFeedStatusSource, /listing-infinite-status--end[\s\S]*?没有更多了/);
 
   const status = ruleBody(layoutCss, ".listing-infinite-status");
   assert.match(status, /display\s*:\s*flex/);
@@ -82,7 +102,7 @@ test("the virtual grid renders whole rows through the window virtualizer", () =>
   );
   assert.match(
     virtualGridSource,
-    /useWindowVirtualizer\(\{[\s\S]*?count: rowCount,[\s\S]*?estimateSize: \(\) => rowHeight,[\s\S]*?overscan: overscanRows,[\s\S]*?scrollMargin,/
+    /useWindowVirtualizer\(\{[\s\S]*?count: virtualRowCountWithTail,[\s\S]*?estimateSize,[\s\S]*?overscan: overscanRows,[\s\S]*?scrollMargin,[\s\S]*?directDomUpdates: true,/
   );
   assert.match(
     virtualGridSource,
@@ -94,15 +114,19 @@ test("the virtual grid renders whole rows through the window virtualizer", () =>
   assert.match(virtualGridSource, /highPriority=\{index < highPriorityCount\}/);
 });
 
-test("the virtual canvas keeps the scrollbar as tall as the whole list", () => {
+test("the scrollbar grows with loaded content and keeps only a fixed tail row", () => {
   assert.match(
     virtualGridSource,
-    /className="video-grid-virtual-canvas"\s*style=\{\{ height: virtualizer\.getTotalSize\(\) \}\}/
+    /ref=\{virtualizer\.containerRef\}[\s\S]*?className="video-grid-virtual-canvas"/
   );
+  assert.match(virtualGridSource, /const TAIL_ROW_HEIGHT = 56/);
+  assert.match(virtualGridSource, /className="video-grid-virtual-tail"/);
   assert.match(
     virtualGridSource,
-    /transform: `translateY\(\$\{\s*virtualRow\.start - virtualizer\.options\.scrollMargin\s*\}px\)`/
+    /const virtualRowCountWithTail = loadedRowCount \+ \(hasTailRow \? 1 : 0\)/
   );
+  assert.doesNotMatch(virtualGridSource, /totalCount|knownTotal|remainingRowCount|reserveTotalHeight/);
+  assert.doesNotMatch(virtualGridSource, /style=\{\{ height: virtualizer\.getTotalSize\(\) \}\}/);
 
   const canvas = ruleBody(videoCardCss, ".video-grid-virtual-canvas");
   assert.match(canvas, /position\s*:\s*relative/);
@@ -110,27 +134,33 @@ test("the virtual canvas keeps the scrollbar as tall as the whole list", () => {
   assert.match(row, /position\s*:\s*absolute/);
   // 行间距做进行自身的下内边距，测到的行高才等于"行 + 间距"。
   assert.match(row, /padding-bottom\s*:\s*var\(--space-4\)/);
+  const tail = ruleBody(videoCardCss, ".video-grid-virtual-tail");
+  assert.match(tail, /position\s*:\s*absolute/);
 });
 
-test("row heights and column counts are measured from the real layout", () => {
+test("layout measurement stays off the per-frame scroll path", () => {
   assert.match(virtualGridSource, /ref=\{virtualizer\.measureElement\}/);
   assert.match(virtualGridSource, /data-index=\{virtualRow\.index\}/);
-  assert.match(
-    virtualGridSource,
-    /virtualGridColumns\(window\.getComputedStyle\(row\)\)/
-  );
+  assert.match(virtualGridSource, /useState\(readResponsiveGridColumns\)/);
+  assert.match(virtualGridSource, /const columns = compact \? 1 : responsiveColumns/);
   assert.match(virtualGridSource, /const nextMargin = rect\.top \+ window\.scrollY;/);
-  assert.match(virtualGridSource, /new ResizeObserver\(measure\)/);
+  assert.match(virtualGridSource, /new ResizeObserver\(\(\[entry\]\) =>/);
   assert.match(virtualGridSource, /observer\?\.disconnect\(\)/);
+  assert.doesNotMatch(virtualGridSource, /window\.getComputedStyle|querySelector<HTMLElement>/);
+  // 只有断点/视图变化清空测量缓存，追加视频不会重测全部旧行。
   assert.match(
     virtualGridSource,
-    /window\.removeEventListener\("resize", measure\)/
+    /if \(previousLayoutIdentityRef\.current === layoutIdentity\) return;[\s\S]*?virtualizer\.measure\(\);[\s\S]*?\}, \[layoutIdentity, virtualizer\]\)/
   );
-  // 列数变了每行内容都会重排，之前测到的行高必须作废。
-  assert.match(
-    virtualGridSource,
-    /virtualizer\.measure\(\);\s*\}, \[columns, compact, virtualizer\]\)/
-  );
+});
+
+test("scrolling rerenders only the virtual list and memoized cards", () => {
+  assert.doesNotMatch(listingPageSource, /useState<VirtualGridRange>|setRange|onRangeChange/);
+  assert.match(virtualGridSource, /directDomUpdates: true/);
+  assert.match(videoCardSource, /export const VideoCard = memo\(function VideoCard/);
+  assert.match(searchPanelSource, /export const SearchPanel = memo\(function SearchPanel/);
+  assert.match(tagCloudSource, /export const TagCloud = memo\(function TagCloud/);
+  assert.match(sortToolbarSource, /export const SortToolbar = memo\(function SortToolbar/);
 });
 
 test("the infinite listing hook keeps one in-flight batch per query", () => {
@@ -141,7 +171,7 @@ test("the infinite listing hook keeps one in-flight batch per query", () => {
   assert.match(infiniteListingHookSource, /controllerRef\.current\?\.abort\(\)/);
   assert.match(
     infiniteListingHookSource,
-    /if \(current\.status === "initial-loading" \|\| current\.status === "loading-more"\) \{\s*return;\s*\}/
+    /if \(controllerRef\.current && !controllerRef\.current\.signal\.aborted\) return;/
   );
   assert.match(
     infiniteListingHookSource,
@@ -152,40 +182,47 @@ test("the infinite listing hook keeps one in-flight batch per query", () => {
     infiniteListingHookSource,
     /if \(stateRef\.current\.items\.length === 0\) \{\s*reload\(\);\s*return;\s*\}\s*requestBatch\(\{ force: true \}\);/
   );
-  // 轮换 feed 的游标在服务端且不幂等，补回来的不是原来那批视频。
+  // token 过期后重新建快照，并一次补回原游标附近的内容。
   assert.match(
     infiniteListingHookSource,
-    /const restoreCount = sourceRef\.current\.supportsRestore\s*\? restoreCountRef\.current\s*:\s*0;/
+    /if \(request\.cursor\.feedToken && feed\.isExpiredError\(error\)\)/
   );
   assert.match(
     infiniteListingHookSource,
-    /size: initialBatchSize\(restoreCount, batchSize\),/
+    /size: initialBatchSize\(restoreCount, feed\.batchSize\),/
+  );
+  assert.match(
+    infiniteListingHookSource,
+    /infiniteListingCacheMatchesRestore\(\{[\s\S]*?restoreFeedToken: restore\.feedToken,[\s\S]*?restoreCount: restore\.count,/
   );
 });
 
 test("browser history navigation restores both the loaded batches and the position", () => {
   assert.match(listingPageSource, /historyKey: location\.key/);
   assert.match(listingPageSource, /restoreCount: restoreTarget\.count/);
+  assert.match(listingPageSource, /restoreFeedToken: restoreTarget\.feedToken/);
   assert.match(
     listingPageSource,
-    /useListingScrollRestore\(\{[\s\S]*?target: restoreTarget,[\s\S]*?requestedCount: listing\.requestedCount,[\s\S]*?itemCount: listing\.items\.length,/
+    /useListingScrollRestore\(\{[\s\S]*?target: restoreTarget,[\s\S]*?requestedCount: listing\.requestedCount,[\s\S]*?feedToken: listing\.feedToken,[\s\S]*?itemCount: listing\.items\.length,/
   );
   // 恢复条数必须在数据层发起首个请求之前解析，所以在渲染期读取。
   assert.match(
     scrollRestoreHookSource,
-    /if \(!targetRef\.current \|\| targetRef\.current\.historyKey !== input\.historyKey\)/
+    /targetRef\.current\.historyKey !== input\.historyKey[\s\S]*?targetRef\.current\.queryKey !== input\.queryKey/
   );
   assert.match(scrollRestoreHookSource, /canRestoreScrollY\(\{/);
   assert.match(scrollRestoreHookSource, /window\.scrollTo\(0, targetScrollY\)/);
-  assert.match(scrollRestoreHookSource, /if \(pendingScrollYRef\.current > 0\) return;/);
+  assert.match(scrollRestoreHookSource, /if \(session\.pendingScrollY > 0 \|\| session\.requestedCount <= 0\) return;/);
   assert.match(
     scrollRestoreHookSource,
     /window\.addEventListener\("pagehide", handlePageHide\)/
   );
   // 卸载时列表 DOM 已被详情页顶掉，window.scrollY 会被压缩，只能用滚动时记下的值。
-  assert.match(
-    scrollRestoreHookSource,
-    /lastScrollYRef\.current = Math\.max\(0, Math\.round\(window\.scrollY\)\);/
-  );
-  assert.match(scrollRestoreHookSource, /save\(lastScrollYRef\.current\);/);
+  const scrollHandler = scrollRestoreHookSource.match(
+    /const handleScroll = \(\) => \{[\s\S]*?\n    \};/
+  )?.[0] ?? "";
+  assert.match(scrollHandler, /session\.lastScrollY = Math\.max\(0, Math\.round\(window\.scrollY\)\)/);
+  assert.doesNotMatch(scrollHandler, /writeListingScrollEntry|sessionStorage|requestAnimationFrame|persist\(/);
+  assert.match(scrollRestoreHookSource, /const handlePageHide = \(\) => \{[\s\S]*?persist\(\)/);
+  assert.match(scrollRestoreHookSource, /return \(\) => \{[\s\S]*?persist\(\);/);
 });

--- a/tests/listingScrollRestore.test.ts
+++ b/tests/listingScrollRestore.test.ts
@@ -9,12 +9,14 @@ import {
   readListingScrollEntry,
   resolveReachableScrollY,
   resolveRestoreCount,
+  resolveRestoreFeedToken,
   resolveRestoreScrollY,
   writeListingScrollEntry,
   type ListingScrollStorage,
 } from "../src/lib/listingScrollRestore.ts";
 
-const QUERY_KEY = '["","","hot",20]';
+const QUERY_KEY = 'listing:["","","hot"]';
+const FEED_TOKEN = "snapshot-token";
 
 function memoryStorage(): ListingScrollStorage & { map: Map<string, string> } {
   const map = new Map<string, string>();
@@ -42,12 +44,14 @@ test("a saved entry round-trips through storage under its history key", () => {
   const storage = memoryStorage();
   writeListingScrollEntry(storage, "history-1", {
     queryKey: QUERY_KEY,
+    feedToken: FEED_TOKEN,
     requestedCount: 60,
     scrollY: 1_800,
   });
 
   assert.deepEqual(readListingScrollEntry(storage, "history-1"), {
     queryKey: QUERY_KEY,
+    feedToken: FEED_TOKEN,
     requestedCount: 60,
     scrollY: 1_800,
   });
@@ -67,6 +71,7 @@ test("unusable storage degrades to no restoration instead of throwing", () => {
   assert.doesNotThrow(() =>
     writeListingScrollEntry(throwingStorage, "history-1", {
       queryKey: QUERY_KEY,
+      feedToken: FEED_TOKEN,
       requestedCount: 40,
       scrollY: 10,
     })
@@ -76,6 +81,7 @@ test("unusable storage degrades to no restoration instead of throwing", () => {
   assert.doesNotThrow(() =>
     writeListingScrollEntry(null, "history-1", {
       queryKey: QUERY_KEY,
+      feedToken: FEED_TOKEN,
       requestedCount: 40,
       scrollY: 10,
     })
@@ -112,18 +118,34 @@ test("malformed stored entries are rejected", () => {
     parseListingScrollEntry(
       JSON.stringify({ queryKey: QUERY_KEY, requestedCount: 40, scrollY: 0 })
     ),
-    { queryKey: QUERY_KEY, requestedCount: 40, scrollY: 0 }
+    { queryKey: QUERY_KEY, feedToken: "", requestedCount: 40, scrollY: 0 }
+  );
+  assert.equal(
+    parseListingScrollEntry(
+      JSON.stringify({
+        queryKey: QUERY_KEY,
+        feedToken: "x".repeat(129),
+        requestedCount: 40,
+        scrollY: 0,
+      })
+    ),
+    null
   );
 });
 
-test("the restore request is rounded up to a page boundary and capped", () => {
-  const entry = { queryKey: QUERY_KEY, requestedCount: 60, scrollY: 900 };
+test("the restore request keeps the exact cursor count and caps deep histories", () => {
+  const entry = {
+    queryKey: QUERY_KEY,
+    feedToken: FEED_TOKEN,
+    requestedCount: 60,
+    scrollY: 900,
+  };
 
   assert.equal(resolveRestoreCount({ entry, queryKey: QUERY_KEY, pageSize: 20 }), 60);
   assert.equal(
     resolveRestoreCount({ entry, queryKey: QUERY_KEY, pageSize: 14 }),
-    70,
-    "换成手机页大小时向上取整，游标仍落在页边界"
+    60,
+    "显式 cursor 不依赖响应式批次的页边界"
   );
   assert.equal(
     resolveRestoreCount({
@@ -140,7 +162,7 @@ test("the restore request is rounded up to a page boundary and capped", () => {
     "只看了首屏就按普通首屏加载"
   );
   assert.equal(
-    resolveRestoreCount({ entry, queryKey: '["","","latest",20]', pageSize: 20 }),
+    resolveRestoreCount({ entry, queryKey: 'listing:["","","latest"]', pageSize: 20 }),
     0,
     "排序变了就是另一个列表，不能沿用旧进度"
   );
@@ -149,10 +171,18 @@ test("the restore request is rounded up to a page boundary and capped", () => {
 });
 
 test("the restore position only applies to the query it was saved for", () => {
-  const entry = { queryKey: QUERY_KEY, requestedCount: 60, scrollY: 1_200 };
+  const entry = {
+    queryKey: QUERY_KEY,
+    feedToken: FEED_TOKEN,
+    requestedCount: 60,
+    scrollY: 1_200,
+  };
   assert.equal(resolveRestoreScrollY(entry, QUERY_KEY), 1_200);
-  assert.equal(resolveRestoreScrollY(entry, '["","","latest",20]'), 0);
+  assert.equal(resolveRestoreFeedToken(entry, QUERY_KEY), FEED_TOKEN);
+  assert.equal(resolveRestoreScrollY(entry, 'listing:["","","latest"]'), 0);
+  assert.equal(resolveRestoreFeedToken(entry, 'listing:["","","latest"]'), "");
   assert.equal(resolveRestoreScrollY(null, QUERY_KEY), 0);
+  assert.equal(resolveRestoreFeedToken(null, QUERY_KEY), "");
 });
 
 test("restoring waits until the document is tall enough to reach the position", () => {

--- a/tests/listingScrollRestore.test.ts
+++ b/tests/listingScrollRestore.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canRestoreScrollY,
+  clearListingScrollEntry,
+  listingScrollStorageKey,
+  MAX_RESTORE_ITEMS,
+  parseListingScrollEntry,
+  readListingScrollEntry,
+  resolveReachableScrollY,
+  resolveRestoreCount,
+  resolveRestoreScrollY,
+  writeListingScrollEntry,
+  type ListingScrollStorage,
+} from "../src/lib/listingScrollRestore.ts";
+
+const QUERY_KEY = '["","","hot",20]';
+
+function memoryStorage(): ListingScrollStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: (key) => void map.delete(key),
+  };
+}
+
+const throwingStorage: ListingScrollStorage = {
+  getItem() {
+    throw new Error("storage disabled");
+  },
+  setItem() {
+    throw new Error("storage disabled");
+  },
+  removeItem() {
+    throw new Error("storage disabled");
+  },
+};
+
+test("a saved entry round-trips through storage under its history key", () => {
+  const storage = memoryStorage();
+  writeListingScrollEntry(storage, "history-1", {
+    queryKey: QUERY_KEY,
+    requestedCount: 60,
+    scrollY: 1_800,
+  });
+
+  assert.deepEqual(readListingScrollEntry(storage, "history-1"), {
+    queryKey: QUERY_KEY,
+    requestedCount: 60,
+    scrollY: 1_800,
+  });
+  assert.equal(
+    storage.map.has(listingScrollStorageKey("history-1")),
+    true,
+    "每条历史记录各自存一份进度"
+  );
+  assert.equal(readListingScrollEntry(storage, "history-2"), null);
+
+  clearListingScrollEntry(storage, "history-1");
+  assert.equal(readListingScrollEntry(storage, "history-1"), null);
+});
+
+test("unusable storage degrades to no restoration instead of throwing", () => {
+  assert.equal(readListingScrollEntry(throwingStorage, "history-1"), null);
+  assert.doesNotThrow(() =>
+    writeListingScrollEntry(throwingStorage, "history-1", {
+      queryKey: QUERY_KEY,
+      requestedCount: 40,
+      scrollY: 10,
+    })
+  );
+  assert.doesNotThrow(() => clearListingScrollEntry(throwingStorage, "history-1"));
+  assert.equal(readListingScrollEntry(null, "history-1"), null);
+  assert.doesNotThrow(() =>
+    writeListingScrollEntry(null, "history-1", {
+      queryKey: QUERY_KEY,
+      requestedCount: 40,
+      scrollY: 10,
+    })
+  );
+});
+
+test("malformed stored entries are rejected", () => {
+  assert.equal(parseListingScrollEntry(null), null);
+  assert.equal(parseListingScrollEntry("not json"), null);
+  assert.equal(parseListingScrollEntry("null"), null);
+  assert.equal(
+    parseListingScrollEntry(JSON.stringify({ requestedCount: 40, scrollY: 10 })),
+    null
+  );
+  assert.equal(
+    parseListingScrollEntry(
+      JSON.stringify({ queryKey: QUERY_KEY, requestedCount: 0, scrollY: 10 })
+    ),
+    null
+  );
+  assert.equal(
+    parseListingScrollEntry(
+      JSON.stringify({ queryKey: QUERY_KEY, requestedCount: 4.5, scrollY: 10 })
+    ),
+    null
+  );
+  assert.equal(
+    parseListingScrollEntry(
+      JSON.stringify({ queryKey: QUERY_KEY, requestedCount: 40, scrollY: -1 })
+    ),
+    null
+  );
+  assert.deepEqual(
+    parseListingScrollEntry(
+      JSON.stringify({ queryKey: QUERY_KEY, requestedCount: 40, scrollY: 0 })
+    ),
+    { queryKey: QUERY_KEY, requestedCount: 40, scrollY: 0 }
+  );
+});
+
+test("the restore request is rounded up to a page boundary and capped", () => {
+  const entry = { queryKey: QUERY_KEY, requestedCount: 60, scrollY: 900 };
+
+  assert.equal(resolveRestoreCount({ entry, queryKey: QUERY_KEY, pageSize: 20 }), 60);
+  assert.equal(
+    resolveRestoreCount({ entry, queryKey: QUERY_KEY, pageSize: 14 }),
+    70,
+    "换成手机页大小时向上取整，游标仍落在页边界"
+  );
+  assert.equal(
+    resolveRestoreCount({
+      entry: { ...entry, requestedCount: 5_000 },
+      queryKey: QUERY_KEY,
+      pageSize: 20,
+    }),
+    MAX_RESTORE_ITEMS,
+    "深滚之后的返回不能打出一个无上限的大请求"
+  );
+  assert.equal(
+    resolveRestoreCount({ entry: { ...entry, requestedCount: 20 }, queryKey: QUERY_KEY, pageSize: 20 }),
+    0,
+    "只看了首屏就按普通首屏加载"
+  );
+  assert.equal(
+    resolveRestoreCount({ entry, queryKey: '["","","latest",20]', pageSize: 20 }),
+    0,
+    "排序变了就是另一个列表，不能沿用旧进度"
+  );
+  assert.equal(resolveRestoreCount({ entry: null, queryKey: QUERY_KEY, pageSize: 20 }), 0);
+  assert.equal(resolveRestoreCount({ entry, queryKey: QUERY_KEY, pageSize: 0 }), 0);
+});
+
+test("the restore position only applies to the query it was saved for", () => {
+  const entry = { queryKey: QUERY_KEY, requestedCount: 60, scrollY: 1_200 };
+  assert.equal(resolveRestoreScrollY(entry, QUERY_KEY), 1_200);
+  assert.equal(resolveRestoreScrollY(entry, '["","","latest",20]'), 0);
+  assert.equal(resolveRestoreScrollY(null, QUERY_KEY), 0);
+});
+
+test("restoring waits until the document is tall enough to reach the position", () => {
+  assert.equal(
+    canRestoreScrollY({
+      targetScrollY: 2_000,
+      documentHeight: 1_500,
+      viewportHeight: 800,
+    }),
+    false
+  );
+  assert.equal(
+    canRestoreScrollY({
+      targetScrollY: 2_000,
+      documentHeight: 2_800,
+      viewportHeight: 800,
+    }),
+    true
+  );
+  assert.equal(
+    canRestoreScrollY({
+      targetScrollY: 0,
+      documentHeight: 0,
+      viewportHeight: 800,
+    }),
+    true
+  );
+});
+
+test("a position deeper than the restore cap falls back to the furthest reachable point", () => {
+  assert.equal(
+    resolveReachableScrollY({
+      targetScrollY: 9_000,
+      documentHeight: 4_000,
+      viewportHeight: 800,
+    }),
+    3_200,
+    "停在已恢复内容的末尾，而不是回到顶部"
+  );
+  assert.equal(
+    resolveReachableScrollY({
+      targetScrollY: 1_000,
+      documentHeight: 4_000,
+      viewportHeight: 800,
+    }),
+    1_000
+  );
+  assert.equal(
+    resolveReachableScrollY({
+      targetScrollY: 500,
+      documentHeight: 600,
+      viewportHeight: 800,
+    }),
+    0
+  );
+});

--- a/tests/videoThumbnail.test.ts
+++ b/tests/videoThumbnail.test.ts
@@ -56,11 +56,15 @@ test("only likely first-viewport thumbnails receive eager and high priority hint
   assert.match(thumbnailSource, /alt=""/);
   assert.match(gridSource, /eager=\{index < eagerCount\}/);
   assert.match(gridSource, /highPriority=\{index < highPriorityCount\}/);
-  assert.match(homeSource, /<SectionHeader title="随机推荐"[\s\S]*?eagerCount=\{eagerCount\}[\s\S]*?highPriorityCount=\{1\}/);
-  assert.match(homeSource, /<SectionHeader title="最新视频"[\s\S]*?<VideoGrid[\s\S]*?videos=\{latest\}[\s\S]*?skeletonCount=\{displayCount\}/);
-  assert.doesNotMatch(
-    homeSource.match(/<SectionHeader title="最新视频"[\s\S]*?<\/div>/)?.[0] ?? "",
-    /eagerCount|highPriorityCount/
+  // 首页两个 tab 共用一个虚拟网格，优先级提示只给首屏那几张。
+  assert.match(
+    homeSource,
+    /<VirtualVideoGrid\s+videos=\{feedItems\}\s+eagerCount=\{eagerCount\}\s+highPriorityCount=\{1\}/
+  );
+  assert.match(homeSource, /const eagerCount = isMobile \? 2 : 4;/);
+  assert.match(
+    homeSource,
+    /<VideoGrid videos=\{\[\]\} loading skeletonCount=\{feedBatchSize\} \/>/
   );
 });
 

--- a/tests/videoThumbnail.test.ts
+++ b/tests/videoThumbnail.test.ts
@@ -76,7 +76,7 @@ test("only likely first-viewport thumbnails receive eager and high priority hint
   assert.match(homeSource, /const eagerCount = isMobile \? 2 : 4;/);
   assert.match(
     homeSource,
-    /<VideoGrid videos=\{\[\]\} loading skeletonCount=\{feedBatchSize\} \/>/
+    /<VideoGrid videos=\{\[\]\} loading skeletonCount=\{feedSource\.batchSize\} \/>/
   );
 });
 

--- a/tests/virtualGrid.test.ts
+++ b/tests/virtualGrid.test.ts
@@ -33,32 +33,22 @@ test("each row maps to its own slice of the list", () => {
   assert.deepEqual(virtualRowRange(0, 4, 0), { start: 0, end: 0 });
 });
 
-test("grid columns are read from the computed template and fall back to one", () => {
-  const grid = (gridTemplateColumns: string) => ({
-    display: "grid",
-    gridTemplateColumns,
-  });
-
-  assert.equal(virtualGridColumns(grid("240px 240px 240px 240px")), 4);
-  assert.equal(virtualGridColumns(grid("  180px   180px  ")), 2);
-  assert.equal(virtualGridColumns(grid("none")), 1);
-  assert.equal(virtualGridColumns(grid("")), 1);
-  // compact 视图是 flex 列表：此时 grid-template-columns 仍是未解析的写法，
-  // 按空格切会被误读成 3 列，进而把三张卡塞进同一个虚拟行。
+test("grid columns are known before the first browser paint", () => {
   assert.equal(
-    virtualGridColumns({
-      display: "flex",
-      gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-    }),
-    1
+    virtualGridColumns({ compact: false, mobile: false, tablet: false }),
+    4
   );
   assert.equal(
-    virtualGridColumns({
-      display: "grid",
-      gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-    }),
-    1,
-    "轨道没被解析成具体宽度时不能猜列数"
+    virtualGridColumns({ compact: false, mobile: false, tablet: true }),
+    3
+  );
+  assert.equal(
+    virtualGridColumns({ compact: false, mobile: true, tablet: true }),
+    2
+  );
+  assert.equal(
+    virtualGridColumns({ compact: true, mobile: false, tablet: false }),
+    1
   );
 });
 

--- a/tests/virtualGrid.test.ts
+++ b/tests/virtualGrid.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  shouldLoadMore,
+  virtualGridColumns,
+  virtualRowCount,
+  virtualRowRange,
+} from "../src/lib/virtualGrid.ts";
+
+test("the flat video list is folded into whole rows", () => {
+  assert.equal(virtualRowCount(0, 4), 0);
+  assert.equal(virtualRowCount(8, 4), 2);
+  assert.equal(virtualRowCount(9, 4), 3, "末行不满也要占一行");
+  assert.equal(virtualRowCount(9, 1), 9);
+});
+
+test("row folding degrades to a single column instead of dividing by zero", () => {
+  assert.equal(virtualRowCount(3, 0), 3);
+  assert.equal(virtualRowCount(3, Number.NaN), 3);
+  assert.deepEqual(virtualRowRange(1, 0, 3), { start: 1, end: 2 });
+});
+
+test("each row maps to its own slice of the list", () => {
+  assert.deepEqual(virtualRowRange(0, 4, 10), { start: 0, end: 4 });
+  assert.deepEqual(virtualRowRange(1, 4, 10), { start: 4, end: 8 });
+  assert.deepEqual(
+    virtualRowRange(2, 4, 10),
+    { start: 8, end: 10 },
+    "末行按实际条数收口，不能读到列表外"
+  );
+  assert.deepEqual(virtualRowRange(5, 4, 10), { start: 10, end: 10 });
+  assert.deepEqual(virtualRowRange(-1, 4, 10), { start: 0, end: 0 });
+  assert.deepEqual(virtualRowRange(0, 4, 0), { start: 0, end: 0 });
+});
+
+test("grid columns are read from the computed template and fall back to one", () => {
+  const grid = (gridTemplateColumns: string) => ({
+    display: "grid",
+    gridTemplateColumns,
+  });
+
+  assert.equal(virtualGridColumns(grid("240px 240px 240px 240px")), 4);
+  assert.equal(virtualGridColumns(grid("  180px   180px  ")), 2);
+  assert.equal(virtualGridColumns(grid("none")), 1);
+  assert.equal(virtualGridColumns(grid("")), 1);
+  // compact 视图是 flex 列表：此时 grid-template-columns 仍是未解析的写法，
+  // 按空格切会被误读成 3 列，进而把三张卡塞进同一个虚拟行。
+  assert.equal(
+    virtualGridColumns({
+      display: "flex",
+      gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+    }),
+    1
+  );
+  assert.equal(
+    virtualGridColumns({
+      display: "grid",
+      gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+    }),
+    1,
+    "轨道没被解析成具体宽度时不能猜列数"
+  );
+});
+
+test("the load-more trigger comes from the render window and stops at the end", () => {
+  const base = {
+    itemCount: 60,
+    columns: 4,
+    hasMore: true,
+    loading: false,
+    prefetchRows: 2,
+  };
+
+  assert.equal(shouldLoadMore({ ...base, endIndex: 40 }), false);
+  assert.equal(shouldLoadMore({ ...base, endIndex: 52 }), true);
+  assert.equal(shouldLoadMore({ ...base, endIndex: 60 }), true);
+  assert.equal(
+    shouldLoadMore({ ...base, endIndex: 60, loading: true }),
+    false,
+    "a request in flight must not be duplicated"
+  );
+  assert.equal(
+    shouldLoadMore({ ...base, endIndex: 60, hasMore: false }),
+    false,
+    "an exhausted list must stop triggering loads"
+  );
+});


### PR DESCRIPTION
Closes #80

## 中文

### 改动内容

**列表页（`/list`）**：原本每 20 条一页，浏览大库要反复点分页条，而且一整页卡片会同时挂进 DOM。现在改成游标式累积 + 窗口化渲染：

- `useInfiniteListing` 按查询条件维护一个累积会话。游标按**请求数量**推进而不是渲染数量 —— 服务端去重和隐藏行不会让偏移量错位；批次按 id 合并，因为滚动过程中有视频增删时页边界会移动。
- `VirtualVideoGrid` 把扁平列表折成行，交给 `@tanstack/react-virtual` 的 window virtualizer，只有视口附近的行保持挂载，同时画布高度撑满整个库，滚动条比例正确。行高和列数从真实布局测量，所以现有的响应式栅格 CSS 依然主导视觉。
- 加载更多由**渲染窗口**推导，而不是单独的哨兵节点 —— 虚拟列表会把哨兵回收掉。加载中、到底了、尾部出错三种状态都在列表底部；尾部失败只重试那一批。
- 前进/后退会同时恢复已加载批次和滚动位置。进度按 history entry 存储，位置在列表还在屏幕上时捕获：在 unmount 阶段读 `window.scrollY` 拿到的是浏览器已经按下一页较短文档钳制过的值。

**首页**：原本是「随机推荐」和「最新视频」两个固定区块，各封顶 12 张卡片，除了刷新按钮没有别的浏览方式。现在改成标签栏，每个标签是一条无限滚动的虚拟化 feed：

- 累积引擎抽象出 feed source，同一套批次、去重、中断、会话缓存逻辑同时支撑列表页和首页标签。source 只描述「第 N 批怎么取」。
- 「随机推荐」保留轮换的 `/api/home`。它的游标在服务端、每次最多 12 条且非幂等，所以 source 会钳制批次大小、放弃 refetch 式恢复，并在一整批全是已在屏视频时判定 feed 结束。
- 「最新视频」改读 `/api/list?sort=latest` 而不是 `/api/home/latest` —— 后者只循环最新 96 行，撑不起无限滚动。
- 当前标签是 URL 参数，前进后退能回到原来那个标签，连同已加载批次和位置。
- 刷新按钮只留在「随机推荐」上，重新洗牌才是这个按钮的语义；时间序标签上它无事可做。

搜索和标签结果保持分页 —— 那是用户会刻意翻回去的结果集。

### 关于 issue 里建议的方案

issue 里提到 `react-window` / `react-virtuoso` / `@tanstack/virtual` 三选一，这里用的是 `@tanstack/react-virtual`（唯一新增依赖）。选它是因为它的 **window virtualizer** 直接虚拟化页面滚动，不需要给列表套一个固定高度的滚动容器 —— 后者会破坏现有的整页滚动手感和移动端地址栏收起行为。

触发方式没有用 Intersection Observer 哨兵，原因见上：虚拟列表会把哨兵节点回收掉，导致触发时灵时不灵。

### 测试

新增/更新 9 个测试文件，覆盖：批次累积与按 id 合并、游标推进、中断与会话缓存、行折叠与列数测量、尾部错误只重试该批、滚动位置在 unmount 前捕获、标签状态随 URL 前进后退、随机 feed 的结束判定。

`tsc --noEmit` 干净，521 个前端测试全部通过。另外在一个 600 条视频的库上用浏览器实测：两个标签都能连续加载，DOM 最多保持约 32 张卡片，最新标签能滚过 96 行的首页轮换上限，标签状态在前进后退后保持。

---

## English

### What changed

**Listing page (`/list`)**: it paged through videos twenty at a time, so browsing a large catalog meant repeated round trips through the pagination bar, and rendering a whole page put every card in the DOM. Replaced with cursor-style accumulation plus windowed rendering:

- `useInfiniteListing` keeps one accumulating session per query. The cursor advances by **requested** count rather than rendered count, so server-side dedup and hidden rows cannot shift the offsets, and batches are merged by id because page boundaries move when videos are inserted or removed mid-scroll.
- `VirtualVideoGrid` folds the flat list into rows and hands them to `@tanstack/react-virtual`'s window virtualizer, so only the rows near the viewport stay mounted while the canvas keeps the scrollbar as tall as the full catalog. Row heights and column counts are measured from the real layout, so the existing responsive grid CSS still drives the design.
- Loading more is derived from the rendered window instead of a separate sentinel node, which a virtualized list can recycle out from under itself. Loading, end-of-list and tail-error states live at the bottom of the list; a failed tail retries only that batch.
- Back/forward restores both the loaded batches and the position. Progress is stored per history entry, and the position is captured while the list is still on screen: reading `window.scrollY` during unmount returns a value the browser already clamped against the next page's shorter document.

**Home page**: it stacked two fixed-size sections, 随机推荐 above 最新视频, each capped at twelve cards with a refresh button as the only way to see anything else. They are now a tab bar, each tab an infinite-scrolling virtualized feed:

- The accumulation engine takes a feed source, so the same batching, dedup, abort and session-cache logic backs both the listing page and the home tabs. A source describes only how to fetch batch N.
- 随机推荐 keeps the rotating `/api/home` feed. Its cursor lives on the server, capped at twelve per call and not idempotent, so the source clamps the batch size, opts out of restore-by-refetch, and ends the feed when a whole batch turns out to be videos already on screen.
- 最新视频 reads `/api/list?sort=latest` rather than `/api/home/latest`: the home endpoint only ever cycles the newest 96 rows, which cannot back an infinite scroll.
- The active tab is a URL parameter, so back and forward return to the tab the user was on, along with its loaded batches and position.
- Refresh only appears on 随机推荐, where re-rolling the shuffle is what the button means; on the time-ordered tab it had nothing to do.

Search and tag results keep their pagination — those are the results users page back into deliberately.

### On the approach suggested in the issue

The issue listed `react-window` / `react-virtuoso` / `@tanstack/virtual`; this uses `@tanstack/react-virtual`, the only added dependency. It was chosen for its **window virtualizer**, which virtualizes the page scroll directly instead of requiring a fixed-height scroll container around the list — the latter would break the existing whole-page scrolling feel and the mobile address-bar collapse behaviour.

Loading is not triggered by an Intersection Observer sentinel, for the reason above: a virtualized list recycles the sentinel node out from under itself, making the trigger unreliable.

### Tests

Nine test files added or updated, covering batch accumulation and merge-by-id, cursor advancement, abort and session cache, row folding and column measurement, tail errors retrying only their own batch, scroll position captured before unmount, tab state surviving back/forward, and end-of-feed detection for the random feed.

`tsc --noEmit` is clean and all 521 frontend tests pass. Also verified in a browser against a 600-video catalog: both tabs load continuously while the DOM holds at most ~32 cards, the latest tab scrolls well past the 96-row home rotation cap, and tab state survives back/forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
