### PR TITLE
Rebuild the Shorts paging and playback experience

### DIFF
--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -209,6 +209,10 @@ export default function ShortsPage() {
   // 手指正在拖动期间冻结活跃屏判定：IO 看的是视觉位置，跟手时轨道位移一直
   // 在变，它会在一次滑动里反复翻转，每翻一次都是一整套暂停/起播/授权清零。
   const pagerGestureActiveRef = useRef(false);
+  // 用户当前的浏览方向（+1 往后看，-1 往回看）。iOS 只有两个持久 media
+  // element，覆盖不了 prev/active/next 三个位置，备用元素只能放一边——
+  // 放在用户正在去的那一边。
+  const browseDirectionRef = useRef(1);
   const userPausedIndexRef = useRef<number | null>(null);
   const [activeReadyForPreload, setActiveReadyForPreload] = useState(false);
   const [, setUserPausedIndexState] = useState<number | null>(null);
@@ -277,6 +281,11 @@ export default function ShortsPage() {
   // 事件监听器和 iOS 持久 video effect 都通过 ref 读取当前索引。放在最前面的
   // layout effect 可避免长队列裁剪与上一轮 passive effect 交错时写回旧值。
   useLayoutEffect(() => {
+    const previous = activeIndexRef.current;
+    // 队列裁剪会整体重排索引，那次跳变不代表用户的浏览方向。
+    if (!queueTrimInProgressRef.current && activeIndex !== previous) {
+      browseDirectionRef.current = activeIndex > previous ? 1 : -1;
+    }
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
@@ -854,8 +863,14 @@ export default function ShortsPage() {
   // effect 必须保持 useLayoutEffect——活跃元素得在这一帧画出来之前就位。
   useEffect(() => {
     if (!useIOSSharedVideo || iosStandbyPreloadDisabled) return;
-    const nextIndex = activeIndex + 1;
-    const nextItem = items[nextIndex];
+    // 备用元素跟着浏览方向放，而不是死盯着下一屏。原来只放 activeIndex+1，
+    // 于是往回看时每一条都是冷启动：共享元素得重新换 src、重新取流、重新
+    // 解首帧，用户看到的就是一张静态封面加一段等待。往回连看几条是很常见
+    // 的用法，不该每条都付这个代价。
+    // 方向反转的那一次仍然是冷的——两个持久元素覆盖不了三个位置，这是
+    // iOS 分支的固有约束（见上面关于 WebKit 有声播放授权的注释）。
+    const nextIndex = activeIndex + browseDirectionRef.current;
+    const nextItem = nextIndex >= 0 ? items[nextIndex] : undefined;
     const nextSlot = iosSharedVideoSlots.current.get(nextIndex);
     if (!nextItem || !nextSlot) return;
 

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -37,7 +37,8 @@ import {
   isWindowsPlatform,
   shouldUseDocumentScrollForShorts,
   shouldUseIOSSharedVideo,
-  shouldUseShortsTouchPager,
+  shouldTakeOverShortsScrolling,
+  shouldUseShortsSwipePager,
 } from "@/shorts/platform";
 import {
   isShortsDebugEnabled,
@@ -228,9 +229,10 @@ export default function ShortsPage() {
   );
   // iPhone 浏览器里改用页面滚动，让 Safari 工具栏能随刷动收起。
   const useDocumentScroll = shouldUseDocumentScrollForShorts();
-  // 移动端由页面自己接管上下滑动：跟手、按距离+速度判定切屏、固定时长落点。
-  // 桌面继续用原生 scroll-snap + 滚轮 / 方向键。
-  const useTouchPager = shouldUseShortsTouchPager();
+  // 手势控制器所有设备都挂：pointer 事件同时吃手指和鼠标，桌面因此也能拖拽。
+  const usePagerGestures = shouldUseShortsSwipePager();
+  // 但只有触屏才连原生滚动一起接管；桌面保留 scroll-snap，滚轮和方向键不变。
+  const takeOverScrolling = shouldTakeOverShortsScrolling();
   // Windows 短视频页只保留静音图标；不挂载桌面 hover 音量条，避免点击
   // 图标时因鼠标仍停留在按钮上而展开滑杆。
   const isWindowsShortsPlatform = isWindowsPlatform();
@@ -654,7 +656,7 @@ export default function ShortsPage() {
   }, []);
 
   useShortsSwipePager({
-    enabled: useTouchPager,
+    enabled: usePagerGestures,
     containerRef,
     trackRef,
     usesDocumentScroll: useDocumentScroll,
@@ -837,20 +839,21 @@ export default function ShortsPage() {
     useIOSSharedVideo,
   ]);
 
-  // 下一屏：用备用元素提前把下一条视频拉起来。iOS 分支此前完全没有预加载，
-  // 唯一的 media element 要等滑动到位后才换 src，网盘取链 + 首帧解码整条
-  // 串行发生在用户眼前；桌面/Android 早就预载了 PRELOAD_AHEAD_COUNT 条。
-  // 开始时机沿用同一套高低水位（activeReadyForPreload），当前视频缓冲不
-  // 健康时不去抢它的带宽。
+  // 下一屏：用备用元素提前把下一条视频拉起来。
+  //
+  // 这里**不看** activeReadyForPreload：备用元素承担的正是"下一条"这一档，
+  // 与非 iOS 路径上 getPreloadAheadCount 的下限 1 是同一条规则。那道授权每次
+  // 切屏都清零、要靠当前条真的起播并囤够 4~12 秒缓冲才挣得回来，而正常刷视频
+  // 比这条链路走完还快——挂在它上面就等于"永远来不及"，滑到位时下一条一个
+  // 字节都还没请求过。授权只该决定再往后囤几条；iOS 一共就两个 media element，
+  // 没有"再往后"，所以这里没有它的位置。
   //
   // 这里是普通 useEffect 而不是 useLayoutEffect：备用元素处于隐藏角色，
   // 移动插槽和起 src 都没有当帧的视觉后果，没必要把一次 appendChild 和一次
   // load()（会立刻发网络请求）压进浏览器绘制前的同步块里。上面那个提升
   // effect 必须保持 useLayoutEffect——活跃元素得在这一帧画出来之前就位。
   useEffect(() => {
-    if (!useIOSSharedVideo || iosStandbyPreloadDisabled || !activeReadyForPreload) {
-      return;
-    }
+    if (!useIOSSharedVideo || iosStandbyPreloadDisabled) return;
     const nextIndex = activeIndex + 1;
     const nextItem = items[nextIndex];
     const nextSlot = iosSharedVideoSlots.current.get(nextIndex);
@@ -875,10 +878,12 @@ export default function ShortsPage() {
     standby.poster = nextItem.poster;
     standby.src = nextItem.videoSrc;
     standby.load();
+    // 光把字节拉下来还是一张静态图：video 在真正播放前一直画 poster。
+    // 拿到元数据后 seek 一次逼它解码首帧，滑到位就直接有画面。
+    warmStandbyFirstFrame(standby);
   }, [
     acquireIOSVideoElement,
     activeIndex,
-    activeReadyForPreload,
     iosStandbyPreloadDisabled,
     items,
     useIOSSharedVideo,
@@ -913,7 +918,7 @@ export default function ShortsPage() {
       body.classList.add("shorts-document-scroll");
       // 文档滚动 + 自接管手势（?shortsPager=1）时要一并关掉根元素的吸附点，
       // 否则程序化写入的 scrollY 会被浏览器重新吸附，逐帧跟手直接失效。
-      if (useTouchPager) {
+      if (takeOverScrolling) {
         html.classList.add("is-touch-paged");
         body.classList.add("is-touch-paged");
       }
@@ -953,7 +958,7 @@ export default function ShortsPage() {
         }
       }
     };
-  }, [useDocumentScroll, useTouchPager]);
+  }, [useDocumentScroll, takeOverScrolling]);
 
   // 用稳定 feed key 在真实 DOM 中找下一条；不闭包 items/index，既能跨队列
   // 裁剪，也不会每取回一批就换回调引用、击穿 ShortsSlide 的 memo。
@@ -983,7 +988,7 @@ export default function ShortsPage() {
   return (
     <div
       className={`shorts-page${useDocumentScroll ? " is-document-scroll" : ""}${
-        useTouchPager ? " is-touch-paged" : ""
+        takeOverScrolling ? " is-touch-paged" : ""
       }${legacyVideoTransitionEnabled ? " has-video-transition" : ""}`}
     >
       <header className="shorts-header">
@@ -1055,7 +1060,7 @@ export default function ShortsPage() {
       )}
 
       <div
-        className={`shorts-feed${useTouchPager ? " is-touch-paged" : ""}`}
+        className={`shorts-feed${takeOverScrolling ? " is-touch-paged" : ""}`}
         ref={containerRef}
       >
         <div className="shorts-feed__track" ref={trackRef}>
@@ -1191,6 +1196,35 @@ export default function ShortsPage() {
       </div>
     </div>
   );
+}
+
+/**
+ * iOS 备用元素的首帧预热。它停在下一屏的插槽里，绑了源却只画 poster——
+ * 按 HTML 渲染模型，video 在播放真正开始前一直呈现 poster frame，缓冲多满
+ * 都一样。seek 一次即可清掉这个标志并强制解码首帧。
+ * 一次性监听：src 换了会重新走这条路。
+ */
+function warmStandbyFirstFrame(video: HTMLVideoElement) {
+  const nudge = () => {
+    if (
+      !shouldWarmFirstFrame({
+        isActive: false,
+        shouldLoad: true,
+        isPlaybackElement: false,
+        readyState: video.readyState,
+        currentTime: video.currentTime,
+      })
+    ) {
+      return;
+    }
+    try {
+      video.currentTime = FIRST_FRAME_WARM_TIME;
+    } catch {
+      // 部分 ready state 下 seek 会抛错；另一个事件还会再试一次。
+    }
+  };
+  video.addEventListener("loadedmetadata", nudge, { once: true });
+  video.addEventListener("loadeddata", nudge, { once: true });
 }
 
 /**
@@ -2238,7 +2272,7 @@ function ShortsSlideImpl({
         !shouldWarmFirstFrame({
           isActive,
           shouldLoad,
-          usesSharedVideo,
+          isPlaybackElement: usesSharedVideo,
           readyState: video.readyState,
           currentTime: video.currentTime,
         })

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -21,11 +21,14 @@ import { hideVideo, setVideoLike, type ShortsItem } from "@/data/videos";
 import {
   averageBytesPerSecond,
   clamp,
+  FIRST_FRAME_WARM_TIME,
+  getPreloadAheadCount,
   getVideoWindowBounds,
   preloadBufferSecondsFor,
   preloadKeepSecondsFor,
   videoBufferIsCritical,
   videoHasBufferedData,
+  shouldWarmFirstFrame,
   videoHasComfortableBuffer,
 } from "@/shorts/mediaBuffer";
 import {
@@ -64,8 +67,6 @@ import {
 } from "@/lib/videoShareClipboard";
 import "@/styles/shorts.css";
 
-// 当前视频流畅播放后，向后预加载多少条视频。
-const PRELOAD_AHEAD_COUNT = 2;
 
 // 距当前屏多少条以内的 slide 才渲染真正的内容（背景、海报、文案、操作栏）。
 // 即使队列已经有几十条，也只让附近 slide 持有位图和完整子树；窗口外退化成
@@ -204,6 +205,9 @@ export default function ShortsPage() {
   // Windows 退出浏览器全屏时视口高度会改变。调整滚动位置期间锁住当前
   // slide，避免 IntersectionObserver 把新的像素位置误判成后续视频。
   const viewportResizeAnchorIndexRef = useRef<number | null>(null);
+  // 手指正在拖动期间冻结活跃屏判定：IO 看的是视觉位置，跟手时轨道位移一直
+  // 在变，它会在一次滑动里反复翻转，每翻一次都是一整套暂停/起播/授权清零。
+  const pagerGestureActiveRef = useRef(false);
   const userPausedIndexRef = useRef<number | null>(null);
   const [activeReadyForPreload, setActiveReadyForPreload] = useState(false);
   const [, setUserPausedIndexState] = useState<number | null>(null);
@@ -224,9 +228,9 @@ export default function ShortsPage() {
   );
   // iPhone 浏览器里改用页面滚动，让 Safari 工具栏能随刷动收起。
   const useDocumentScroll = shouldUseDocumentScrollForShorts();
-  // 移动端由页面自己接管上下滑动：跟手、按距离+速度判定切屏、惯性收尾。
+  // 移动端由页面自己接管上下滑动：跟手、按距离+速度判定切屏、固定时长落点。
   // 桌面继续用原生 scroll-snap + 滚轮 / 方向键。
-  const useTouchPager = shouldUseShortsTouchPager(useDocumentScroll);
+  const useTouchPager = shouldUseShortsTouchPager();
   // Windows 短视频页只保留静音图标；不挂载桌面 hover 音量条，避免点击
   // 图标时因鼠标仍停留在按钮上而展开滑杆。
   const isWindowsShortsPlatform = isWindowsPlatform();
@@ -580,7 +584,8 @@ export default function ShortsPage() {
       (entries) => {
         if (
           viewportResizeAnchorIndexRef.current !== null ||
-          queueTrimInProgressRef.current
+          queueTrimInProgressRef.current ||
+          pagerGestureActiveRef.current
         ) {
           return;
         }
@@ -644,12 +649,17 @@ export default function ShortsPage() {
   // 移动端的上下滑动手势。activeIndex 仍然只由上面的 IntersectionObserver
   // 决定：这个 hook 只负责把手指位移写进同一个 scrollTop，播放 / 预载 /
   // iOS 共享元素那条链路完全不受影响。
+  const handlePagerGestureActiveChange = useCallback((active: boolean) => {
+    pagerGestureActiveRef.current = active;
+  }, []);
+
   useShortsSwipePager({
     enabled: useTouchPager,
     containerRef,
     trackRef,
     usesDocumentScroll: useDocumentScroll,
     getAnchorSlide: getActiveSlideElement,
+    onGestureActiveChange: handlePagerGestureActiveChange,
   });
 
   // 先停掉所有非当前屏。当前屏的 play() 由 ShortsSlide 负责，
@@ -1089,11 +1099,13 @@ export default function ShortsPage() {
             const isInCacheWindow =
               index >= videoWindow.start && index <= videoWindow.end;
             const preloadOffset = index - activeIndex;
+            // 下一条无条件预载，再往后才受"当前屏缓冲健康"的授权节流。
+            // 详见 getPreloadAheadCount 的注释：让下一条"存在"和"后台囤积"
+            // 是两件成本差一个数量级的事，不该共用一个开关。
             const shouldPreload =
               !useIOSSharedVideo &&
-              activeReadyForPreload &&
               preloadOffset > 0 &&
-              preloadOffset <= PRELOAD_AHEAD_COUNT;
+              preloadOffset <= getPreloadAheadCount(activeReadyForPreload);
             const shouldMount =
               isActiveSlide ||
               (!useIOSSharedVideo && (isInCacheWindow || shouldPreload));
@@ -2215,8 +2227,36 @@ function ShortsSlideImpl({
       }
     }
 
+    /**
+     * 预载条的首帧预热。字节下下来了不等于有画面：video 元素在真正开始播放
+     * 之前一直画 poster，哪怕缓冲已满。写一次 currentTime 触发 seek，强制它
+     * 解码并呈现真实首帧，滑到这一屏时就不再是一张静态封面。
+     * 全程静音、不播放，判定条件见 shouldWarmFirstFrame。
+     */
+    const warmFirstFrame = () => {
+      if (
+        !shouldWarmFirstFrame({
+          isActive,
+          shouldLoad,
+          usesSharedVideo,
+          readyState: video.readyState,
+          currentTime: video.currentTime,
+        })
+      ) {
+        return;
+      }
+      try {
+        video.currentTime = FIRST_FRAME_WARM_TIME;
+      } catch {
+        // 少数 ready state 下 seek 会抛错；下一次 loadeddata 还会再试。
+      }
+    };
+
     handleLoaded();
     handleTime();
+    warmFirstFrame();
+    video.addEventListener("loadedmetadata", warmFirstFrame);
+    video.addEventListener("loadeddata", warmFirstFrame);
     video.addEventListener("loadedmetadata", handleLoaded);
     video.addEventListener("durationchange", handleLoaded);
     video.addEventListener("timeupdate", handleTime);
@@ -2236,6 +2276,8 @@ function ShortsSlideImpl({
     }
 
     return () => {
+      video.removeEventListener("loadedmetadata", warmFirstFrame);
+      video.removeEventListener("loadeddata", warmFirstFrame);
       video.removeEventListener("loadedmetadata", handleLoaded);
       video.removeEventListener("durationchange", handleLoaded);
       video.removeEventListener("timeupdate", handleTime);

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -53,6 +53,7 @@ import {
 import { useShortsSlideGestures } from "@/shorts/useShortsSlideGestures";
 import {
   measureOffsetWithinSlide,
+  readShortsSlideTopWithinTrack,
   useShortsSwipePager,
 } from "@/shorts/useShortsSwipePager";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
@@ -159,6 +160,11 @@ export default function ShortsPage() {
   }, []);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // 承载滑动位移的轨道。它没有定位也没有常驻 transform，slide 的 offsetTop
+  // 和 nextElementSibling 关系都不受影响；只有手势 / 落点动画进行中才会被
+  // 写上 translate3d，落定立刻清掉——不给 WebKit 在 <video> 祖先上留常驻
+  // 合成层（本页在 iOS 合成路径上踩过坑，见 .shorts-page 的注释）。
+  const trackRef = useRef<HTMLDivElement | null>(null);
   const itemsLengthRef = useRef(items.length);
   itemsLengthRef.current = items.length;
   // 整页只建一个 slide 观察器，新批次到达时增量补充观察目标。
@@ -395,6 +401,7 @@ export default function ShortsPage() {
       activeIndex: nextActiveIndex,
       offsetWithinAnchor: measureOffsetWithinActiveSlide(
         root,
+        trackRef.current,
         activeIndex,
         useDocumentScroll
       ),
@@ -483,15 +490,15 @@ export default function ShortsPage() {
     if (root && slide) {
       // 还原裁剪那一刻锚点内的偏移：切屏动画进行到一半时被裁剪打断，也只是
       // 坐标系整体平移，画面不会跳回吸附点。偏移已在测量时夹在一屏之内。
-      const offsetWithinAnchor = pending.offsetWithinAnchor;
+      // 位置和测量用同一个参照系（轨道），两边都不受 transform 影响。
+      const track = trackRef.current;
+      const top = track
+        ? readShortsSlideTopWithinTrack(slide, track) + pending.offsetWithinAnchor
+        : slide.offsetTop + pending.offsetWithinAnchor;
       if (useDocumentScroll) {
-        const top =
-          window.scrollY +
-          slide.getBoundingClientRect().top +
-          offsetWithinAnchor;
         window.scrollTo({ top: Math.max(0, top), behavior: "auto" });
       } else {
-        root.scrollTop = Math.max(0, slide.offsetTop + offsetWithinAnchor);
+        root.scrollTop = Math.max(0, top);
       }
     }
     pendingQueueTrimRef.current = null;
@@ -640,6 +647,7 @@ export default function ShortsPage() {
   useShortsSwipePager({
     enabled: useTouchPager,
     containerRef,
+    trackRef,
     usesDocumentScroll: useDocumentScroll,
     getAnchorSlide: getActiveSlideElement,
   });
@@ -1040,154 +1048,160 @@ export default function ShortsPage() {
         className={`shorts-feed${useTouchPager ? " is-touch-paged" : ""}`}
         ref={containerRef}
       >
-        {loading && items.length === 0 && !empty && !loadError && (
-          <div className="shorts-empty shorts-loading" aria-live="polite">
-            <div className="shorts-empty__content">
-              <ShortsLoadingSpinner size={30} />
-              <p>正在加载短视频</p>
+        <div className="shorts-feed__track" ref={trackRef}>
+          {loading && items.length === 0 && !empty && !loadError && (
+            <div className="shorts-empty shorts-loading" aria-live="polite">
+              <div className="shorts-empty__content">
+                <ShortsLoadingSpinner size={30} />
+                <p>正在加载短视频</p>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {loadError && items.length === 0 && (
-          <div className="shorts-empty" role="alert">
-            <div className="shorts-empty__content">
-              <p>短视频加载失败，请检查网络后重试</p>
-              <button
-                type="button"
-                className="shorts-empty__link"
-                onClick={() => void loadMore()}
-              >
-                重新加载
-              </button>
+          {loadError && items.length === 0 && (
+            <div className="shorts-empty" role="alert">
+              <div className="shorts-empty__content">
+                <p>短视频加载失败，请检查网络后重试</p>
+                <button
+                  type="button"
+                  className="shorts-empty__link"
+                  onClick={() => void loadMore()}
+                >
+                  重新加载
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {empty && items.length === 0 && (
-          <div className="shorts-empty">
-            <AdminEmptyVisual
-              variant="empty"
-              text="当前库中没有视频"
-              className="shorts-empty__visual"
-            />
-          </div>
-        )}
-
-        {items.map((item, index) => {
-          const itemKey = shortsQueueItemKey(item);
-          const isActiveSlide = index === activeIndex;
-          const isInCacheWindow =
-            index >= videoWindow.start && index <= videoWindow.end;
-          const preloadOffset = index - activeIndex;
-          const shouldPreload =
-            !useIOSSharedVideo &&
-            activeReadyForPreload &&
-            preloadOffset > 0 &&
-            preloadOffset <= PRELOAD_AHEAD_COUNT;
-          const shouldMount =
-            isActiveSlide ||
-            (!useIOSSharedVideo && (isInCacheWindow || shouldPreload));
-          // 视频窗口内已经缓冲过的视频保留 src：
-          // 在窗口内来回切换时，直接复用浏览器已缓冲数据。
-          const shouldRetainCached =
-            !useIOSSharedVideo &&
-            isInCacheWindow &&
-            !isActiveSlide &&
-            cacheableSourceIds.has(item.id);
-          const shouldLoad = isActiveSlide || shouldPreload || shouldRetainCached;
-          const shouldEagerLoad = isActiveSlide || shouldPreload;
-          // 视口附近的照常渲染；再加上所有还挂着 <video> 的 slide——那些是
-          // 有意保留的缓冲，不能因为离开视口就被拆掉。两者之和有上限，
-          // 与队列长度无关。
-          const shouldRenderContent =
-            Math.abs(preloadOffset) <= SLIDE_CONTENT_WINDOW_RADIUS ||
-            shouldMount ||
-            shouldRetainCached;
-          return (
-            <ShortsSlide
-              key={itemKey}
-              item={item}
-              itemKey={itemKey}
-              index={index}
-              isActive={isActiveSlide}
-              // 固定 4 条视频窗口内才挂载 <video> 壳；
-              // 当前屏先绑定 src；后两个视频等当前屏缓冲健康后再预加载；
-              // 已缓冲过的窗口内视频保留 src，便于来回切换复用缓存。
-              shouldMount={shouldMount}
-              shouldLoad={shouldLoad}
-              shouldEagerLoad={shouldEagerLoad}
-              shouldRenderContent={shouldRenderContent}
-              keyboardSeekPreview={
-                keyboardSeekPreview?.videoIndex === index
-                  ? keyboardSeekPreview
-                  : undefined
-              }
-              sharedVideoRef={
-                useIOSSharedVideo ? iosSharedVideoRef : undefined
-              }
-              sharedVideoSlotRef={
-                useIOSSharedVideo
-                  ? setIOSSharedVideoSlotRef(index)
-                  : undefined
-              }
-              muted={muted}
-              videoRef={setVideoRef(index)}
-              onLikeToggle={handleLikeToggle}
-              hasLiked={hasLiked}
-              registerKeyboardLikeHandler={registerKeyboardLikeHandler}
-              canHide={isAdmin}
-              onHideSuccess={handleHideSuccess}
-              onActiveReadyForPreload={handleActiveReadyForPreload}
-              onActiveNeedsPriority={handleActiveNeedsPriority}
-              onSourceCached={handleSourceCached}
-              onUserPausedChange={setUserPausedForIndex}
-              isVideoPausedByUser={isVideoPausedByUser}
-              onRouteClick={handleShortsRouteClick}
-              showHud={showHud}
-              loopDebugProbeRef={
-                debugHudEnabled ? loopDebugProbeRef : undefined
-              }
-            />
-          );
-        })}
-
-        {loadError && items.length > 0 && (
-          <div className="shorts-empty" role="alert">
-            <div className="shorts-empty__content">
-              <p>后续视频加载失败</p>
-              <button
-                type="button"
-                className="shorts-empty__link"
-                onClick={() => void loadMore()}
-              >
-                重新加载
-              </button>
+          {empty && items.length === 0 && (
+            <div className="shorts-empty">
+              <AdminEmptyVisual
+                variant="empty"
+                text="当前库中没有视频"
+                className="shorts-empty__visual"
+              />
             </div>
-          </div>
-        )}
+          )}
+
+          {items.map((item, index) => {
+            const itemKey = shortsQueueItemKey(item);
+            const isActiveSlide = index === activeIndex;
+            const isInCacheWindow =
+              index >= videoWindow.start && index <= videoWindow.end;
+            const preloadOffset = index - activeIndex;
+            const shouldPreload =
+              !useIOSSharedVideo &&
+              activeReadyForPreload &&
+              preloadOffset > 0 &&
+              preloadOffset <= PRELOAD_AHEAD_COUNT;
+            const shouldMount =
+              isActiveSlide ||
+              (!useIOSSharedVideo && (isInCacheWindow || shouldPreload));
+            // 视频窗口内已经缓冲过的视频保留 src：
+            // 在窗口内来回切换时，直接复用浏览器已缓冲数据。
+            const shouldRetainCached =
+              !useIOSSharedVideo &&
+              isInCacheWindow &&
+              !isActiveSlide &&
+              cacheableSourceIds.has(item.id);
+            const shouldLoad = isActiveSlide || shouldPreload || shouldRetainCached;
+            const shouldEagerLoad = isActiveSlide || shouldPreload;
+            // 视口附近的照常渲染；再加上所有还挂着 <video> 的 slide——那些是
+            // 有意保留的缓冲，不能因为离开视口就被拆掉。两者之和有上限，
+            // 与队列长度无关。
+            const shouldRenderContent =
+              Math.abs(preloadOffset) <= SLIDE_CONTENT_WINDOW_RADIUS ||
+              shouldMount ||
+              shouldRetainCached;
+            return (
+              <ShortsSlide
+                key={itemKey}
+                item={item}
+                itemKey={itemKey}
+                index={index}
+                isActive={isActiveSlide}
+                // 固定 4 条视频窗口内才挂载 <video> 壳；
+                // 当前屏先绑定 src；后两个视频等当前屏缓冲健康后再预加载；
+                // 已缓冲过的窗口内视频保留 src，便于来回切换复用缓存。
+                shouldMount={shouldMount}
+                shouldLoad={shouldLoad}
+                shouldEagerLoad={shouldEagerLoad}
+                shouldRenderContent={shouldRenderContent}
+                keyboardSeekPreview={
+                  keyboardSeekPreview?.videoIndex === index
+                    ? keyboardSeekPreview
+                    : undefined
+                }
+                sharedVideoRef={
+                  useIOSSharedVideo ? iosSharedVideoRef : undefined
+                }
+                sharedVideoSlotRef={
+                  useIOSSharedVideo
+                    ? setIOSSharedVideoSlotRef(index)
+                    : undefined
+                }
+                muted={muted}
+                videoRef={setVideoRef(index)}
+                onLikeToggle={handleLikeToggle}
+                hasLiked={hasLiked}
+                registerKeyboardLikeHandler={registerKeyboardLikeHandler}
+                canHide={isAdmin}
+                onHideSuccess={handleHideSuccess}
+                onActiveReadyForPreload={handleActiveReadyForPreload}
+                onActiveNeedsPriority={handleActiveNeedsPriority}
+                onSourceCached={handleSourceCached}
+                onUserPausedChange={setUserPausedForIndex}
+                isVideoPausedByUser={isVideoPausedByUser}
+                onRouteClick={handleShortsRouteClick}
+                showHud={showHud}
+                loopDebugProbeRef={
+                  debugHudEnabled ? loopDebugProbeRef : undefined
+                }
+              />
+            );
+          })}
+
+          {loadError && items.length > 0 && (
+            <div className="shorts-empty" role="alert">
+              <div className="shorts-empty__content">
+                <p>后续视频加载失败</p>
+                <button
+                  type="button"
+                  className="shorts-empty__link"
+                  onClick={() => void loadMore()}
+                >
+                  重新加载
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
 }
 
 /**
- * 队列裁剪前，当前屏在滚动方向上偏离吸附点多少。两种滚动模式下"容器上沿"
- * 分别是 feed 的 rect.top 和视口顶端，其余计算共用同一个纯函数。
+ * 队列裁剪前，当前屏在滚动方向上偏离吸附点多少。
+ *
+ * slide 的位置必须相对**轨道**来量，不能相对 feed 或视口：滑动手势进行中
+ * 轨道上挂着 translateY，相对视口的 rect 会把这段位移重复计入，重贴时画面
+ * 会跳一整屏。两个 rect 受同一个 transform 影响，相减正好把它消掉。
  */
 function measureOffsetWithinActiveSlide(
   root: HTMLElement | null,
+  track: HTMLElement | null,
   activeIndex: number,
   usesDocumentScroll: boolean
 ): number {
-  if (!root) return 0;
+  if (!root || !track) return 0;
   const slide = root.querySelector<HTMLElement>(
     `[data-shorts-slide][data-index="${activeIndex}"]`
   );
   if (!slide) return 0;
-  const base = usesDocumentScroll ? 0 : root.getBoundingClientRect().top;
   return measureOffsetWithinSlide({
-    slideTop: slide.getBoundingClientRect().top - base,
+    scrollTop: usesDocumentScroll ? window.scrollY : root.scrollTop,
+    slideTop: readShortsSlideTopWithinTrack(slide, track),
     viewportHeight: usesDocumentScroll ? window.innerHeight : root.clientHeight,
   });
 }

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -2793,7 +2793,11 @@ function ShortsSlideImpl({
 
 
 
-      {paused && !playbackFailure && isActive && !scrubbing && (
+      {paused &&
+        !playbackFailure &&
+        isActive &&
+        !scrubbing &&
+        !isMarkedHidden && (
         <div className="shorts-slide__paused" aria-hidden="true">
           <span className="shorts-slide__paused-icon">
             <Play size={22} fill="currentColor" strokeWidth={1.75} />

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -2824,19 +2824,13 @@ function ShortsSlideImpl({
           onClick={(e) => e.stopPropagation()}
         >
           <AlertCircle size={28} aria-hidden="true" />
-          <div className="shorts-slide__playback-error-copy">
-            <div className="shorts-slide__playback-error-title">播放失败</div>
-            <div className="shorts-slide__playback-error-message">
-              视频暂时无法播放
-            </div>
-          </div>
+          <div className="shorts-slide__playback-error-title">播放失败</div>
           <button
             type="button"
             className="shorts-slide__playback-retry"
             onClick={handlePlaybackRetry}
           >
-            <Play size={15} fill="currentColor" aria-hidden="true" />
-            <span>重新播放</span>
+            重试播放
           </button>
         </div>
       )}

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -34,6 +34,7 @@ import {
   isWindowsPlatform,
   shouldUseDocumentScrollForShorts,
   shouldUseIOSSharedVideo,
+  shouldUseShortsTouchPager,
 } from "@/shorts/platform";
 import {
   isShortsDebugEnabled,
@@ -50,6 +51,10 @@ import {
   type ShortsKeyboardSeekPreview,
 } from "@/shorts/useShortsKeyboard";
 import { useShortsSlideGestures } from "@/shorts/useShortsSlideGestures";
+import {
+  measureOffsetWithinSlide,
+  useShortsSwipePager,
+} from "@/shorts/useShortsSwipePager";
 import { AdminEmptyVisual } from "@/admin/AdminEmptyVisual";
 import { useAuth } from "@/admin/AuthContext";
 import {
@@ -183,6 +188,12 @@ export default function ShortsPage() {
   const pendingQueueTrimRef = useRef<{
     anchorKey: string;
     activeIndex: number;
+    /**
+     * 裁剪发生时滚动位置相对锚点 slide 顶端的偏移。切屏动画（原生吸附或
+     * 自定义落点动画）跑到一半时索引就已经推进，裁剪往往正好插在中间；
+     * 重贴时把这段偏移一并还原，视觉位置才是连续的，不会硬跳到吸附点。
+     */
+    offsetWithinAnchor: number;
   } | null>(null);
   // Windows 退出浏览器全屏时视口高度会改变。调整滚动位置期间锁住当前
   // slide，避免 IntersectionObserver 把新的像素位置误判成后续视频。
@@ -207,6 +218,9 @@ export default function ShortsPage() {
   );
   // iPhone 浏览器里改用页面滚动，让 Safari 工具栏能随刷动收起。
   const useDocumentScroll = shouldUseDocumentScrollForShorts();
+  // 移动端由页面自己接管上下滑动：跟手、按距离+速度判定切屏、惯性收尾。
+  // 桌面继续用原生 scroll-snap + 滚轮 / 方向键。
+  const useTouchPager = shouldUseShortsTouchPager(useDocumentScroll);
   // Windows 短视频页只保留静音图标；不挂载桌面 hover 音量条，避免点击
   // 图标时因鼠标仍停留在按钮上而展开滑杆。
   const isWindowsShortsPlatform = isWindowsPlatform();
@@ -374,14 +388,20 @@ export default function ShortsPage() {
     const removeCount = getShortsQueueTrimCount(activeIndex, items.length);
     const nextActiveIndex = activeIndex - removeCount;
     queueTrimInProgressRef.current = true;
+    const root = containerRef.current;
+    // 偏移必须在 DOM 变化之前量：重贴 effect 跑的时候旧 slide 已经不在了。
     pendingQueueTrimRef.current = {
       anchorKey: shortsQueueItemKey(activeItem),
       activeIndex: nextActiveIndex,
+      offsetWithinAnchor: measureOffsetWithinActiveSlide(
+        root,
+        activeIndex,
+        useDocumentScroll
+      ),
     };
 
     // IntersectionObserver 会持有 target；被裁掉前显式 unobserve，避免旧空壳
     // 继续留在观察器内部。裁剪期间忽略迟到的 observer 回调。
-    const root = containerRef.current;
     const observer = slideObserverRef.current;
     if (root && observer) {
       const slides =
@@ -439,6 +459,7 @@ export default function ShortsPage() {
     items,
     trimQueueBefore,
     updateUserPausedIndex,
+    useDocumentScroll,
   ]);
 
   // DOM 已按新索引提交后，把同一个逻辑视频重新贴到视口起点。用实际 offset
@@ -460,11 +481,17 @@ export default function ShortsPage() {
         )
       : undefined;
     if (root && slide) {
+      // 还原裁剪那一刻锚点内的偏移：切屏动画进行到一半时被裁剪打断，也只是
+      // 坐标系整体平移，画面不会跳回吸附点。偏移已在测量时夹在一屏之内。
+      const offsetWithinAnchor = pending.offsetWithinAnchor;
       if (useDocumentScroll) {
-        const top = window.scrollY + slide.getBoundingClientRect().top;
-        window.scrollTo({ top, behavior: "auto" });
+        const top =
+          window.scrollY +
+          slide.getBoundingClientRect().top +
+          offsetWithinAnchor;
+        window.scrollTo({ top: Math.max(0, top), behavior: "auto" });
       } else {
-        root.scrollTop = slide.offsetTop;
+        root.scrollTop = Math.max(0, slide.offsetTop + offsetWithinAnchor);
       }
     }
     pendingQueueTrimRef.current = null;
@@ -596,6 +623,26 @@ export default function ShortsPage() {
       observer.observe(el);
     });
   }, [items.length]);
+
+  // 视口尺寸变化后（旋转、输入法）重新对齐用的当前屏。接管手势后原生吸附
+  // 已关闭，浏览器不会再自己纠正，这个查询就是唯一的锚点来源。
+  const getActiveSlideElement = useCallback(() => {
+    const root = containerRef.current;
+    if (!root) return null;
+    return root.querySelector<HTMLElement>(
+      `[data-shorts-slide][data-index="${activeIndexRef.current}"]`
+    );
+  }, []);
+
+  // 移动端的上下滑动手势。activeIndex 仍然只由上面的 IntersectionObserver
+  // 决定：这个 hook 只负责把手指位移写进同一个 scrollTop，播放 / 预载 /
+  // iOS 共享元素那条链路完全不受影响。
+  useShortsSwipePager({
+    enabled: useTouchPager,
+    containerRef,
+    usesDocumentScroll: useDocumentScroll,
+    getAnchorSlide: getActiveSlideElement,
+  });
 
   // 先停掉所有非当前屏。当前屏的 play() 由 ShortsSlide 负责，
   // 那里能在 Safari 拒绝/中断播放时同步 UI，并在 canplay 后安全重试。
@@ -846,6 +893,12 @@ export default function ShortsPage() {
     if (useDocumentScroll) {
       html.classList.add("shorts-document-scroll");
       body.classList.add("shorts-document-scroll");
+      // 文档滚动 + 自接管手势（?shortsPager=1）时要一并关掉根元素的吸附点，
+      // 否则程序化写入的 scrollY 会被浏览器重新吸附，逐帧跟手直接失效。
+      if (useTouchPager) {
+        html.classList.add("is-touch-paged");
+        body.classList.add("is-touch-paged");
+      }
     } else {
       html.style.overflow = "hidden";
       body.style.overflow = "hidden";
@@ -869,6 +922,8 @@ export default function ShortsPage() {
     return () => {
       html.classList.remove("shorts-document-scroll");
       body.classList.remove("shorts-document-scroll");
+      html.classList.remove("is-touch-paged");
+      body.classList.remove("is-touch-paged");
       html.style.overflow = prevHtmlOverflow;
       body.style.overflow = prevBodyOverflow;
       body.style.background = prevBodyBg;
@@ -880,7 +935,7 @@ export default function ShortsPage() {
         }
       }
     };
-  }, [useDocumentScroll]);
+  }, [useDocumentScroll, useTouchPager]);
 
   // 用稳定 feed key 在真实 DOM 中找下一条；不闭包 items/index，既能跨队列
   // 裁剪，也不会每取回一批就换回调引用、击穿 ShortsSlide 的 memo。
@@ -910,8 +965,8 @@ export default function ShortsPage() {
   return (
     <div
       className={`shorts-page${useDocumentScroll ? " is-document-scroll" : ""}${
-        legacyVideoTransitionEnabled ? " has-video-transition" : ""
-      }`}
+        useTouchPager ? " is-touch-paged" : ""
+      }${legacyVideoTransitionEnabled ? " has-video-transition" : ""}`}
     >
       <header className="shorts-header">
         <Link
@@ -981,7 +1036,10 @@ export default function ShortsPage() {
         />
       )}
 
-      <div className="shorts-feed" ref={containerRef}>
+      <div
+        className={`shorts-feed${useTouchPager ? " is-touch-paged" : ""}`}
+        ref={containerRef}
+      >
         {loading && items.length === 0 && !empty && !loadError && (
           <div className="shorts-empty shorts-loading" aria-live="polite">
             <div className="shorts-empty__content">
@@ -1111,6 +1169,27 @@ export default function ShortsPage() {
       </div>
     </div>
   );
+}
+
+/**
+ * 队列裁剪前，当前屏在滚动方向上偏离吸附点多少。两种滚动模式下"容器上沿"
+ * 分别是 feed 的 rect.top 和视口顶端，其余计算共用同一个纯函数。
+ */
+function measureOffsetWithinActiveSlide(
+  root: HTMLElement | null,
+  activeIndex: number,
+  usesDocumentScroll: boolean
+): number {
+  if (!root) return 0;
+  const slide = root.querySelector<HTMLElement>(
+    `[data-shorts-slide][data-index="${activeIndex}"]`
+  );
+  if (!slide) return 0;
+  const base = usesDocumentScroll ? 0 : root.getBoundingClientRect().top;
+  return measureOffsetWithinSlide({
+    slideTop: slide.getBoundingClientRect().top - base,
+    viewportHeight: usesDocumentScroll ? window.innerHeight : root.clientHeight,
+  });
 }
 
 type SlideProps = {
@@ -2761,6 +2840,8 @@ function ShortsSlideImpl({
           className={`shorts-slide__progress ${
             scrubbing ? "is-scrubbing" : ""
           }`}
+          // 进度条自己就要吃掉整根手指：横向定位、纵向也不该误触发翻页。
+          data-shorts-no-swipe=""
           onPointerDown={handleProgressPointerDown}
           onPointerMove={handleProgressPointerMove}
           onPointerUp={handleProgressPointerEnd}

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -37,7 +37,6 @@ import {
   isWindowsPlatform,
   shouldUseDocumentScrollForShorts,
   shouldUseIOSSharedVideo,
-  shouldTakeOverShortsScrolling,
   shouldUseShortsSwipePager,
 } from "@/shorts/platform";
 import {
@@ -233,10 +232,9 @@ export default function ShortsPage() {
   );
   // iPhone 浏览器里改用页面滚动，让 Safari 工具栏能随刷动收起。
   const useDocumentScroll = shouldUseDocumentScrollForShorts();
-  // 手势控制器所有设备都挂：pointer 事件同时吃手指和鼠标，桌面因此也能拖拽。
+  // 全部滚动输入都由页面自己接管：手指、鼠标拖拽、滚轮共用同一条落点动画。
+  // 凡是留给浏览器的输入通道，"原生吸附手感不可控"这个问题就原样留在那里。
   const usePagerGestures = shouldUseShortsSwipePager();
-  // 但只有触屏才连原生滚动一起接管；桌面保留 scroll-snap，滚轮和方向键不变。
-  const takeOverScrolling = shouldTakeOverShortsScrolling();
   // Windows 短视频页只保留静音图标；不挂载桌面 hover 音量条，避免点击
   // 图标时因鼠标仍停留在按钮上而展开滑杆。
   const isWindowsShortsPlatform = isWindowsPlatform();
@@ -933,9 +931,9 @@ export default function ShortsPage() {
       body.classList.add("shorts-document-scroll");
       // 文档滚动 + 自接管手势（?shortsPager=1）时要一并关掉根元素的吸附点，
       // 否则程序化写入的 scrollY 会被浏览器重新吸附，逐帧跟手直接失效。
-      if (takeOverScrolling) {
-        html.classList.add("is-touch-paged");
-        body.classList.add("is-touch-paged");
+      if (usePagerGestures) {
+        html.classList.add("is-pager-driven");
+        body.classList.add("is-pager-driven");
       }
     } else {
       html.style.overflow = "hidden";
@@ -960,8 +958,8 @@ export default function ShortsPage() {
     return () => {
       html.classList.remove("shorts-document-scroll");
       body.classList.remove("shorts-document-scroll");
-      html.classList.remove("is-touch-paged");
-      body.classList.remove("is-touch-paged");
+      html.classList.remove("is-pager-driven");
+      body.classList.remove("is-pager-driven");
       html.style.overflow = prevHtmlOverflow;
       body.style.overflow = prevBodyOverflow;
       body.style.background = prevBodyBg;
@@ -973,7 +971,7 @@ export default function ShortsPage() {
         }
       }
     };
-  }, [useDocumentScroll, takeOverScrolling]);
+  }, [useDocumentScroll, usePagerGestures]);
 
   // 用稳定 feed key 在真实 DOM 中找下一条；不闭包 items/index，既能跨队列
   // 裁剪，也不会每取回一批就换回调引用、击穿 ShortsSlide 的 memo。
@@ -1003,7 +1001,7 @@ export default function ShortsPage() {
   return (
     <div
       className={`shorts-page${useDocumentScroll ? " is-document-scroll" : ""}${
-        takeOverScrolling ? " is-touch-paged" : ""
+        usePagerGestures ? " is-pager-driven" : ""
       }${legacyVideoTransitionEnabled ? " has-video-transition" : ""}`}
     >
       <header className="shorts-header">
@@ -1075,7 +1073,7 @@ export default function ShortsPage() {
       )}
 
       <div
-        className={`shorts-feed${takeOverScrolling ? " is-touch-paged" : ""}`}
+        className={`shorts-feed${usePagerGestures ? " is-pager-driven" : ""}`}
         ref={containerRef}
       >
         <div className="shorts-feed__track" ref={trackRef}>

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -103,6 +103,9 @@ export default function ShortsPage() {
     : "";
   // 是否静音；首次必须静音才能 autoplay，用户点击后切换
   const [muted, setMuted] = useState(true);
+  // iOS/WebKit 的有声播放授权按 media element 管理。iOS 分支始终复用
+  // 同一个真实 <video>，滑动时只移动节点并更换 src。
+  const useIOSSharedVideo = shouldUseIOSSharedVideo();
   // 全局 Toast / HUD 提醒文字
   const [hudText, setHudText] = useState<{ id: number; text: string; icon?: React.ReactNode } | null>(null);
   const hudTimeoutRef = useRef<number | null>(null);
@@ -121,37 +124,45 @@ export default function ShortsPage() {
 
   const handleMuteButtonClick = useCallback(() => {
     const activeVideo = getVideoAtIndex(activeIndex);
-    const canResumeActiveVideo = () =>
-      Boolean(activeVideo) &&
-      getVideoAtIndex(activeIndexRef.current) === activeVideo &&
-      userPausedIndexRef.current !== activeIndexRef.current;
     const next = !muted;
     if (activeVideo) {
-      normalizeVideoPlaybackRate(activeVideo);
-      applyVideoMutedState(activeVideo, next);
-      // 必须直接发生在这个 click 回调中：这一次 play() 给 iOS 的持久
-      // media element 授予有声播放权限，之后切 src 仍复用同一元素。
-      if (canResumeActiveVideo()) {
-        activeVideo.play().catch(() => undefined);
+      // Android Chrome 切换静音时可能正在重建音频管线。对一个本来就在
+      // 播放的元素重复 play() 和延迟重试只会干扰这次切换，因此普通 video
+      // 路径到这里就结束；下面的恢复只服务于 iOS 持久 media element。
+      if (!useIOSSharedVideo) {
+        applyVideoMutedState(activeVideo, next);
+      } else {
+        const canResumeActiveVideo = () =>
+          getVideoAtIndex(activeIndexRef.current) === activeVideo &&
+          userPausedIndexRef.current !== activeIndexRef.current;
+        normalizeVideoPlaybackRate(activeVideo);
+        applyVideoMutedState(activeVideo, next);
+        // 必须直接发生在这个 click 回调中：这一次 play() 给 iOS 的持久
+        // media element 授予有声播放权限，之后切 src 仍复用同一元素。
+        if (canResumeActiveVideo()) {
+          activeVideo.play().catch(() => undefined);
+        }
+        stabilizeVideoAfterAudioToggle(
+          activeVideo,
+          canResumeActiveVideo
+        );
       }
-      stabilizeVideoAfterAudioToggle(
-        activeVideo,
-        canResumeActiveVideo
-      );
     }
     // 预载用的备用元素之后会被提升为播放元素，而 WebKit 的有声播放授权是
     // 按 media element 记账的。趁这次用户手势一并给它授权，否则它接管播放
     // 的那一刻会被当成"没有手势的有声自动播放"直接拒掉。
-    const standbyVideo = iosStandbyVideoRef.current;
-    if (standbyVideo && standbyVideo !== activeVideo) {
-      unlockVideoAudioPlayback(standbyVideo);
+    if (useIOSSharedVideo) {
+      const standbyVideo = iosStandbyVideoRef.current;
+      if (standbyVideo && standbyVideo !== activeVideo) {
+        unlockVideoAudioPlayback(standbyVideo);
+      }
     }
     setMuted(next);
     showHud(
       next ? "已静音" : "音量已开启",
       next ? <VolumeX size={16} /> : <Volume2 size={16} />
     );
-  }, [activeIndex, muted, showHud]);
+  }, [activeIndex, muted, showHud, useIOSSharedVideo]);
 
   // 组件卸载时清理 HUD 定时器
   useEffect(() => {
@@ -238,10 +249,6 @@ export default function ShortsPage() {
   // Windows 短视频页只保留静音图标；不挂载桌面 hover 音量条，避免点击
   // 图标时因鼠标仍停留在按钮上而展开滑杆。
   const isWindowsShortsPlatform = isWindowsPlatform();
-  // iOS/WebKit 的有声播放授权按 media element 管理。iOS 分支始终复用
-  // 同一个真实 <video>，滑动时只移动节点并更换 src。
-  const useIOSSharedVideo = shouldUseIOSSharedVideo();
-
   const handleShortsRouteClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>, destination: string) => {
       // 主导航点击 documentElement 后进入的是“文档全屏”，SPA 路由切换

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -315,19 +315,22 @@ export default function ShortsPage() {
     []
   );
 
-  // 键盘快捷键：↑↓切换、空格播放/暂停（双空格点赞）、←→累计快进、M/L
-  const { keyboardSeekPreview, registerKeyboardLikeHandler } =
-    useShortsKeyboard({
-      containerRef,
-      activeIndexRef,
-      itemsLengthRef,
-      getVideoAtIndex,
-      isVideoPausedByUser,
-      setUserPausedForIndex,
-      onToggleMute: handleMuteButtonClick,
-      showHud,
-      isWindowsShortsPlatform,
-    });
+  // 键盘快捷键：↑↓切换、空格播放/暂停（双空格点赞）、←快退、→长按倍速、M/L
+  const {
+    keyboardSeekPreview,
+    keyboardFastPlaybackIndex,
+    registerKeyboardLikeHandler,
+  } = useShortsKeyboard({
+    containerRef,
+    activeIndexRef,
+    itemsLengthRef,
+    getVideoAtIndex,
+    isVideoPausedByUser,
+    setUserPausedForIndex,
+    onToggleMute: handleMuteButtonClick,
+    showHud,
+    isWindowsShortsPlatform,
+  });
 
   useEffect(() => {
     updateUserPausedIndex(null);
@@ -1172,6 +1175,7 @@ export default function ShortsPage() {
                     ? keyboardSeekPreview
                     : undefined
                 }
+                keyboardFastPlayback={keyboardFastPlaybackIndex === index}
                 sharedVideoRef={
                   useIOSSharedVideo ? iosSharedVideoRef : undefined
                 }
@@ -1294,6 +1298,8 @@ type SlideProps = {
     ShortsKeyboardSeekPreview,
     "currentTime" | "duration"
   >;
+  /** 当前 slide 是否正由键盘右键长按驱动 2 倍速播放。 */
+  keyboardFastPlayback: boolean;
   /** iOS 所有 slide 共用的同一个持久 video DOM 节点 */
   sharedVideoRef?: React.RefObject<HTMLVideoElement>;
   /** 持久 video 当前应移动到的 slide 插槽 */
@@ -1353,6 +1359,7 @@ function ShortsSlideImpl({
   shouldEagerLoad,
   shouldRenderContent,
   keyboardSeekPreview,
+  keyboardFastPlayback,
   sharedVideoRef,
   sharedVideoSlotRef,
   muted,
@@ -2785,7 +2792,7 @@ function ShortsSlideImpl({
         />
       )}
 
-      {fastActive && (
+      {(fastActive || keyboardFastPlayback) && (
         <div className="shorts-slide__rate-hint" aria-hidden="true">
           2x 速播放中
         </div>

--- a/src/pages/ShortsPage.tsx
+++ b/src/pages/ShortsPage.tsx
@@ -758,7 +758,6 @@ export default function ShortsPage() {
         // 在 ended 后受控重播，桌面/Android 的 JSX video 仍保留原生 loop。
         video.loop = false;
         video.playsInline = true;
-        video.preload = "auto";
         video.disablePictureInPicture = true;
         video.setAttribute("playsinline", "");
         video.setAttribute("webkit-playsinline", "");
@@ -846,14 +845,10 @@ export default function ShortsPage() {
     useIOSSharedVideo,
   ]);
 
-  // 下一屏：用备用元素提前把下一条视频拉起来。
+  // 下一屏：用备用元素提前准备下一条视频。
   //
-  // 这里**不看** activeReadyForPreload：备用元素承担的正是"下一条"这一档，
-  // 与非 iOS 路径上 getPreloadAheadCount 的下限 1 是同一条规则。那道授权每次
-  // 切屏都清零、要靠当前条真的起播并囤够 4~12 秒缓冲才挣得回来，而正常刷视频
-  // 比这条链路走完还快——挂在它上面就等于"永远来不及"，滑到位时下一条一个
-  // 字节都还没请求过。授权只该决定再往后囤几条；iOS 一共就两个 media element，
-  // 没有"再往后"，所以这里没有它的位置。
+  // 备用元素一直保留下一条的 src：当前屏缓冲不足时只取 metadata，缓冲健康后
+  // 再切到 auto。降级时不重设 src，因此已经下载的数据仍能复用。
   //
   // 这里是普通 useEffect 而不是 useLayoutEffect：备用元素处于隐藏角色，
   // 移动插槽和起 src 都没有当帧的视觉后果，没必要把一次 appendChild 和一次
@@ -877,6 +872,7 @@ export default function ShortsPage() {
     if (standby === iosSharedVideoRef.current) return;
 
     applyIOSVideoRole(standby, "standby");
+    standby.preload = activeReadyForPreload ? "auto" : "metadata";
     // 直接停进下一屏的插槽：滑动到位后连 DOM 移动都省了。
     if (standby.parentElement !== nextSlot) nextSlot.appendChild(standby);
     iosStandbyVideoIndexRef.current = nextIndex;
@@ -897,6 +893,7 @@ export default function ShortsPage() {
   }, [
     acquireIOSVideoElement,
     activeIndex,
+    activeReadyForPreload,
     iosStandbyPreloadDisabled,
     items,
     useIOSSharedVideo,
@@ -1117,16 +1114,18 @@ export default function ShortsPage() {
             const isInCacheWindow =
               index >= videoWindow.start && index <= videoWindow.end;
             const preloadOffset = index - activeIndex;
-            // 下一条无条件预载，再往后才受"当前屏缓冲健康"的授权节流。
-            // 详见 getPreloadAheadCount 的注释：让下一条"存在"和"后台囤积"
-            // 是两件成本差一个数量级的事，不该共用一个开关。
+            // 下一条始终挂源做轻量准备；只有当前屏缓冲健康时，后续视频才允许
+            // 用 preload="auto" 全速拉取。卡顿时只降级 preload，不删除已有 src。
+            const shouldPrepareNext =
+              !useIOSSharedVideo && preloadOffset === 1;
             const shouldPreload =
               !useIOSSharedVideo &&
               preloadOffset > 0 &&
               preloadOffset <= getPreloadAheadCount(activeReadyForPreload);
             const shouldMount =
               isActiveSlide ||
-              (!useIOSSharedVideo && (isInCacheWindow || shouldPreload));
+              (!useIOSSharedVideo &&
+                (isInCacheWindow || shouldPrepareNext || shouldPreload));
             // 视频窗口内已经缓冲过的视频保留 src：
             // 在窗口内来回切换时，直接复用浏览器已缓冲数据。
             const shouldRetainCached =
@@ -1134,7 +1133,11 @@ export default function ShortsPage() {
               isInCacheWindow &&
               !isActiveSlide &&
               cacheableSourceIds.has(item.id);
-            const shouldLoad = isActiveSlide || shouldPreload || shouldRetainCached;
+            const shouldLoad =
+              isActiveSlide ||
+              shouldPrepareNext ||
+              shouldPreload ||
+              shouldRetainCached;
             const shouldEagerLoad = isActiveSlide || shouldPreload;
             // 视口附近的照常渲染；再加上所有还挂着 <video> 的 slide——那些是
             // 有意保留的缓冲，不能因为离开视口就被拆掉。两者之和有上限，
@@ -1151,7 +1154,7 @@ export default function ShortsPage() {
                 index={index}
                 isActive={isActiveSlide}
                 // 固定 4 条视频窗口内才挂载 <video> 壳；
-                // 当前屏先绑定 src；后两个视频等当前屏缓冲健康后再预加载；
+                // 下一屏先用 metadata 轻量准备；当前屏缓冲健康后再全速预加载；
                 // 已缓冲过的窗口内视频保留 src，便于来回切换复用缓存。
                 shouldMount={shouldMount}
                 shouldLoad={shouldLoad}
@@ -3003,18 +3006,21 @@ function applyVideoMutedState(video: HTMLVideoElement, nextMuted: boolean) {
 }
 
 /**
- * 两个持久 media element 的角色。备用元素只负责把下一条的数据先拉下来：
- * 不能带 autoplay（有数据后会在屏幕外真的播起来），也必须保持静音。
+ * 两个持久 media element 的角色。播放元素始终优先加载；备用元素默认只做
+ * metadata 准备，页面会在当前视频缓冲健康时把它提升为 auto。备用元素不能
+ * 带 autoplay（有数据后会在屏幕外真的播起来），也必须保持静音。
  */
 function applyIOSVideoRole(
   video: HTMLVideoElement,
   role: "active" | "standby"
 ) {
   if (role === "active") {
+    video.preload = "auto";
     video.autoplay = true;
     video.setAttribute("autoplay", "");
     return;
   }
+  video.preload = "metadata";
   video.autoplay = false;
   video.removeAttribute("autoplay");
   applyVideoMutedState(video, true);

--- a/src/shorts/mediaBuffer.ts
+++ b/src/shorts/mediaBuffer.ts
@@ -58,8 +58,11 @@ export type FirstFrameWarmProbe = {
   isActive: boolean;
   /** 该 slide 是否已经绑定了 src */
   shouldLoad: boolean;
-  /** iOS 共享元素分支自有生命周期，不参与预热 */
-  usesSharedVideo: boolean;
+  /**
+   * 该元素是不是"播放位"——即将被 play() 的那一个。播放位由 play() 自己
+   * 清掉 show-poster 标志，不该被 seek 打断；只有候补位才需要预热。
+   */
+  isPlaybackElement: boolean;
   readyState: number;
   currentTime: number;
 };
@@ -83,7 +86,7 @@ export type FirstFrameWarmProbe = {
 export function shouldWarmFirstFrame(probe: FirstFrameWarmProbe): boolean {
   if (probe.isActive) return false;
   if (!probe.shouldLoad) return false;
-  if (probe.usesSharedVideo) return false;
+  if (probe.isPlaybackElement) return false;
   // HAVE_METADATA 之前 seek 无处可去；currentTime 非 0 说明已经被推进过。
   if (probe.readyState < 1) return false;
   return probe.currentTime === 0;

--- a/src/shorts/mediaBuffer.ts
+++ b/src/shorts/mediaBuffer.ts
@@ -26,7 +26,7 @@ export const ACTIVE_PRELOAD_KEEP_RATIO = 1 / 3;
 export const ACTIVE_PRELOAD_MIN_KEEP_SECONDS = 1.5;
 
 // 维护一个固定大小的视频窗口：窗口内才 mount 真实 <video> 壳。
-// 当前屏先绑定 src；后续预加载要等当前屏缓冲健康后才开始。
+// 下一屏可以轻量准备；全速预加载要等当前屏缓冲健康后才开始。
 // 窗口内只要已经产生过可复用缓冲，就保留 src 复用浏览器缓存。
 export const VIDEO_WINDOW_SIZE = 4;
 
@@ -34,23 +34,14 @@ export const VIDEO_WINDOW_SIZE = 4;
 export const PRELOAD_AHEAD_COUNT = 2;
 
 /**
- * 实际允许向后预载几条。
+ * 当前屏缓冲状态允许几条后续视频使用 preload="auto"。
  *
- * 关键在于**下限是 1 而不是 0**：紧邻的下一条永远无条件预载。
- *
- * 原来的写法是"当前屏缓冲健康（activeReadyForPreload）才允许预载"，而这个
- * 授权每次切屏都会被清零、要重新挣回来——需要新活跃条真的起播、并囤够
- * 4~12 秒前向缓冲。正常刷短视频是 3~5 秒一条，比这条链路走完还快，于是下一条
- * 在被滑到的那一刻**根本没有开始过任何网络请求**，只能先画一张静态封面。
- *
- * 这里把两件成本差一个数量级的事拆开：让下一条"存在"（绑 src、取 moov 和
- * 第一个 GOP，几百 KB，是"滑到就有画面"的底线）不该和"后台囤积后续视频"
- * （几 MB，是带宽优化）共用一个开关。zyronon/douyin 的 SlideVerticalInfinite
- * 对窗口内每一条无条件挂 <video> 并绑源，机制上不存在"下一条还没开始加载"
- * 这种状态；授权只该决定预载的**深度**，不该决定它**存不存在**。
+ * 这里只负责全速预载的深度。下一屏是否挂载、绑定 src 并用 metadata 做轻量
+ * 准备，由页面单独决定。分开后，当前视频卡顿时可以收回后台带宽，又不用删除
+ * 下一屏的 src 或丢弃已经下载的数据。
  */
 export function getPreloadAheadCount(activeReadyForPreload: boolean): number {
-  return activeReadyForPreload ? PRELOAD_AHEAD_COUNT : 1;
+  return activeReadyForPreload ? PRELOAD_AHEAD_COUNT : 0;
 }
 
 /** shouldWarmFirstFrame 的输入切面；HTMLVideoElement 天然满足前两项。 */

--- a/src/shorts/mediaBuffer.ts
+++ b/src/shorts/mediaBuffer.ts
@@ -30,6 +30,68 @@ export const ACTIVE_PRELOAD_MIN_KEEP_SECONDS = 1.5;
 // 窗口内只要已经产生过可复用缓冲，就保留 src 复用浏览器缓存。
 export const VIDEO_WINDOW_SIZE = 4;
 
+/** 当前屏缓冲健康时，向后预载几条。 */
+export const PRELOAD_AHEAD_COUNT = 2;
+
+/**
+ * 实际允许向后预载几条。
+ *
+ * 关键在于**下限是 1 而不是 0**：紧邻的下一条永远无条件预载。
+ *
+ * 原来的写法是"当前屏缓冲健康（activeReadyForPreload）才允许预载"，而这个
+ * 授权每次切屏都会被清零、要重新挣回来——需要新活跃条真的起播、并囤够
+ * 4~12 秒前向缓冲。正常刷短视频是 3~5 秒一条，比这条链路走完还快，于是下一条
+ * 在被滑到的那一刻**根本没有开始过任何网络请求**，只能先画一张静态封面。
+ *
+ * 这里把两件成本差一个数量级的事拆开：让下一条"存在"（绑 src、取 moov 和
+ * 第一个 GOP，几百 KB，是"滑到就有画面"的底线）不该和"后台囤积后续视频"
+ * （几 MB，是带宽优化）共用一个开关。zyronon/douyin 的 SlideVerticalInfinite
+ * 对窗口内每一条无条件挂 <video> 并绑源，机制上不存在"下一条还没开始加载"
+ * 这种状态；授权只该决定预载的**深度**，不该决定它**存不存在**。
+ */
+export function getPreloadAheadCount(activeReadyForPreload: boolean): number {
+  return activeReadyForPreload ? PRELOAD_AHEAD_COUNT : 1;
+}
+
+/** shouldWarmFirstFrame 的输入切面；HTMLVideoElement 天然满足前两项。 */
+export type FirstFrameWarmProbe = {
+  isActive: boolean;
+  /** 该 slide 是否已经绑定了 src */
+  shouldLoad: boolean;
+  /** iOS 共享元素分支自有生命周期，不参与预热 */
+  usesSharedVideo: boolean;
+  readyState: number;
+  currentTime: number;
+};
+
+/**
+ * 非活跃的预载视频要不要"逼出首帧"。
+ *
+ * 按 HTML 渲染模型，video 元素的 show-poster 标志在播放真正开始之前一直为真：
+ * 哪怕已经 preload="auto" 缓冲到满、首帧完全可解码，元素画的仍然是那张静态
+ * poster。也就是说光把字节下下来并不能让"滑到就有画面"成立——浏览器没有
+ * 任何理由去解码一帧。
+ *
+ * 清掉这个标志只有 play() 和 seek 两条路。预载条不能 play()（会出声、会抢
+ * 解码器），所以走 seek：写一次 currentTime 就会强制解码该位置的一帧并送进
+ * 合成器。douyin 的 BaseVideo.vue 在 onMounted 里对每个挂载的 video 写
+ * `videoEl.currentTime = 0`，就是这一步。
+ *
+ * 只在还停在起点（currentTime 为 0）且已经拿到元数据时做一次，避免把用户
+ * 的播放进度或正在进行的 seek 冲掉。
+ */
+export function shouldWarmFirstFrame(probe: FirstFrameWarmProbe): boolean {
+  if (probe.isActive) return false;
+  if (!probe.shouldLoad) return false;
+  if (probe.usesSharedVideo) return false;
+  // HAVE_METADATA 之前 seek 无处可去；currentTime 非 0 说明已经被推进过。
+  if (probe.readyState < 1) return false;
+  return probe.currentTime === 0;
+}
+
+/** 预热用的落点：足够小以视觉上仍是首帧，又足以让 seek 真的发生。 */
+export const FIRST_FRAME_WARM_TIME = 0.001;
+
 /** 判定所需的最小视频元素切面；HTMLVideoElement 天然满足。 */
 export type BufferedMediaProbe = {
   currentTime: number;

--- a/src/shorts/platform.ts
+++ b/src/shorts/platform.ts
@@ -41,28 +41,48 @@ export function isLegacyShortsVideoTransitionEnabled() {
 }
 
 /**
- * 是否由页面自己接管上下滑动（跟手 + 大幅滑动才切屏 + 固定时长落点），
- * 替代浏览器的原生 scroll-snap。只在"触屏是主输入"的设备上启用：桌面和
- * 触控本（hover: hover）继续走原生滚动 + 滚轮 / 键盘，行为完全不变。
+ * 是否挂载自己的滑动手势控制器（跟手 + 大幅滑动才切屏 + 固定时长落点）。
+ *
+ * 默认对**所有**设备开启。控制器用的是 pointer 事件，同一套代码同时吃手指
+ * 和鼠标——桌面的拖拽翻页是白送的。参考实现 zyronon/douyin 的 SlideVertical
+ * 也只绑 pointerdown/move/up，全仓一处 touch 事件都没有；把它拆成"移动端
+ * 一套、桌面一套"是我们凭空加的平台特例。
  *
  * iPhone 浏览器壳（文档滚动模式）一度默认排除在外，理由是"接管触摸会让
  * Safari 工具栏收不起来"。真机截图推翻了这个前提：`scroll-snap-type: y
  * mandatory` 每次滑动都把滚动截断，工具栏本来就从没收起过——那是个不存在
- * 的功能，为它牺牲手感不划算。现在两条路径一视同仁。
+ * 的功能，为它牺牲手感不划算。
  *
- * `?shortsPager=0` 强制回到原生滚动（真机回退开关）；`?shortsPager=1`
- * 强制开启，用来在桌面上做同机 A/B。
+ * `?shortsPager=0` 整个关掉，回到纯原生滚动（真机回退开关）。
  */
-export function shouldUseShortsTouchPager() {
+export function shouldUseShortsSwipePager() {
   if (typeof window === "undefined") return false;
-  const override = new URLSearchParams(window.location.search).get(
-    "shortsPager"
-  );
+  return readShortsPagerOverride() !== "0";
+}
+
+/**
+ * 是否连浏览器的原生滚动一起接管（关掉 scroll-snap 与 touch-action）。
+ *
+ * 只有触屏设备需要——手指的位移必须完全由我们写进 transform，不能和浏览器
+ * 的滚动预测抢同一根手指。桌面则相反：滚轮和方向键走原生吸附本来就很好用，
+ * 没有理由替浏览器重写一遍（参考实现是纯移动端 demo，桌面上只能拖、根本
+ * 没有滚轮，那不是我们能照抄的）。桌面只叠加鼠标拖拽：拖动只写 transform，
+ * 松手写回的 scrollTop 正好落在吸附点上，与原生吸附不冲突。
+ *
+ * `?shortsPager=1` 可在桌面上强制走触屏那套，用来做同机对照。
+ */
+export function shouldTakeOverShortsScrolling() {
+  if (typeof window === "undefined") return false;
+  const override = readShortsPagerOverride();
   if (override === "0") return false;
   if (override === "1") return true;
   return (
     window.matchMedia?.("(hover: none) and (pointer: coarse)").matches === true
   );
+}
+
+function readShortsPagerOverride() {
+  return new URLSearchParams(window.location.search).get("shortsPager");
 }
 
 export function isWindowsPlatform() {

--- a/src/shorts/platform.ts
+++ b/src/shorts/platform.ts
@@ -41,24 +41,25 @@ export function isLegacyShortsVideoTransitionEnabled() {
 }
 
 /**
- * 是否由页面自己接管上下滑动（惯性收尾 + 大幅滑动才切屏），替代浏览器的
- * 原生 scroll-snap。默认只在"触屏是主输入"的设备上启用：桌面和触控本
- * （hover: hover）继续走原生滚动 + 滚轮 / 键盘，行为完全不变。
+ * 是否由页面自己接管上下滑动（跟手 + 大幅滑动才切屏 + 固定时长落点），
+ * 替代浏览器的原生 scroll-snap。只在"触屏是主输入"的设备上启用：桌面和
+ * 触控本（hover: hover）继续走原生滚动 + 滚轮 / 键盘，行为完全不变。
  *
- * iPhone 浏览器壳走的是文档滚动，目的是让 Safari 工具栏随刷动收起；接管
- * 触摸会让工具栏永远展开，属于功能回退，所以默认不启用。
+ * iPhone 浏览器壳（文档滚动模式）一度默认排除在外，理由是"接管触摸会让
+ * Safari 工具栏收不起来"。真机截图推翻了这个前提：`scroll-snap-type: y
+ * mandatory` 每次滑动都把滚动截断，工具栏本来就从没收起过——那是个不存在
+ * 的功能，为它牺牲手感不划算。现在两条路径一视同仁。
  *
  * `?shortsPager=0` 强制回到原生滚动（真机回退开关）；`?shortsPager=1`
- * 强制开启，用来在 iPhone 文档滚动模式或桌面上做同机 A/B。
+ * 强制开启，用来在桌面上做同机 A/B。
  */
-export function shouldUseShortsTouchPager(usesDocumentScroll: boolean) {
+export function shouldUseShortsTouchPager() {
   if (typeof window === "undefined") return false;
   const override = new URLSearchParams(window.location.search).get(
     "shortsPager"
   );
   if (override === "0") return false;
   if (override === "1") return true;
-  if (usesDocumentScroll) return false;
   return (
     window.matchMedia?.("(hover: none) and (pointer: coarse)").matches === true
   );

--- a/src/shorts/platform.ts
+++ b/src/shorts/platform.ts
@@ -40,6 +40,30 @@ export function isLegacyShortsVideoTransitionEnabled() {
   );
 }
 
+/**
+ * 是否由页面自己接管上下滑动（惯性收尾 + 大幅滑动才切屏），替代浏览器的
+ * 原生 scroll-snap。默认只在"触屏是主输入"的设备上启用：桌面和触控本
+ * （hover: hover）继续走原生滚动 + 滚轮 / 键盘，行为完全不变。
+ *
+ * iPhone 浏览器壳走的是文档滚动，目的是让 Safari 工具栏随刷动收起；接管
+ * 触摸会让工具栏永远展开，属于功能回退，所以默认不启用。
+ *
+ * `?shortsPager=0` 强制回到原生滚动（真机回退开关）；`?shortsPager=1`
+ * 强制开启，用来在 iPhone 文档滚动模式或桌面上做同机 A/B。
+ */
+export function shouldUseShortsTouchPager(usesDocumentScroll: boolean) {
+  if (typeof window === "undefined") return false;
+  const override = new URLSearchParams(window.location.search).get(
+    "shortsPager"
+  );
+  if (override === "0") return false;
+  if (override === "1") return true;
+  if (usesDocumentScroll) return false;
+  return (
+    window.matchMedia?.("(hover: none) and (pointer: coarse)").matches === true
+  );
+}
+
 export function isWindowsPlatform() {
   if (typeof navigator === "undefined") return false;
   const platform = navigator.platform || "";

--- a/src/shorts/platform.ts
+++ b/src/shorts/platform.ts
@@ -41,48 +41,27 @@ export function isLegacyShortsVideoTransitionEnabled() {
 }
 
 /**
- * 是否挂载自己的滑动手势控制器（跟手 + 大幅滑动才切屏 + 固定时长落点）。
+ * 短视频页是否由自己接管全部滚动输入——拖拽、滚轮、原生吸附一并接管。
  *
- * 默认对**所有**设备开启。控制器用的是 pointer 事件，同一套代码同时吃手指
- * 和鼠标——桌面的拖拽翻页是白送的。参考实现 zyronon/douyin 的 SlideVertical
- * 也只绑 pointerdown/move/up，全仓一处 touch 事件都没有；把它拆成"移动端
- * 一套、桌面一套"是我们凭空加的平台特例。
+ * 对**所有**设备、**所有**输入方式一视同仁，这是刻意的：这个页面存在的整个
+ * 理由就是"浏览器控制的吸附滚动手感不可控"，凡是还留给浏览器的输入通道，
+ * 那份不可控就原样保留在那里。曾经分过两次特例，两次都被证伪：
  *
- * iPhone 浏览器壳（文档滚动模式）一度默认排除在外，理由是"接管触摸会让
- * Safari 工具栏收不起来"。真机截图推翻了这个前提：`scroll-snap-type: y
- * mandatory` 每次滑动都把滚动截断，工具栏本来就从没收起过——那是个不存在
- * 的功能，为它牺牲手感不划算。
+ * - "iPhone 走文档滚动，接管触摸会让 Safari 工具栏收不起来" —— 真机截图
+ *   显示有 `scroll-snap-type: y mandatory` 在时工具栏本来就从没收起过。
+ * - "桌面滚轮走原生吸附本来就好用" —— 实测手感和移动端原来一样糟，而且
+ *   保留吸附还让鼠标拖拽彻底失效（吸附点跟着轨道 transform 走，mandatory
+ *   会反向拉 scrollTop 把位移抵消掉）。
+ *
+ * 控制器用 pointer 事件 + wheel，同一套判定同时服务手指、鼠标拖拽和滚轮，
+ * 三者共用同一条落点动画。参考实现 zyronon/douyin 也只绑 pointer 事件
+ * （它是纯移动端 demo，没有滚轮，那一半是我们自己补的）。
  *
  * `?shortsPager=0` 整个关掉，回到纯原生滚动（真机回退开关）。
  */
 export function shouldUseShortsSwipePager() {
   if (typeof window === "undefined") return false;
-  return readShortsPagerOverride() !== "0";
-}
-
-/**
- * 是否连浏览器的原生滚动一起接管（关掉 scroll-snap 与 touch-action）。
- *
- * 只有触屏设备需要——手指的位移必须完全由我们写进 transform，不能和浏览器
- * 的滚动预测抢同一根手指。桌面则相反：滚轮和方向键走原生吸附本来就很好用，
- * 没有理由替浏览器重写一遍（参考实现是纯移动端 demo，桌面上只能拖、根本
- * 没有滚轮，那不是我们能照抄的）。桌面只叠加鼠标拖拽：拖动只写 transform，
- * 松手写回的 scrollTop 正好落在吸附点上，与原生吸附不冲突。
- *
- * `?shortsPager=1` 可在桌面上强制走触屏那套，用来做同机对照。
- */
-export function shouldTakeOverShortsScrolling() {
-  if (typeof window === "undefined") return false;
-  const override = readShortsPagerOverride();
-  if (override === "0") return false;
-  if (override === "1") return true;
-  return (
-    window.matchMedia?.("(hover: none) and (pointer: coarse)").matches === true
-  );
-}
-
-function readShortsPagerOverride() {
-  return new URLSearchParams(window.location.search).get("shortsPager");
+  return new URLSearchParams(window.location.search).get("shortsPager") !== "0";
 }
 
 export function isWindowsPlatform() {

--- a/src/shorts/useShortsKeyboard.tsx
+++ b/src/shorts/useShortsKeyboard.tsx
@@ -9,7 +9,8 @@ import { Sparkles } from "lucide-react";
 import { clamp } from "./mediaBuffer";
 
 const SHORTS_KEYBOARD_SEEK_SECONDS = 5;
-// 浏览器失焦时可能收不到 keyup；最后一次重复按键后自动提交，避免目标悬空。
+const SHORTS_KEYBOARD_FAST_PLAYBACK_DELAY_MS = 400;
+// 浏览器失焦时可能收不到 keyup；左键最后一次重复事件后自动提交，避免目标悬空。
 const SHORTS_KEYBOARD_SEEK_IDLE_COMMIT_MS = 1500;
 const SHORTS_KEYBOARD_SEEK_RELEASE_HIDE_MS = 400;
 const SHORTS_KEYBOARD_DOUBLE_SPACE_MS = 280;
@@ -43,11 +44,14 @@ export type ShortsKeyboardOptions = {
 /**
  * 短视频页的键盘快捷键：
  * - ↑/↓ 切换上下视频，空格播放/暂停（双空格点赞），M 静音，L 点赞
- * - ←/→ 长按累计 5s/次，只更新预览；全部松开（或失焦/超时）后提交一次真实 seek
+ * - ← 按键重复时累计快退 5s/次，松开（或失焦/超时）后提交一次真实 seek
+ * - → 短按快进 5s；按住 400ms 后以 2 倍速播放，松开恢复 1 倍速
  */
 export function useShortsKeyboard(options: ShortsKeyboardOptions) {
   const [keyboardSeekPreview, setKeyboardSeekPreview] =
     useState<ShortsKeyboardSeekPreview | null>(null);
+  const [keyboardFastPlaybackIndex, setKeyboardFastPlaybackIndex] =
+    useState<number | null>(null);
   const keyboardSeekTargetRef = useRef<ShortsKeyboardSeekTarget | null>(null);
   const keyboardSeekHeldKeysRef = useRef<Set<ShortsKeyboardSeekKey>>(new Set());
   const keyboardSeekCommitTimerRef = useRef<number | null>(null);
@@ -83,6 +87,12 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
     let pendingSpaceTarget: {
       videoIndex: number;
       video: HTMLVideoElement;
+    } | null = null;
+    let keyboardRightPressTimer: number | null = null;
+    let keyboardRightPressTarget: {
+      videoIndex: number;
+      video: HTMLVideoElement;
+      fastPlaybackActive: boolean;
     } | null = null;
 
     const clearKeyboardSeekCommitTimer = () => {
@@ -176,7 +186,7 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
             : target.duration;
         const nextTime = clamp(target.currentTime, 0, duration);
         try {
-          // 长按期间只更新预览；在左右键全部松开后才执行这一次真实 seek。
+          // 左键连按期间只更新预览；松开后才执行这一次真实 seek。
           target.video.currentTime = nextTime;
         } catch {
           // ignore（部分 ready state 下设置会抛错）
@@ -237,6 +247,76 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
       scheduleKeyboardSeekIdleCommit();
     };
 
+    const clearKeyboardRightPressTimer = () => {
+      if (keyboardRightPressTimer === null) return;
+      window.clearTimeout(keyboardRightPressTimer);
+      keyboardRightPressTimer = null;
+    };
+
+    const finishKeyboardRightPress = (seekOnShortPress: boolean) => {
+      clearKeyboardRightPressTimer();
+      const target = keyboardRightPressTarget;
+      keyboardRightPressTarget = null;
+      if (!target) return;
+
+      if (target.fastPlaybackActive) {
+        try {
+          target.video.playbackRate = 1;
+        } catch {
+          // ignore
+        }
+        setKeyboardFastPlaybackIndex(null);
+        return;
+      }
+
+      if (
+        seekOnShortPress &&
+        activeIndexRef.current === target.videoIndex &&
+        getCurrentVideoAtIndex(target.videoIndex) === target.video
+      ) {
+        previewKeyboardSeek(
+          SHORTS_KEYBOARD_SEEK_SECONDS,
+          "ArrowRight"
+        );
+        keyboardSeekHeldKeysRef.current.delete("ArrowRight");
+        finishKeyboardSeek();
+      }
+    };
+
+    const startKeyboardRightPress = () => {
+      if (keyboardRightPressTarget) return;
+      finishKeyboardSeek();
+      const videoIndex = activeIndexRef.current;
+      const video = getCurrentVideoAtIndex(videoIndex);
+      if (!video) return;
+
+      keyboardRightPressTarget = {
+        videoIndex,
+        video,
+        fastPlaybackActive: false,
+      };
+      keyboardRightPressTimer = window.setTimeout(() => {
+        keyboardRightPressTimer = null;
+        const target = keyboardRightPressTarget;
+        if (
+          !target ||
+          activeIndexRef.current !== target.videoIndex ||
+          getCurrentVideoAtIndex(target.videoIndex) !== target.video ||
+          target.video.paused ||
+          target.video.ended
+        ) {
+          return;
+        }
+        try {
+          target.video.playbackRate = 2;
+        } catch {
+          return;
+        }
+        target.fastPlaybackActive = true;
+        setKeyboardFastPlaybackIndex(target.videoIndex);
+      }, SHORTS_KEYBOARD_FAST_PLAYBACK_DELAY_MS);
+    };
+
     const handleKeyDown = (e: KeyboardEvent) => {
       const activeEl = document.activeElement;
       if (
@@ -251,6 +331,7 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
 
       if (e.key === "ArrowDown") {
         e.preventDefault();
+        finishKeyboardRightPress(false);
         finishKeyboardSeek();
         const nextIdx = activeIndexRef.current + 1;
         if (nextIdx < itemsLengthRef.current) {
@@ -261,6 +342,7 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
         }
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
+        finishKeyboardRightPress(false);
         finishKeyboardSeek();
         const prevIdx = activeIndexRef.current - 1;
         if (prevIdx >= 0) {
@@ -271,6 +353,7 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
         }
       } else if (e.key === " ") {
         e.preventDefault();
+        finishKeyboardRightPress(false);
         finishKeyboardSeek();
         if (e.repeat) return;
         const videoIndex = activeIndexRef.current;
@@ -294,22 +377,23 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
         scheduleKeyboardSpaceToggle(videoIndex, activeVideo);
       } else if (e.key === "m" || e.key === "M") {
         e.preventDefault();
+        finishKeyboardRightPress(false);
         finishKeyboardSeek();
         if (e.repeat) return;
         optionsRef.current.onToggleMute();
       } else if (e.key === "l" || e.key === "L") {
         e.preventDefault();
+        finishKeyboardRightPress(false);
         finishKeyboardSeek();
         if (e.repeat) return;
         getActiveLikeButton(activeIndexRef.current)?.click();
       } else if (e.key === "ArrowRight") {
         e.preventDefault();
-        previewKeyboardSeek(
-          SHORTS_KEYBOARD_SEEK_SECONDS,
-          "ArrowRight"
-        );
+        if (e.repeat) return;
+        startKeyboardRightPress();
       } else if (e.key === "ArrowLeft") {
         e.preventDefault();
+        finishKeyboardRightPress(false);
         previewKeyboardSeek(
           -SHORTS_KEYBOARD_SEEK_SECONDS,
           "ArrowLeft"
@@ -318,7 +402,13 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+      if (e.key === "ArrowRight") {
+        if (!keyboardRightPressTarget) return;
+        e.preventDefault();
+        finishKeyboardRightPress(true);
+        return;
+      }
+      if (e.key !== "ArrowLeft") return;
       if (!keyboardSeekTargetRef.current) return;
 
       e.preventDefault();
@@ -328,11 +418,13 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
 
     const handleVisibilityChange = () => {
       if (!document.hidden) return;
+      finishKeyboardRightPress(false);
       finishKeyboardSeek();
       clearKeyboardSpaceTimer();
     };
 
     const handleWindowBlur = () => {
+      finishKeyboardRightPress(false);
       finishKeyboardSeek();
       clearKeyboardSpaceTimer();
     };
@@ -347,6 +439,7 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
       window.removeEventListener("blur", handleWindowBlur);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       clearKeyboardSpaceTimer();
+      finishKeyboardRightPress(false);
       // 卸载时同步清掉累计 seek 的定时器与目标，避免悬空提交
       clearKeyboardSeekCommitTimer();
       if (keyboardSeekHideTimerRef.current !== null) {
@@ -358,5 +451,9 @@ export function useShortsKeyboard(options: ShortsKeyboardOptions) {
     };
   }, []);
 
-  return { keyboardSeekPreview, registerKeyboardLikeHandler };
+  return {
+    keyboardSeekPreview,
+    keyboardFastPlaybackIndex,
+    registerKeyboardLikeHandler,
+  };
 }

--- a/src/shorts/useShortsSlideGestures.ts
+++ b/src/shorts/useShortsSlideGestures.ts
@@ -344,14 +344,37 @@ export function useShortsSlideGestures(options: ShortsSlideGesturesOptions) {
       end();
     };
 
+    // 桌面现在也能用鼠标拖拽翻页，"按住不动 400ms = 2 倍速"因此必须能被
+    // 拖动取消：否则慢一点的拖拽会顺手把视频切成 2 倍速。触摸那侧本来就有
+    // 同样的取消（cancelFastForTouchSeek），这里补上鼠标的。
+    let mouseDownAt: { x: number; y: number } | null = null;
+
     const handleMouseDown = (event: MouseEvent) => {
-      if (event.button === 0) start();
+      if (event.button !== 0) return;
+      mouseDownAt = { x: event.clientX, y: event.clientY };
+      start();
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!mouseDownAt) return;
+      const dx = event.clientX - mouseDownAt.x;
+      const dy = event.clientY - mouseDownAt.y;
+      // 与横向 seek 共用同一套方向判定的阈值：过了阈值就不再算"按住不动"。
+      if (classifyTouchSeekIntent(dx, dy) === "pending") return;
+      mouseDownAt = null;
+      cancelFastForTouchSeek();
     };
 
     const handleMouseUp = (event: MouseEvent) => {
       if (event.button !== 0) return;
+      mouseDownAt = null;
       const wasFastPress = active;
       if (wasFastPress) suppressNextSyntheticClick();
+      end();
+    };
+
+    const handleMouseLeave = () => {
+      mouseDownAt = null;
       end();
     };
 
@@ -362,8 +385,9 @@ export function useShortsSlideGestures(options: ShortsSlideGesturesOptions) {
     video.addEventListener("touchend", handleTouchEnd);
     video.addEventListener("touchcancel", handleTouchCancel);
     video.addEventListener("mousedown", handleMouseDown);
+    video.addEventListener("mousemove", handleMouseMove);
     video.addEventListener("mouseup", handleMouseUp);
-    video.addEventListener("mouseleave", end);
+    video.addEventListener("mouseleave", handleMouseLeave);
     video.addEventListener("pause", end);
     video.addEventListener("ended", end);
 
@@ -376,8 +400,9 @@ export function useShortsSlideGestures(options: ShortsSlideGesturesOptions) {
       video.removeEventListener("touchend", handleTouchEnd);
       video.removeEventListener("touchcancel", handleTouchCancel);
       video.removeEventListener("mousedown", handleMouseDown);
+      video.removeEventListener("mousemove", handleMouseMove);
       video.removeEventListener("mouseup", handleMouseUp);
-      video.removeEventListener("mouseleave", end);
+      video.removeEventListener("mouseleave", handleMouseLeave);
       video.removeEventListener("pause", end);
       video.removeEventListener("ended", end);
     };

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -556,7 +556,15 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   };
 
   // ---- 手势 ----
+  // 用 pointer 事件而不是 touch 事件：同一套代码同时吃手指和鼠标，桌面
+  // 拖拽是白送的。zyronon/douyin 的 SlideVertical 也只绑 pointerdown/move/up，
+  // 全仓一处 touch 事件都没有——分成"移动端一套、桌面一套"是我们凭空加的
+  // 平台特例。
   let drag: PagerDrag | null = null;
+  /** 当前按在屏幕上的所有指针；多于一个就交出手势。 */
+  const activePointers = new Set<number>();
+  /** 正在驱动本次手势的那一个指针。 */
+  let dragPointerId: number | null = null;
   let gestureActive = false;
   const setGestureActive = (active: boolean) => {
     if (gestureActive === active) return;
@@ -573,7 +581,8 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     settleTo(slides[index] ?? null, false);
   };
 
-  const handleTouchStart = (event: TouchEvent) => {
+  const handlePointerDown = (event: PointerEvent) => {
+    activePointers.add(event.pointerId);
     // 新的一次按下：上一次竖滑的合成 click 早该到了，守卫立刻失效，
     // 这样紧接着的这次轻点一定能穿到 slide 上。
     releaseClickGuard();
@@ -588,7 +597,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       if (interrupted) settleToNearest();
     };
 
-    if (event.touches.length !== 1) return bail();
+    dragPointerId = null;
+    // 鼠标只认左键；第二根手指落下时整只手势作废。
+    if (event.pointerType === "mouse" && event.button !== 0) return bail();
+    if (activePointers.size !== 1) return bail();
 
     // 用鸭子类型而不是 instanceof Element：这条状态机要能脱离浏览器全局
     // 直接被测试，而 target 在真实环境里一定是元素或 null。
@@ -611,12 +623,12 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     const previousTop = slideTops[anchorIndex - 1] ?? anchorTop;
     const nextTop = slideTops[anchorIndex + 1] ?? anchorTop;
     const scrollTop = getScrollTop();
-    const touch = event.touches[0];
     const now = performance.now();
+    dragPointerId = event.pointerId;
 
     drag = {
-      startX: touch.clientX,
-      startY: touch.clientY,
+      startX: event.clientX,
+      startY: event.clientY,
       startTime: now,
       baselineY: 0,
       originTranslate: translate,
@@ -631,13 +643,14 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       committed: false,
       abandoned: false,
       interrupted,
-      samples: [{ y: touch.clientY, t: now }],
+      samples: [{ y: event.clientY, t: now }],
     };
   };
 
-  const handleTouchMove = (event: TouchEvent) => {
+  const handlePointerMove = (event: PointerEvent) => {
     if (!drag || drag.abandoned) return;
-    if (event.touches.length !== 1) {
+    if (event.pointerId !== dragPointerId) return;
+    if (activePointers.size !== 1) {
       // 第二根手指落下：交出手势，已经拖开的部分就近吸附回去。
       const shouldSettle = drag.committed || drag.interrupted;
       drag.abandoned = true;
@@ -646,7 +659,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       return;
     }
 
-    const touch = event.touches[0];
+    const touch = event;
     const deltaX = touch.clientX - drag.startX;
     const deltaY = touch.clientY - drag.startY;
 
@@ -663,6 +676,12 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       }
       drag.committed = true;
       setGestureActive(true);
+      // 鼠标拖到容器外面也要继续收事件；触摸本来就隐式捕获，这里是给桌面用的。
+      try {
+        root.setPointerCapture(event.pointerId);
+      } catch {
+        // 指针已经抬起 / 不支持捕获时忽略，后续事件照常走冒泡。
+      }
       // 激活阈值那段位移不能再算进画面位移，否则接管的瞬间会跳一下。
       drag.baselineY = deltaY;
       track.style.willChange = "transform";
@@ -696,7 +715,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     );
   };
 
-  const handleTouchEnd = (event: TouchEvent) => {
+  const handlePointerUp = (event: PointerEvent) => {
+    activePointers.delete(event.pointerId);
+    if (dragPointerId !== null && event.pointerId !== dragPointerId) return;
+    dragPointerId = null;
     const current = drag;
     drag = null;
     setGestureActive(false);
@@ -716,14 +738,9 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     if (event.cancelable) event.preventDefault();
     guardNextClick();
 
-    const changedTouch = event.changedTouches[0];
     const now = performance.now();
-    if (changedTouch) {
-      current.samples.push({ y: changedTouch.clientY, t: now });
-    }
-    const deltaY = changedTouch
-      ? changedTouch.clientY - current.startY
-      : current.samples[current.samples.length - 1].y - current.startY;
+    current.samples.push({ y: event.clientY, t: now });
+    const deltaY = event.clientY - current.startY;
 
     const targetIndex = resolveShortsPagerTargetIndex({
       deltaY,
@@ -739,7 +756,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     settleTo(target, targetIndex !== current.anchorIndex);
   };
 
-  const handleTouchCancel = () => {
+  const handlePointerCancel = (event: PointerEvent) => {
+    activePointers.delete(event.pointerId);
+    if (dragPointerId !== null && event.pointerId !== dragPointerId) return;
+    dragPointerId = null;
     const current = drag;
     drag = null;
     setGestureActive(false);
@@ -778,10 +798,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }, 240);
   };
 
-  root.addEventListener("touchstart", handleTouchStart, { passive: true });
-  root.addEventListener("touchmove", handleTouchMove, { passive: false });
-  root.addEventListener("touchend", handleTouchEnd);
-  root.addEventListener("touchcancel", handleTouchCancel);
+  root.addEventListener("pointerdown", handlePointerDown, { passive: true });
+  root.addEventListener("pointermove", handlePointerMove, { passive: false });
+  root.addEventListener("pointerup", handlePointerUp);
+  root.addEventListener("pointercancel", handlePointerCancel);
   window.addEventListener("resize", handleViewportResize);
   window.addEventListener("orientationchange", handleViewportResize);
 
@@ -802,10 +822,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     setGestureActive(false);
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);
-    root.removeEventListener("touchstart", handleTouchStart);
-    root.removeEventListener("touchmove", handleTouchMove);
-    root.removeEventListener("touchend", handleTouchEnd);
-    root.removeEventListener("touchcancel", handleTouchCancel);
+    root.removeEventListener("pointerdown", handlePointerDown);
+    root.removeEventListener("pointermove", handlePointerMove);
+    root.removeEventListener("pointerup", handlePointerUp);
+    root.removeEventListener("pointercancel", handlePointerCancel);
     window.removeEventListener("resize", handleViewportResize);
     window.removeEventListener("orientationchange", handleViewportResize);
   };

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -9,16 +9,32 @@ import { classifyTouchSeekIntent } from "./useShortsSlideGestures";
  * 各家实现不一致，慢速大幅滑动经常被判回弹，快速轻扫又可能不吸附，落点动画
  * 的时长和缓动也不可控——这就是移动端"手感不好"的根源。
  *
- * 这里参考 zyronon/douyin 的 `utils/slide.ts` 把判定收回自己手里：
- * - 按下到抬手全程 1:1 跟手（不跟随浏览器的滚动预测）
- * - 抬手时按"距离 + 时长"判定切屏还是回弹，规则固定、跨浏览器一致
- * - 落点用 easeOutCubic 收尾，时长按抬手速度反解，读起来是惯性减速而非跳变
+ * 判定和运动两部分都照 zyronon/douyin 的 `utils/slide.ts` 来：
+ * - 判定：位移 <20px 回弹、>1/3 屏必切、中间地带看 150ms 内是否抬手
+ * - 运动：`translate3d` + CSS `transition`，**跑在合成器线程上**
  *
- * 与 douyin 不同的是，这里不引入 transform 轨道：位移仍然写在原有滚动容器的
- * `scrollTop`（文档滚动模式写 `window.scrollY`）上。页面其余部分——
- * IntersectionObserver 判活跃屏、长会话队列裁剪重贴、键盘 `scrollIntoView`、
- * 隐藏视频后跳下一条——全都建立在同一套 scrollTop / offsetTop 几何上，换成
- * transform 轨道会一次性推翻它们。
+ * 运动机制这条尤其关键。切屏那几百毫秒恰好是主线程最忙的时候——activeIndex
+ * 变化触发 React 重渲染、iOS 共享 <video> 换插槽、`play()` 起播、下一条预载。
+ * 用 rAF 逐帧写 `scrollTop` 的话主线程一掉帧动画就顿；交给 CSS transition
+ * 则完全不受主线程影响。
+ *
+ * ## 坐标模型
+ *
+ * 记 `T` 为轨道当前的 translateY，任意时刻的等效滚动位置恒为 `scrollTop - T`；
+ * 下面所有几何换算都从这一条推出来。三个阶段：
+ *
+ * - 静止：`scrollTop` 精确落在某条 slide 上，`T = 0`，轨道上什么都没有。
+ * - 跟手：`scrollTop` 不动，位移全部记在 `T` 上（逐帧只写 transform）。
+ * - 落点：**先把 `scrollTop` 写到目标 slide，再用 `T` 反向补偿这次跳变，
+ *   然后让 `T` 动画归零**（FLIP）。画面是平滑滑过去的，但滚动位置在第 0
+ *   毫秒就已经是新的了。
+ *
+ * 落点这样排有两个直接后果：IntersectionObserver 在松手当场就判出新的活跃屏
+ * （下一条视频立刻起播，与 douyin 在 touchEnd 里推进 index 一致），以及位置
+ * 提交完全不依赖 transitionend——那个事件丢了也只是 will-change 多留一会儿。
+ *
+ * 页面其余部分因此完全不用改：判活跃屏、长会话队列裁剪重贴、键盘
+ * `scrollIntoView`、隐藏视频后跳下一条，全都仍然建立在 `scrollTop` 几何上。
  */
 
 /** 位移不足这个值一律当误触，回弹到当前视频。 */
@@ -30,15 +46,22 @@ export const SHORTS_PAGER_FLICK_MS = 150;
 /** 落点动画时长区间；douyin 用的是固定 300ms，这里按速度在区间内浮动。 */
 export const SHORTS_PAGER_MIN_SETTLE_MS = 180;
 export const SHORTS_PAGER_MAX_SETTLE_MS = 380;
+/**
+ * 落点缓动。这是 easeOutCubic 的 cubic-bezier 形式，起始斜率
+ * 0.61 / 0.215 ≈ 2.84，与下面按 3×距离/时长 反解时长的假设吻合：动画第一帧
+ * 的速度就接上手指离开时的速度，读起来是继续减速滑过去而不是重新起步。
+ * 换缓动就必须同步改 resolveShortsPagerSettleDuration 里的系数。
+ */
+export const SHORTS_PAGER_SETTLE_EASING = "cubic-bezier(0.215, 0.61, 0.355, 1)";
 /** 抬手速度取这个时间窗内的平均值，避免最后一帧抖动主导结果。 */
 export const SHORTS_PAGER_VELOCITY_WINDOW_MS = 100;
+/**
+ * transitionend 兜底。标签页切走、合成器丢事件时它可能不来；位置早已提交，
+ * 这里只是保证 will-change 和内联 transform 不会一直挂在轨道上。
+ */
+export const SHORTS_PAGER_SETTLE_FALLBACK_MS = 80;
 /** 低于这个速度就不按速度反解时长，直接按剩余距离取。 */
 const SHORTS_PAGER_MIN_VELOCITY_PX_PER_MS = 0.05;
-/**
- * 判定"滚动位置被外力挪过"的阈值。自己写进去的值再读回来只会有亚像素级
- * 取整误差；队列裁剪重贴一次至少挪掉好几屏，两者相差好几个数量级。
- */
-const SHORTS_PAGER_EXTERNAL_SCROLL_EPSILON_PX = 4;
 /**
  * 竖滑之后吞掉合成 click 的时间窗。合成 click 紧跟在同一次 touchend 之后
  * 到达，这个窗口只要覆盖住它即可；下一次按下也会立刻解除，用户真正的轻点
@@ -109,9 +132,8 @@ export function resolveShortsPagerTargetIndex(input: ShortsPagerRelease): number
 }
 
 /**
- * 落点动画时长。easeOutCubic 的起始速度是 3 × 距离 / 时长，按抬手速度反解
- * 时长，动画第一帧就能接上手指离开时的速度，看起来是"继续减速滑过去"而不是
- * 松手后重新起步——这正是需求里的惯性滚动。
+ * 落点动画时长。SHORTS_PAGER_SETTLE_EASING 的起始速度约为 3 × 距离 / 时长，
+ * 按抬手速度反解时长，动画第一帧就能接上手指离开时的速度。
  *
  * 速度过低（慢慢拖到位再松手）时反解出来的时长会趋于无穷，改按剩余距离取：
  * 拖得越远收尾越长，短距离回弹不会拖泥带水。两条路径最后都夹在区间内。
@@ -140,25 +162,69 @@ export function resolveShortsPagerSettleDuration(input: {
   );
 }
 
-/** easeOutCubic：入场快、收尾慢，和惯性减速同形。 */
-export function shortsPagerEase(t: number): number {
-  const clamped = clamp(t, 0, 1);
-  return 1 - (1 - clamped) * (1 - clamped) * (1 - clamped);
+/**
+ * 从 transform 值里取出 translateY。内联样式写的是 `translate3d(0, Npx, 0)`，
+ * `getComputedStyle` 读回来的是 `matrix(...)` / `matrix3d(...)`——动画进行中
+ * 只有后者能拿到当前的中间值，所以两种都要认。认不出来时返回 0：宁可当成
+ * 没有位移（最坏是少平移一次），也不要把 NaN 传进滚动位置里。
+ */
+export function parseTranslateY(transform: string | null | undefined): number {
+  if (!transform || transform === "none") return 0;
+
+  const translate3d = /translate3d\(\s*[^,]+,\s*(-?[\d.]+)px/.exec(transform);
+  if (translate3d) return toFiniteNumber(translate3d[1]);
+
+  const translateY = /translateY\(\s*(-?[\d.]+)px/.exec(transform);
+  if (translateY) return toFiniteNumber(translateY[1]);
+
+  const matrix3d = /^matrix3d\((.+)\)$/.exec(transform);
+  if (matrix3d) {
+    const parts = matrix3d[1].split(",");
+    return parts.length === 16 ? toFiniteNumber(parts[13]) : 0;
+  }
+
+  const matrix = /^matrix\((.+)\)$/.exec(transform);
+  if (matrix) {
+    const parts = matrix[1].split(",");
+    return parts.length === 6 ? toFiniteNumber(parts[5]) : 0;
+  }
+
+  return 0;
+}
+
+function toFiniteNumber(raw: string): number {
+  const value = Number(raw.trim());
+  return Number.isFinite(value) ? value : 0;
 }
 
 /**
- * 锚点 slide 内的滚动偏移：0 表示正好贴在吸附点上，正值表示已经往下滑过了
- * 一部分。长会话队列裁剪要用它把"裁剪前的画面位置"原样搬到新坐标系里。
- * 夹在 ±一屏之内，异常几何（尺寸未就绪、节点已脱离布局）不会把滚动甩飞。
+ * 滚动位置相对某条 slide 顶端的偏移：0 表示正好贴在吸附点上，正值表示已经
+ * 往下滑过了一部分。长会话队列裁剪要用它把"裁剪前的画面位置"原样搬到新
+ * 坐标系里。夹在 ±一屏之内，异常几何不会把滚动位置甩飞。
+ *
+ * 传进来的 `slideTop` 必须是**消掉了轨道 transform 之后**的布局位置，
+ * 否则动画进行中量出来的值会把 translateY 重复计入一次，重贴时画面会跳
+ * 一整屏。取法见 readShortsSlideTopWithinTrack。
  */
 export function measureOffsetWithinSlide(input: {
-  /** slide 顶端相对滚动容器上沿的距离，向下为正。 */
+  scrollTop: number;
   slideTop: number;
   viewportHeight: number;
 }): number {
   const limit = Math.max(0, input.viewportHeight);
-  // `0 - x` 而不是 `-x`：贴合吸附点时前者是 +0，后者是 -0，会污染调用方的比较。
-  return clamp(0 - input.slideTop, -limit, limit);
+  return clamp(input.scrollTop - input.slideTop, -limit, limit);
+}
+
+/**
+ * slide 相对轨道内容原点的位置。两个 rect 受同一个 transform 影响，相减就
+ * 把它消掉了，因此这个值在动画进行中同样可靠，且不依赖 offsetParent 语义。
+ */
+export function readShortsSlideTopWithinTrack(
+  slide: HTMLElement | null,
+  track: HTMLElement | null
+): number {
+  if (!slide || !track) return 0;
+  return slide.getBoundingClientRect().top - track.getBoundingClientRect().top;
 }
 
 /** 贴合度最高的那一屏；用于手势起点和落点的锚定。 */
@@ -185,12 +251,15 @@ type PagerDrag = {
   startTime: number;
   /** 判定为纵向翻页那一刻的位移；后续按它做零点，避免激活时画面跳一下。 */
   baselineY: number;
+  /** 手势开始时轨道已有的位移（中途接住动画时非 0）。 */
+  originTranslate: number;
   anchorIndex: number;
-  anchorTop: number;
-  /** 本次手势允许到达的滚动范围：最多相邻一屏。 */
-  minTop: number;
-  maxTop: number;
+  /** 本次手势允许到达的 translateY 范围：最多相邻一屏。 */
+  minTranslate: number;
+  maxTranslate: number;
   viewportHeight: number;
+  /** 手势开始时的 slide 节点与它们的等效滚动位置。 */
+  slides: HTMLElement[];
   slideTops: number[];
   /** 已判定为纵向翻页并接管 */
   committed: boolean;
@@ -202,8 +271,10 @@ type PagerDrag = {
 };
 
 export type ShortsSwipePagerHost = {
-  /** slide 所在的容器；同时也是触摸监听的挂载点。 */
+  /** slide 所在的滚动容器；同时也是触摸监听的挂载点。 */
   root: HTMLElement;
+  /** 承载位移的轨道，`root` 的唯一子元素。 */
+  track: HTMLElement;
   /** iPhone 浏览器壳的文档滚动模式：位移写在 window 上。 */
   usesDocumentScroll: boolean;
   /** 视口尺寸变化后用来重新对齐的当前屏。 */
@@ -212,32 +283,18 @@ export type ShortsSwipePagerHost = {
 
 /**
  * 手势状态机本体，不依赖 React。这样它能脱离渲染器直接接受完整的事件序列
- * 测试——按下 / 移动 / 抬手 / 多指 / 打断动画每条分支都能覆盖到，这些恰恰
- * 是"手感"真正落在的地方。返回值是解除绑定的函数。
+ * 测试——按下 / 移动 / 抬手 / 多指 / 打断动画 / 落点提交每条分支都能覆盖到，
+ * 这些恰恰是"手感"真正落在的地方。返回值是解除绑定的函数。
  */
 export function createShortsSwipePager(host: ShortsSwipePagerHost) {
-  const { root, usesDocumentScroll } = host;
+  const { root, track, usesDocumentScroll } = host;
+
   // ---- 滚动目标适配：容器滚动 / 文档滚动共用同一套位移逻辑 ----
   const getScrollTop = () =>
     usesDocumentScroll ? window.scrollY : root.scrollTop;
-  /** 上一次由本模块写入的滚动位置；null 表示当前没有在跟踪。 */
-  let lastWrittenTop: number | null = null;
   const setScrollTop = (value: number) => {
     if (usesDocumentScroll) window.scrollTo(0, value);
     else root.scrollTop = value;
-    lastWrittenTop = value;
-  };
-  /**
-   * 外力（长会话队列裁剪重贴、scrollIntoView）挪动滚动位置时的位移量，
-   * 没被挪过就是 0。裁剪几乎总是插在切屏过程中间：不跟着平移，跟手位移
-   * 和落点动画都会按旧坐标继续写，画面会硬跳一大截。
-   */
-  const readExternalScrollDelta = () => {
-    if (lastWrittenTop === null) return 0;
-    const delta = getScrollTop() - lastWrittenTop;
-    return Math.abs(delta) > SHORTS_PAGER_EXTERNAL_SCROLL_EPSILON_PX
-      ? delta
-      : 0;
   };
   const getViewportHeight = () =>
     usesDocumentScroll ? window.innerHeight : root.clientHeight;
@@ -248,68 +305,169 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
         ? document.documentElement.scrollHeight - window.innerHeight
         : root.scrollHeight - root.clientHeight
     );
-  /**
-   * slide 在滚动坐标系里的位置。不用 offsetTop：那依赖 offsetParent 恰好
-   * 是滚动容器的上沿，rect 差值在两种滚动模式下都成立。
-   */
-  const getSlideTop = (slide: HTMLElement) => {
-    const base = usesDocumentScroll ? 0 : root.getBoundingClientRect().top;
-    return slide.getBoundingClientRect().top - base + getScrollTop();
+
+  // ---- 轨道位移 ----
+  /** 轨道当前的 translateY。等效滚动位置恒为 getScrollTop() - translate。 */
+  let translate = 0;
+  /** 动画进行中内联样式记的是终点值，当前值只能从 computed 里读。 */
+  const readLiveTranslate = () => {
+    const computed = window.getComputedStyle?.(track)?.transform;
+    return computed === undefined ? translate : parseTranslateY(computed);
   };
-  /** 一次手势只读一次：容器 rect 和滚动位置在循环外取好，避免逐条回读布局。 */
+  const applyTranslate = (value: number) => {
+    translate = value;
+    track.style.transform = `translate3d(0, ${value}px, 0)`;
+  };
+  /** 静止态：清掉 transform 和合成层提示。 */
+  const clearTranslate = () => {
+    translate = 0;
+    track.style.transition = "";
+    track.style.transform = "";
+    track.style.willChange = "";
+  };
+
+  /**
+   * 当前等效滚动位置。用**实时** translate 而不是内联终点值：动画进行中两者
+   * 不同，rect 反映的是实时值，混用会算出差一整屏的结果。
+   * 每次手势 / 落点只调用几次（逐帧的跟手位移不走这里），开销可以忽略。
+   */
+  const getEffectiveTop = () => getScrollTop() - readLiveTranslate();
+  const readSlides = () => [
+    ...root.querySelectorAll<HTMLElement>("[data-shorts-slide]"),
+  ];
+  /**
+   * slide 的等效滚动位置。由 `slide.rect.top = rootRect.top + (S - scrollTop)
+   * + translate` 反解而来；rect 和减掉的 translate 取自同一时刻，因此不管
+   * 动画跑到哪一帧，结果都是这条 slide 真实的布局落点。
+   */
   const readSlideTops = () => {
     const base = usesDocumentScroll ? 0 : root.getBoundingClientRect().top;
-    const origin = getScrollTop();
-    return [...root.querySelectorAll<HTMLElement>("[data-shorts-slide]")].map(
+    const origin = getEffectiveTop();
+    return readSlides().map(
       (slide) => slide.getBoundingClientRect().top - base + origin
     );
   };
+  const readSlideTop = (slide: HTMLElement) =>
+    slide.getBoundingClientRect().top -
+    (usesDocumentScroll ? 0 : root.getBoundingClientRect().top) +
+    getEffectiveTop();
 
   // ---- 落点动画 ----
-  let settleFrame: number | null = null;
+  let settleTimer: number | null = null;
+  let settling = false;
+
+  const handleTransitionEnd = (event: Event) => {
+    const transitionEvent = event as TransitionEvent;
+    if (transitionEvent.target !== track) return;
+    if (
+      transitionEvent.propertyName &&
+      transitionEvent.propertyName !== "transform"
+    ) {
+      return;
+    }
+    finishMotion();
+  };
+
+  const detachSettleListeners = () => {
+    if (settleTimer !== null) {
+      window.clearTimeout(settleTimer);
+      settleTimer = null;
+    }
+    track.removeEventListener("transitionend", handleTransitionEnd);
+  };
+
+  /** 动画收尾：只是摘掉合成层提示，位置在动画开始时就已经落定了。 */
+  const finishMotion = () => {
+    if (!settling) return;
+    settling = false;
+    detachSettleListeners();
+    clearTranslate();
+  };
+
   /** 返回是否真的打断了一次进行中的动画。 */
   const cancelSettle = () => {
-    if (settleFrame === null) return false;
-    window.cancelAnimationFrame(settleFrame);
-    settleFrame = null;
+    if (!settling) return false;
+    settling = false;
+    detachSettleListeners();
+    // 冻结在当前这一帧的位置，手指从这里接着走。
+    const live = readLiveTranslate();
+    track.style.transition = "none";
+    applyTranslate(live);
     return true;
   };
-  const settleTo = (targetTop: number, velocityPxPerMs: number) => {
-    cancelSettle();
-    let from = getScrollTop();
-    const distance = targetTop - from;
+
+  /**
+   * 落点：**先提交位置，再补一段动画**（FLIP）。
+   *
+   * 松手的当下就把 `scrollTop` 写到目标 slide 上，然后给轨道加一个反向的
+   * translate 抵消掉这次跳变，再让它动画归零——画面看起来是平滑滑过去的，
+   * 但滚动位置在第 0 毫秒就已经是新的了。
+   *
+   * 这么排有两个好处，都关乎手感和健壮性：
+   * 1. IntersectionObserver 在松手当场就判出新的活跃屏，下一条视频立刻起播，
+   *    不用等动画走完（douyin 也是在 touchEnd 里就推进 localIndex 的）。
+   *    也就不必去赌"合成器动画期间 IO 会不会被触发"。
+   * 2. 位置提交不依赖 transitionend。那个事件在标签页切走、动画被打断时会丢；
+   *    在这个排法里丢了也只是 will-change 多留一会儿，绝不会卡在两屏之间。
+   *
+   * 长会话队列裁剪同理：它保持 `scrollTop - slide 布局位置` 不变，轨道上的
+   * translate 原样继续，视觉完全连续，不需要任何额外处理。
+   */
+  const settleTo = (target: HTMLElement | null, velocityPxPerMs: number) => {
+    detachSettleListeners();
+    settling = false;
+
+    const live = readLiveTranslate();
+    const from = getScrollTop();
+    const targetTop = clamp(
+      target ? readSlideTop(target) : from - live,
+      0,
+      getMaxScrollTop()
+    );
+
+    setScrollTop(targetTop);
+    // 浏览器可能夹取实际落点，按真正生效的值算补偿量，画面才不会跳。
+    const compensation = live + (getScrollTop() - from);
+
     const duration = resolveShortsPagerSettleDuration({
-      remainingPx: distance,
+      remainingPx: compensation,
       velocityPxPerMs,
       viewportHeight: getViewportHeight(),
     });
     if (duration <= 0) {
-      setScrollTop(targetTop);
+      clearTranslate();
       return;
     }
-    lastWrittenTop = from;
-    const startedAt = performance.now();
-    const step = (now: number) => {
-      // 队列裁剪只是把整条 feed 换了坐标系，画面位置是连续的：起点跟着
-      // 平移，终点（from + distance）自然一起平移，动画不受影响地跑完。
-      from += readExternalScrollDelta();
-      const progress = clamp((now - startedAt) / duration, 0, 1);
-      setScrollTop(from + distance * shortsPagerEase(progress));
-      if (progress < 1) {
-        settleFrame = window.requestAnimationFrame(step);
-      } else {
-        settleFrame = null;
-        lastWrittenTop = null;
-      }
-    };
-    settleFrame = window.requestAnimationFrame(step);
+
+    settling = true;
+    track.style.willChange = "transform";
+    // 起点必须先以"无过渡"的方式落到样式上，否则浏览器会把它和终点合并，
+    // 直接跳到 0 而没有动画。
+    track.style.transition = "none";
+    applyTranslate(compensation);
+    forceStyleFlush();
+    track.style.transition = `transform ${Math.round(duration)}ms ${SHORTS_PAGER_SETTLE_EASING}`;
+    applyTranslate(0);
+    track.addEventListener("transitionend", handleTransitionEnd);
+    settleTimer = window.setTimeout(
+      finishMotion,
+      Math.round(duration) + SHORTS_PAGER_SETTLE_FALLBACK_MS
+    );
   };
+
+  /**
+   * 把刚写下的起点值真正提交给样式系统。用方法调用而不是 `void el.offsetHeight`：
+   * 属性读取有被压缩器判成无副作用而删掉的风险，那会让 FLIP 的两次写入被合并，
+   * 动画直接消失。
+   */
+  function forceStyleFlush() {
+    track.getBoundingClientRect();
+  }
 
   // ---- 合成 click 兜底 ----
   // touchend 上的 preventDefault 按规范应当挡住合成 click，但个别 WebKit
   // 版本只认"第一个 touchmove 上的 preventDefault"。漏出来的那一次 click 会
   // 落到 slide 上被当成单击去暂停视频——每滑一屏暂停一次，非常显眼。
-  // 这里只吞掉紧跟在一次成功竖滑之后的那一个 click。
   let clickGuardTimer: number | null = null;
   const swallowClick = (event: Event) => {
     releaseClickGuard();
@@ -336,19 +494,20 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
 
   /** 多指 / 取消等中断：就近吸附，不要停在两屏之间。 */
   const settleToNearest = () => {
+    const slides = drag?.slides ?? readSlides();
     const slideTops = drag?.slideTops ?? readSlideTops();
-    const index = findNearestShortsSlideIndex(slideTops, getScrollTop());
+    const index = findNearestShortsSlideIndex(slideTops, getEffectiveTop());
     if (index < 0) return;
-    settleTo(clamp(slideTops[index], 0, getMaxScrollTop()), 0);
+    settleTo(slides[index] ?? null, 0);
   };
 
   const handleTouchStart = (event: TouchEvent) => {
-    // 上一次的落点动画还在跑：接住它，用当前位置作为新手势的起点。
-    // 打断过动画、或上一次手势被第二根手指顶掉，位置就停在两屏之间，
-    // 这次手势无论走哪条分支收尾都得把它吸回吸附点。
     // 新的一次按下：上一次竖滑的合成 click 早该到了，守卫立刻失效，
     // 这样紧接着的这次轻点一定能穿到 slide 上。
     releaseClickGuard();
+    // 上一次的落点动画还在跑：接住它，用当前位置作为新手势的起点。
+    // 打断过动画、或上一次手势被第二根手指顶掉，位置就停在两屏之间，
+    // 这次手势无论走哪条分支收尾都得把它吸回吸附点。
     const previous = drag;
     drag = null;
     const interrupted = cancelSettle() || Boolean(previous?.committed);
@@ -369,32 +528,33 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       return bail();
     }
 
+    const slides = readSlides();
+    if (slides.length === 0) return bail();
     const slideTops = readSlideTops();
-    if (slideTops.length === 0) return bail();
-    const scrollTop = getScrollTop();
-    const anchorIndex = findNearestShortsSlideIndex(slideTops, scrollTop);
+    const effectiveTop = getEffectiveTop();
+    const anchorIndex = findNearestShortsSlideIndex(slideTops, effectiveTop);
     if (anchorIndex < 0) return bail();
-    const maxScrollTop = getMaxScrollTop();
-    const previousTop = slideTops[anchorIndex - 1];
-    const nextTop = slideTops[anchorIndex + 1];
+
     const anchorTop = slideTops[anchorIndex];
+    const previousTop = slideTops[anchorIndex - 1] ?? anchorTop;
+    const nextTop = slideTops[anchorIndex + 1] ?? anchorTop;
+    const scrollTop = getScrollTop();
     const touch = event.touches[0];
     const now = performance.now();
-    // 几何刚刚重新采过，之前那次动画写下的位置不能再当作平移基准。
-    lastWrittenTop = null;
 
     drag = {
       startX: touch.clientX,
       startY: touch.clientY,
       startTime: now,
       baselineY: 0,
+      originTranslate: translate,
       anchorIndex,
-      // 手势起点就是当前实际位置：中途接住动画时不会先跳回吸附点。
-      anchorTop: clamp(scrollTop, 0, maxScrollTop),
       // 一次手势最多离开当前屏一屏；否则松手只切一屏会看到明显的回抽。
-      minTop: clamp(previousTop ?? anchorTop, 0, maxScrollTop),
-      maxTop: clamp(nextTop ?? anchorTop, 0, maxScrollTop),
+      // translate 与滚动位置反向，因此 next 对应下限、previous 对应上限。
+      minTranslate: scrollTop - nextTop,
+      maxTranslate: scrollTop - previousTop,
       viewportHeight: getViewportHeight(),
+      slides,
       slideTops,
       committed: false,
       abandoned: false,
@@ -430,6 +590,8 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       drag.committed = true;
       // 激活阈值那段位移不能再算进画面位移，否则接管的瞬间会跳一下。
       drag.baselineY = deltaY;
+      track.style.willChange = "transform";
+      track.style.transition = "none";
     }
 
     // 接管后必须挡掉浏览器的默认处理（容器已是 touch-action: none，
@@ -446,35 +608,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       drag.samples.shift();
     }
 
-    // 拖动途中被队列裁剪换了坐标系：重新采一次几何，手指接着往下拖时
-    // 位移仍然连续，不会突然跳到旧坐标对应的位置。
-    const externalDelta = readExternalScrollDelta();
-    if (externalDelta !== 0) {
-      const maxScrollTop = getMaxScrollTop();
-      drag.slideTops = readSlideTops();
-      drag.anchorTop = clamp(drag.anchorTop + externalDelta, 0, maxScrollTop);
-      const anchorIndex = findNearestShortsSlideIndex(
-        drag.slideTops,
-        drag.anchorTop
-      );
-      if (anchorIndex >= 0) {
-        const ownTop = drag.slideTops[anchorIndex];
-        drag.anchorIndex = anchorIndex;
-        drag.minTop = clamp(
-          drag.slideTops[anchorIndex - 1] ?? ownTop,
-          0,
-          maxScrollTop
-        );
-        drag.maxTop = clamp(
-          drag.slideTops[anchorIndex + 1] ?? ownTop,
-          0,
-          maxScrollTop
-        );
-      }
-    }
-
-    const offset = drag.anchorTop - (deltaY - drag.baselineY);
-    setScrollTop(clamp(offset, drag.minTop, drag.maxTop));
+    // 位移纯粹由手指决定，不读 scrollTop——队列裁剪在拖动中途换坐标系时
+    // 跟手也不会被带偏（裁剪同时改 slide 布局与 scrollTop，视觉是连续的）。
+    const next = drag.originTranslate + (deltaY - drag.baselineY);
+    applyTranslate(clamp(next, drag.minTranslate, drag.maxTranslate));
   };
 
   const handleTouchEnd = (event: TouchEvent) => {
@@ -510,14 +647,12 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       elapsedMs: now - current.startTime,
       viewportHeight: current.viewportHeight,
       anchorIndex: current.anchorIndex,
-      slideCount: current.slideTops.length,
+      slideCount: current.slides.length,
     });
-    const targetTop = clamp(
-      current.slideTops[targetIndex] ?? current.anchorTop,
-      0,
-      getMaxScrollTop()
-    );
-    settleTo(targetTop, computeShortsPagerVelocity(current.samples));
+    // 记住目标**节点**而不是坐标：队列裁剪会在动画途中改坐标系，节点身份不会变。
+    const target =
+      current.slides[targetIndex] ?? current.slides[current.anchorIndex] ?? null;
+    settleTo(target, computeShortsPagerVelocity(current.samples));
   };
 
   const handleTouchCancel = () => {
@@ -537,9 +672,12 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     if (drag) return;
     const slide = host.getAnchorSlide();
     if (!slide) return;
-    setScrollTop(clamp(getSlideTop(slide), 0, getMaxScrollTop()));
+    const top = readSlideTop(slide);
+    clearTranslate();
+    setScrollTop(clamp(top, 0, getMaxScrollTop()));
   };
   const handleViewportResize = () => {
+    // 尺寸都变了，正在跑的动画按旧尺寸算的终点已经没有意义。
     cancelSettle();
     realign();
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
@@ -563,7 +701,18 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   window.addEventListener("orientationchange", handleViewportResize);
 
   return () => {
-    cancelSettle();
+    // 落点动画进行中时位置早已提交，直接清干净即可；只有拖到一半被卸载
+    // （手指还按着）才需要把跟手位移落回 scrollTop。
+    if (settling) {
+      finishMotion();
+    } else if (translate !== 0) {
+      const top = getEffectiveTop();
+      clearTranslate();
+      setScrollTop(clamp(top, 0, getMaxScrollTop()));
+    } else {
+      clearTranslate();
+    }
+    detachSettleListeners();
     releaseClickGuard();
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);
@@ -580,6 +729,7 @@ export type ShortsSwipePagerOptions = {
   /** 关闭时完全不挂监听，页面回到原生 scroll-snap。 */
   enabled: boolean;
   containerRef: React.RefObject<HTMLElement | null>;
+  trackRef: React.RefObject<HTMLElement | null>;
   usesDocumentScroll: boolean;
   getAnchorSlide: () => HTMLElement | null;
 };
@@ -594,9 +744,11 @@ export function useShortsSwipePager(options: ShortsSwipePagerOptions) {
   useEffect(() => {
     if (!enabled) return;
     const root = optionsRef.current.containerRef.current;
-    if (!root) return;
+    const track = optionsRef.current.trackRef.current;
+    if (!root || !track) return;
     return createShortsSwipePager({
       root,
+      track,
       usesDocumentScroll,
       // 走 ref 读取，回调换引用不会重挂监听。
       getAnchorSlide: () => optionsRef.current.getAnchorSlide(),

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -361,6 +361,30 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
         : root.scrollHeight - root.clientHeight
     );
 
+  // ---- 原生吸附的临时摘除 ----
+  // CSS 的吸附点是按元素**变换后**的位置算的。轨道一平移，吸附点就跟着移，
+  // `scroll-snap-type: mandatory` 会立刻把 scrollTop 反向拉回去补偿——净效果
+  // 正好抵消掉跟手位移，桌面上表现为"鼠标怎么拖画面都不动"。
+  //
+  // 触屏路径靠 .shorts-feed.is-touch-paged 常驻关掉吸附；桌面故意保留吸附让
+  // 滚轮和方向键继续走原生，所以只能在手势和落点动画期间临时摘掉，落定再还
+  // 回去。还回去时我们已经精确停在吸附点上，浏览器的重新吸附是空操作。
+  const snapHosts: HTMLElement[] = usesDocumentScroll
+    ? [document.documentElement, document.body]
+    : [root];
+  let snapSuspended = false;
+  const suspendSnap = () => {
+    if (snapSuspended) return;
+    snapSuspended = true;
+    for (const host of snapHosts) host.style.scrollSnapType = "none";
+  };
+  const restoreSnap = () => {
+    if (!snapSuspended) return;
+    snapSuspended = false;
+    // 清成空串而不是写死值：还给样式表决定，触屏路径那边本来就是 none。
+    for (const host of snapHosts) host.style.scrollSnapType = "";
+  };
+
   // ---- 轨道位移 ----
   /** 轨道当前的 translateY。等效滚动位置恒为 getScrollTop() - translate。 */
   let translate = 0;
@@ -437,6 +461,8 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     settling = false;
     detachSettleListeners();
     clearTranslate();
+    // 必须在 transform 清掉之后才还，否则浏览器会按带位移的吸附点重新吸附。
+    restoreSnap();
   };
 
   /** 返回是否真的打断了一次进行中的动画。 */
@@ -472,6 +498,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   const settleTo = (target: HTMLElement | null, committed: boolean) => {
     detachSettleListeners();
     settling = false;
+    suspendSnap();
 
     const live = readLiveTranslate();
     const from = getScrollTop();
@@ -492,6 +519,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     });
     if (duration <= 0) {
       clearTranslate();
+      restoreSnap();
       return;
     }
 
@@ -676,6 +704,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       }
       drag.committed = true;
       setGestureActive(true);
+      suspendSnap();
       // 鼠标拖到容器外面也要继续收事件；触摸本来就隐式捕获，这里是给桌面用的。
       try {
         root.setPointerCapture(event.pointerId);
@@ -779,6 +808,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     if (!slide) return;
     const top = readSlideTop(slide);
     clearTranslate();
+    restoreSnap();
     setScrollTop(clamp(top, 0, getMaxScrollTop()));
   };
   const handleViewportResize = () => {
@@ -819,6 +849,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }
     detachSettleListeners();
     releaseClickGuard();
+    restoreSnap();
     setGestureActive(false);
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -1,0 +1,605 @@
+import { useEffect, useRef } from "react";
+import { clamp } from "./mediaBuffer";
+import { classifyTouchSeekIntent } from "./useShortsSlideGestures";
+
+/**
+ * 移动端上下翻页手势控制器。
+ *
+ * 原生 `scroll-snap-type: y mandatory` 把"滑多远才算切屏"完全交给了浏览器：
+ * 各家实现不一致，慢速大幅滑动经常被判回弹，快速轻扫又可能不吸附，落点动画
+ * 的时长和缓动也不可控——这就是移动端"手感不好"的根源。
+ *
+ * 这里参考 zyronon/douyin 的 `utils/slide.ts` 把判定收回自己手里：
+ * - 按下到抬手全程 1:1 跟手（不跟随浏览器的滚动预测）
+ * - 抬手时按"距离 + 时长"判定切屏还是回弹，规则固定、跨浏览器一致
+ * - 落点用 easeOutCubic 收尾，时长按抬手速度反解，读起来是惯性减速而非跳变
+ *
+ * 与 douyin 不同的是，这里不引入 transform 轨道：位移仍然写在原有滚动容器的
+ * `scrollTop`（文档滚动模式写 `window.scrollY`）上。页面其余部分——
+ * IntersectionObserver 判活跃屏、长会话队列裁剪重贴、键盘 `scrollIntoView`、
+ * 隐藏视频后跳下一条——全都建立在同一套 scrollTop / offsetTop 几何上，换成
+ * transform 轨道会一次性推翻它们。
+ */
+
+/** 位移不足这个值一律当误触，回弹到当前视频。 */
+export const SHORTS_PAGER_MIN_COMMIT_PX = 20;
+/** 位移超过一屏的这个比例，无论快慢都切屏。 */
+export const SHORTS_PAGER_COMMIT_RATIO = 1 / 3;
+/** 中间地带（位移够但不大）看抬手快慢：短于这个时长算轻扫，切屏。 */
+export const SHORTS_PAGER_FLICK_MS = 150;
+/** 落点动画时长区间；douyin 用的是固定 300ms，这里按速度在区间内浮动。 */
+export const SHORTS_PAGER_MIN_SETTLE_MS = 180;
+export const SHORTS_PAGER_MAX_SETTLE_MS = 380;
+/** 抬手速度取这个时间窗内的平均值，避免最后一帧抖动主导结果。 */
+export const SHORTS_PAGER_VELOCITY_WINDOW_MS = 100;
+/** 低于这个速度就不按速度反解时长，直接按剩余距离取。 */
+const SHORTS_PAGER_MIN_VELOCITY_PX_PER_MS = 0.05;
+/**
+ * 判定"滚动位置被外力挪过"的阈值。自己写进去的值再读回来只会有亚像素级
+ * 取整误差；队列裁剪重贴一次至少挪掉好几屏，两者相差好几个数量级。
+ */
+const SHORTS_PAGER_EXTERNAL_SCROLL_EPSILON_PX = 4;
+/**
+ * 竖滑之后吞掉合成 click 的时间窗。合成 click 紧跟在同一次 touchend 之后
+ * 到达，这个窗口只要覆盖住它即可；下一次按下也会立刻解除，用户真正的轻点
+ * 不会被误伤。
+ */
+const SHORTS_PAGER_CLICK_GUARD_MS = 300;
+/** 起点标记：滑动手势不接管这个子树内按下的触摸（如底部进度条）。 */
+export const SHORTS_NO_SWIPE_ATTRIBUTE = "data-shorts-no-swipe";
+
+export type ShortsPagerSample = { y: number; t: number };
+
+/**
+ * 抬手速度（px/ms，向下为正）。取最近 SHORTS_PAGER_VELOCITY_WINDOW_MS 内
+ * 最早的一个采样点与最后一个采样点做差：只用最后两帧会被单帧抖动放大，
+ * 用整段手势又会把中途的停顿算进来。
+ */
+export function computeShortsPagerVelocity(samples: ShortsPagerSample[]): number {
+  if (samples.length < 2) return 0;
+  const last = samples[samples.length - 1];
+  let first = samples[0];
+  for (const sample of samples) {
+    if (last.t - sample.t <= SHORTS_PAGER_VELOCITY_WINDOW_MS) {
+      first = sample;
+      break;
+    }
+  }
+  const elapsed = last.t - first.t;
+  if (elapsed <= 0) return 0;
+  return (last.y - first.y) / elapsed;
+}
+
+export type ShortsPagerRelease = {
+  /** 纵向位移，向上滑（看下一条）为负。 */
+  deltaY: number;
+  /** 按下到抬手的毫秒数。 */
+  elapsedMs: number;
+  /** 一屏高度。 */
+  viewportHeight: number;
+  /** 手势开始时贴合的那一屏。 */
+  anchorIndex: number;
+  /** 当前队列里的 slide 总数。 */
+  slideCount: number;
+};
+
+/**
+ * 松手后应该停在哪一屏；返回值仍等于 anchorIndex 表示回弹。
+ *
+ * 判定顺序照搬 douyin：先用距离把两头的情况定死（太短必不通过、超过 1/3 屏
+ * 必通过），只有中间地带才看抬手快慢。目标恒为 anchorIndex ± 1——一次手势
+ * 最多切一屏，快速连滑靠多次手势叠加，不会一口气跳过中间的视频。
+ */
+export function resolveShortsPagerTargetIndex(input: ShortsPagerRelease): number {
+  const { deltaY, elapsedMs, viewportHeight, anchorIndex, slideCount } = input;
+  const lastIndex = Math.max(0, slideCount - 1);
+  const distance = Math.abs(deltaY);
+
+  let gapTime = elapsedMs;
+  if (distance < SHORTS_PAGER_MIN_COMMIT_PX) {
+    gapTime = Number.POSITIVE_INFINITY;
+  } else if (distance > viewportHeight * SHORTS_PAGER_COMMIT_RATIO) {
+    gapTime = 0;
+  }
+  if (gapTime >= SHORTS_PAGER_FLICK_MS) return clamp(anchorIndex, 0, lastIndex);
+
+  const next = deltaY < 0 ? anchorIndex + 1 : anchorIndex - 1;
+  // 到头/到尾时 clamp 会把目标压回 anchorIndex，等价于回弹。
+  return clamp(next, 0, lastIndex);
+}
+
+/**
+ * 落点动画时长。easeOutCubic 的起始速度是 3 × 距离 / 时长，按抬手速度反解
+ * 时长，动画第一帧就能接上手指离开时的速度，看起来是"继续减速滑过去"而不是
+ * 松手后重新起步——这正是需求里的惯性滚动。
+ *
+ * 速度过低（慢慢拖到位再松手）时反解出来的时长会趋于无穷，改按剩余距离取：
+ * 拖得越远收尾越长，短距离回弹不会拖泥带水。两条路径最后都夹在区间内。
+ *
+ * `velocityPxPerMs` 只取模：抬手瞬间的方向偶尔会和落点方向相反（滑过头又
+ * 回带一点），那时用的是它的快慢而不是朝向。
+ */
+export function resolveShortsPagerSettleDuration(input: {
+  remainingPx: number;
+  velocityPxPerMs: number;
+  viewportHeight: number;
+}): number {
+  const remaining = Math.abs(input.remainingPx);
+  if (remaining < 1) return 0;
+  const speed = Math.abs(input.velocityPxPerMs);
+  const ratio = clamp(remaining / Math.max(1, input.viewportHeight), 0, 1);
+  const duration =
+    speed > SHORTS_PAGER_MIN_VELOCITY_PX_PER_MS
+      ? (3 * remaining) / speed
+      : SHORTS_PAGER_MIN_SETTLE_MS +
+        (SHORTS_PAGER_MAX_SETTLE_MS - SHORTS_PAGER_MIN_SETTLE_MS) * ratio;
+  return clamp(
+    duration,
+    SHORTS_PAGER_MIN_SETTLE_MS,
+    SHORTS_PAGER_MAX_SETTLE_MS
+  );
+}
+
+/** easeOutCubic：入场快、收尾慢，和惯性减速同形。 */
+export function shortsPagerEase(t: number): number {
+  const clamped = clamp(t, 0, 1);
+  return 1 - (1 - clamped) * (1 - clamped) * (1 - clamped);
+}
+
+/**
+ * 锚点 slide 内的滚动偏移：0 表示正好贴在吸附点上，正值表示已经往下滑过了
+ * 一部分。长会话队列裁剪要用它把"裁剪前的画面位置"原样搬到新坐标系里。
+ * 夹在 ±一屏之内，异常几何（尺寸未就绪、节点已脱离布局）不会把滚动甩飞。
+ */
+export function measureOffsetWithinSlide(input: {
+  /** slide 顶端相对滚动容器上沿的距离，向下为正。 */
+  slideTop: number;
+  viewportHeight: number;
+}): number {
+  const limit = Math.max(0, input.viewportHeight);
+  // `0 - x` 而不是 `-x`：贴合吸附点时前者是 +0，后者是 -0，会污染调用方的比较。
+  return clamp(0 - input.slideTop, -limit, limit);
+}
+
+/** 贴合度最高的那一屏；用于手势起点和落点的锚定。 */
+export function findNearestShortsSlideIndex(
+  slideTops: number[],
+  scrollTop: number
+): number {
+  if (slideTops.length === 0) return -1;
+  let bestIndex = 0;
+  let bestDistance = Math.abs(slideTops[0] - scrollTop);
+  for (let index = 1; index < slideTops.length; index += 1) {
+    const distance = Math.abs(slideTops[index] - scrollTop);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+type PagerDrag = {
+  startX: number;
+  startY: number;
+  startTime: number;
+  /** 判定为纵向翻页那一刻的位移；后续按它做零点，避免激活时画面跳一下。 */
+  baselineY: number;
+  anchorIndex: number;
+  anchorTop: number;
+  /** 本次手势允许到达的滚动范围：最多相邻一屏。 */
+  minTop: number;
+  maxTop: number;
+  viewportHeight: number;
+  slideTops: number[];
+  /** 已判定为纵向翻页并接管 */
+  committed: boolean;
+  /** 判定为横向 seek / 多指 / 起点在禁用区：本次手势不归我管 */
+  abandoned: boolean;
+  /** 起手时打断了上一次的落点动画，位置多半不在吸附点上，收尾必须补一次 */
+  interrupted: boolean;
+  samples: ShortsPagerSample[];
+};
+
+export type ShortsSwipePagerHost = {
+  /** slide 所在的容器；同时也是触摸监听的挂载点。 */
+  root: HTMLElement;
+  /** iPhone 浏览器壳的文档滚动模式：位移写在 window 上。 */
+  usesDocumentScroll: boolean;
+  /** 视口尺寸变化后用来重新对齐的当前屏。 */
+  getAnchorSlide: () => HTMLElement | null;
+};
+
+/**
+ * 手势状态机本体，不依赖 React。这样它能脱离渲染器直接接受完整的事件序列
+ * 测试——按下 / 移动 / 抬手 / 多指 / 打断动画每条分支都能覆盖到，这些恰恰
+ * 是"手感"真正落在的地方。返回值是解除绑定的函数。
+ */
+export function createShortsSwipePager(host: ShortsSwipePagerHost) {
+  const { root, usesDocumentScroll } = host;
+  // ---- 滚动目标适配：容器滚动 / 文档滚动共用同一套位移逻辑 ----
+  const getScrollTop = () =>
+    usesDocumentScroll ? window.scrollY : root.scrollTop;
+  /** 上一次由本模块写入的滚动位置；null 表示当前没有在跟踪。 */
+  let lastWrittenTop: number | null = null;
+  const setScrollTop = (value: number) => {
+    if (usesDocumentScroll) window.scrollTo(0, value);
+    else root.scrollTop = value;
+    lastWrittenTop = value;
+  };
+  /**
+   * 外力（长会话队列裁剪重贴、scrollIntoView）挪动滚动位置时的位移量，
+   * 没被挪过就是 0。裁剪几乎总是插在切屏过程中间：不跟着平移，跟手位移
+   * 和落点动画都会按旧坐标继续写，画面会硬跳一大截。
+   */
+  const readExternalScrollDelta = () => {
+    if (lastWrittenTop === null) return 0;
+    const delta = getScrollTop() - lastWrittenTop;
+    return Math.abs(delta) > SHORTS_PAGER_EXTERNAL_SCROLL_EPSILON_PX
+      ? delta
+      : 0;
+  };
+  const getViewportHeight = () =>
+    usesDocumentScroll ? window.innerHeight : root.clientHeight;
+  const getMaxScrollTop = () =>
+    Math.max(
+      0,
+      usesDocumentScroll
+        ? document.documentElement.scrollHeight - window.innerHeight
+        : root.scrollHeight - root.clientHeight
+    );
+  /**
+   * slide 在滚动坐标系里的位置。不用 offsetTop：那依赖 offsetParent 恰好
+   * 是滚动容器的上沿，rect 差值在两种滚动模式下都成立。
+   */
+  const getSlideTop = (slide: HTMLElement) => {
+    const base = usesDocumentScroll ? 0 : root.getBoundingClientRect().top;
+    return slide.getBoundingClientRect().top - base + getScrollTop();
+  };
+  /** 一次手势只读一次：容器 rect 和滚动位置在循环外取好，避免逐条回读布局。 */
+  const readSlideTops = () => {
+    const base = usesDocumentScroll ? 0 : root.getBoundingClientRect().top;
+    const origin = getScrollTop();
+    return [...root.querySelectorAll<HTMLElement>("[data-shorts-slide]")].map(
+      (slide) => slide.getBoundingClientRect().top - base + origin
+    );
+  };
+
+  // ---- 落点动画 ----
+  let settleFrame: number | null = null;
+  /** 返回是否真的打断了一次进行中的动画。 */
+  const cancelSettle = () => {
+    if (settleFrame === null) return false;
+    window.cancelAnimationFrame(settleFrame);
+    settleFrame = null;
+    return true;
+  };
+  const settleTo = (targetTop: number, velocityPxPerMs: number) => {
+    cancelSettle();
+    let from = getScrollTop();
+    const distance = targetTop - from;
+    const duration = resolveShortsPagerSettleDuration({
+      remainingPx: distance,
+      velocityPxPerMs,
+      viewportHeight: getViewportHeight(),
+    });
+    if (duration <= 0) {
+      setScrollTop(targetTop);
+      return;
+    }
+    lastWrittenTop = from;
+    const startedAt = performance.now();
+    const step = (now: number) => {
+      // 队列裁剪只是把整条 feed 换了坐标系，画面位置是连续的：起点跟着
+      // 平移，终点（from + distance）自然一起平移，动画不受影响地跑完。
+      from += readExternalScrollDelta();
+      const progress = clamp((now - startedAt) / duration, 0, 1);
+      setScrollTop(from + distance * shortsPagerEase(progress));
+      if (progress < 1) {
+        settleFrame = window.requestAnimationFrame(step);
+      } else {
+        settleFrame = null;
+        lastWrittenTop = null;
+      }
+    };
+    settleFrame = window.requestAnimationFrame(step);
+  };
+
+  // ---- 合成 click 兜底 ----
+  // touchend 上的 preventDefault 按规范应当挡住合成 click，但个别 WebKit
+  // 版本只认"第一个 touchmove 上的 preventDefault"。漏出来的那一次 click 会
+  // 落到 slide 上被当成单击去暂停视频——每滑一屏暂停一次，非常显眼。
+  // 这里只吞掉紧跟在一次成功竖滑之后的那一个 click。
+  let clickGuardTimer: number | null = null;
+  const swallowClick = (event: Event) => {
+    releaseClickGuard();
+    event.stopPropagation();
+    event.preventDefault();
+  };
+  function releaseClickGuard() {
+    if (clickGuardTimer === null) return;
+    window.clearTimeout(clickGuardTimer);
+    clickGuardTimer = null;
+    root.removeEventListener("click", swallowClick, true);
+  }
+  const guardNextClick = () => {
+    releaseClickGuard();
+    root.addEventListener("click", swallowClick, true);
+    clickGuardTimer = window.setTimeout(
+      releaseClickGuard,
+      SHORTS_PAGER_CLICK_GUARD_MS
+    );
+  };
+
+  // ---- 手势 ----
+  let drag: PagerDrag | null = null;
+
+  /** 多指 / 取消等中断：就近吸附，不要停在两屏之间。 */
+  const settleToNearest = () => {
+    const slideTops = drag?.slideTops ?? readSlideTops();
+    const index = findNearestShortsSlideIndex(slideTops, getScrollTop());
+    if (index < 0) return;
+    settleTo(clamp(slideTops[index], 0, getMaxScrollTop()), 0);
+  };
+
+  const handleTouchStart = (event: TouchEvent) => {
+    // 上一次的落点动画还在跑：接住它，用当前位置作为新手势的起点。
+    // 打断过动画、或上一次手势被第二根手指顶掉，位置就停在两屏之间，
+    // 这次手势无论走哪条分支收尾都得把它吸回吸附点。
+    // 新的一次按下：上一次竖滑的合成 click 早该到了，守卫立刻失效，
+    // 这样紧接着的这次轻点一定能穿到 slide 上。
+    releaseClickGuard();
+    const previous = drag;
+    drag = null;
+    const interrupted = cancelSettle() || Boolean(previous?.committed);
+
+    const bail = () => {
+      if (interrupted) settleToNearest();
+    };
+
+    if (event.touches.length !== 1) return bail();
+
+    // 用鸭子类型而不是 instanceof Element：这条状态机要能脱离浏览器全局
+    // 直接被测试，而 target 在真实环境里一定是元素或 null。
+    const target = event.target as Element | null;
+    if (
+      typeof target?.closest === "function" &&
+      target.closest(`[${SHORTS_NO_SWIPE_ATTRIBUTE}]`)
+    ) {
+      return bail();
+    }
+
+    const slideTops = readSlideTops();
+    if (slideTops.length === 0) return bail();
+    const scrollTop = getScrollTop();
+    const anchorIndex = findNearestShortsSlideIndex(slideTops, scrollTop);
+    if (anchorIndex < 0) return bail();
+    const maxScrollTop = getMaxScrollTop();
+    const previousTop = slideTops[anchorIndex - 1];
+    const nextTop = slideTops[anchorIndex + 1];
+    const anchorTop = slideTops[anchorIndex];
+    const touch = event.touches[0];
+    const now = performance.now();
+    // 几何刚刚重新采过，之前那次动画写下的位置不能再当作平移基准。
+    lastWrittenTop = null;
+
+    drag = {
+      startX: touch.clientX,
+      startY: touch.clientY,
+      startTime: now,
+      baselineY: 0,
+      anchorIndex,
+      // 手势起点就是当前实际位置：中途接住动画时不会先跳回吸附点。
+      anchorTop: clamp(scrollTop, 0, maxScrollTop),
+      // 一次手势最多离开当前屏一屏；否则松手只切一屏会看到明显的回抽。
+      minTop: clamp(previousTop ?? anchorTop, 0, maxScrollTop),
+      maxTop: clamp(nextTop ?? anchorTop, 0, maxScrollTop),
+      viewportHeight: getViewportHeight(),
+      slideTops,
+      committed: false,
+      abandoned: false,
+      interrupted,
+      samples: [{ y: touch.clientY, t: now }],
+    };
+  };
+
+  const handleTouchMove = (event: TouchEvent) => {
+    if (!drag || drag.abandoned) return;
+    if (event.touches.length !== 1) {
+      // 第二根手指落下：交出手势，已经拖开的部分就近吸附回去。
+      const shouldSettle = drag.committed || drag.interrupted;
+      drag.abandoned = true;
+      if (shouldSettle) settleToNearest();
+      return;
+    }
+
+    const touch = event.touches[0];
+    const deltaX = touch.clientX - drag.startX;
+    const deltaY = touch.clientY - drag.startY;
+
+    if (!drag.committed) {
+      // 与视频上的横向 seek 共用同一套方向判定，两者互斥，不会同时激活。
+      const intent = classifyTouchSeekIntent(deltaX, deltaY);
+      if (intent === "pending") return;
+      if (intent === "seek") {
+        drag.abandoned = true;
+        // 横向 seek 与纵向落点互不干扰，被打断的那次动画照样要收尾。
+        if (drag.interrupted) settleToNearest();
+        return;
+      }
+      drag.committed = true;
+      // 激活阈值那段位移不能再算进画面位移，否则接管的瞬间会跳一下。
+      drag.baselineY = deltaY;
+    }
+
+    // 接管后必须挡掉浏览器的默认处理（容器已是 touch-action: none，
+    // 这里是对老 WebKit 的双保险），否则会和原生滚动抢同一根手指。
+    if (event.cancelable) event.preventDefault();
+
+    const now = performance.now();
+    drag.samples.push({ y: touch.clientY, t: now });
+    // 采样窗口之外的点只用于兜底，留一个即可。
+    while (
+      drag.samples.length > 2 &&
+      now - drag.samples[1].t > SHORTS_PAGER_VELOCITY_WINDOW_MS
+    ) {
+      drag.samples.shift();
+    }
+
+    // 拖动途中被队列裁剪换了坐标系：重新采一次几何，手指接着往下拖时
+    // 位移仍然连续，不会突然跳到旧坐标对应的位置。
+    const externalDelta = readExternalScrollDelta();
+    if (externalDelta !== 0) {
+      const maxScrollTop = getMaxScrollTop();
+      drag.slideTops = readSlideTops();
+      drag.anchorTop = clamp(drag.anchorTop + externalDelta, 0, maxScrollTop);
+      const anchorIndex = findNearestShortsSlideIndex(
+        drag.slideTops,
+        drag.anchorTop
+      );
+      if (anchorIndex >= 0) {
+        const ownTop = drag.slideTops[anchorIndex];
+        drag.anchorIndex = anchorIndex;
+        drag.minTop = clamp(
+          drag.slideTops[anchorIndex - 1] ?? ownTop,
+          0,
+          maxScrollTop
+        );
+        drag.maxTop = clamp(
+          drag.slideTops[anchorIndex + 1] ?? ownTop,
+          0,
+          maxScrollTop
+        );
+      }
+    }
+
+    const offset = drag.anchorTop - (deltaY - drag.baselineY);
+    setScrollTop(clamp(offset, drag.minTop, drag.maxTop));
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    const current = drag;
+    drag = null;
+    if (!current || current.abandoned) return;
+    if (!current.committed) {
+      // 没构成滑动。若这一下只是"按住把飞行中的动画停下来"，同样要吸回
+      // 吸附点，并吞掉这次点击——否则会被当成单击而暂停视频。
+      if (current.interrupted) {
+        if (event.cancelable) event.preventDefault();
+        guardNextClick();
+        settleToNearest();
+      }
+      return;
+    }
+
+    // 竖滑结束后浏览器还会补一次合成 click，会被 slide 当成单击而暂停视频。
+    if (event.cancelable) event.preventDefault();
+    guardNextClick();
+
+    const changedTouch = event.changedTouches[0];
+    const now = performance.now();
+    if (changedTouch) {
+      current.samples.push({ y: changedTouch.clientY, t: now });
+    }
+    const deltaY = changedTouch
+      ? changedTouch.clientY - current.startY
+      : current.samples[current.samples.length - 1].y - current.startY;
+
+    const targetIndex = resolveShortsPagerTargetIndex({
+      deltaY,
+      elapsedMs: now - current.startTime,
+      viewportHeight: current.viewportHeight,
+      anchorIndex: current.anchorIndex,
+      slideCount: current.slideTops.length,
+    });
+    const targetTop = clamp(
+      current.slideTops[targetIndex] ?? current.anchorTop,
+      0,
+      getMaxScrollTop()
+    );
+    settleTo(targetTop, computeShortsPagerVelocity(current.samples));
+  };
+
+  const handleTouchCancel = () => {
+    const current = drag;
+    drag = null;
+    if (current && (current.committed || current.interrupted)) {
+      settleToNearest();
+    }
+  };
+
+  // ---- 视口尺寸变化后重新对齐 ----
+  // 接管手势的同时关掉了 scroll-snap，浏览器不会再在旋转 / 键盘弹出后
+  // 自动把当前屏拉回吸附点，这里补上。
+  let realignFrame: number | null = null;
+  let realignTimer: number | null = null;
+  const realign = () => {
+    if (drag) return;
+    const slide = host.getAnchorSlide();
+    if (!slide) return;
+    setScrollTop(clamp(getSlideTop(slide), 0, getMaxScrollTop()));
+  };
+  const handleViewportResize = () => {
+    cancelSettle();
+    realign();
+    if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
+    realignFrame = window.requestAnimationFrame(() => {
+      realignFrame = null;
+      realign();
+    });
+    // 移动端工具栏 / 输入法收放会连着发多次 resize，尺寸稳定后再对齐一次。
+    if (realignTimer !== null) window.clearTimeout(realignTimer);
+    realignTimer = window.setTimeout(() => {
+      realignTimer = null;
+      realign();
+    }, 240);
+  };
+
+  root.addEventListener("touchstart", handleTouchStart, { passive: true });
+  root.addEventListener("touchmove", handleTouchMove, { passive: false });
+  root.addEventListener("touchend", handleTouchEnd);
+  root.addEventListener("touchcancel", handleTouchCancel);
+  window.addEventListener("resize", handleViewportResize);
+  window.addEventListener("orientationchange", handleViewportResize);
+
+  return () => {
+    cancelSettle();
+    releaseClickGuard();
+    if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
+    if (realignTimer !== null) window.clearTimeout(realignTimer);
+    root.removeEventListener("touchstart", handleTouchStart);
+    root.removeEventListener("touchmove", handleTouchMove);
+    root.removeEventListener("touchend", handleTouchEnd);
+    root.removeEventListener("touchcancel", handleTouchCancel);
+    window.removeEventListener("resize", handleViewportResize);
+    window.removeEventListener("orientationchange", handleViewportResize);
+  };
+}
+
+export type ShortsSwipePagerOptions = {
+  /** 关闭时完全不挂监听，页面回到原生 scroll-snap。 */
+  enabled: boolean;
+  containerRef: React.RefObject<HTMLElement | null>;
+  usesDocumentScroll: boolean;
+  getAnchorSlide: () => HTMLElement | null;
+};
+
+/** React 侧只负责生命周期；判定和动画全在 createShortsSwipePager 里。 */
+export function useShortsSwipePager(options: ShortsSwipePagerOptions) {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const { enabled, usesDocumentScroll } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const root = optionsRef.current.containerRef.current;
+    if (!root) return;
+    return createShortsSwipePager({
+      root,
+      usesDocumentScroll,
+      // 走 ref 读取，回调换引用不会重挂监听。
+      getAnchorSlide: () => optionsRef.current.getAnchorSlide(),
+    });
+  }, [enabled, usesDocumentScroll]);
+}

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -88,6 +88,23 @@ export const SHORTS_PAGER_SETTLE_FALLBACK_MS = 80;
  * 不会被误伤。
  */
 const SHORTS_PAGER_CLICK_GUARD_MS = 300;
+/**
+ * 一次滚轮手势内累计位移达到这个像素数就切一屏。
+ * 鼠标一格通常是 100px（deltaMode=0）或 3 行（deltaMode=1，≈48px），
+ * 取 40 保证任何一格都够；触控板轻推一下也够。
+ */
+export const SHORTS_PAGER_WHEEL_STEP_PX = 40;
+/**
+ * 两次 wheel 事件间隔超过这个毫秒数就算新的一次手势。
+ *
+ * 这是"一次手势最多切一屏"在滚轮上的落点，也是触控板惯性尾巴的分水岭：
+ * 触控板一次轻扫会连发几十个事件、间隔只有十几毫秒，尾巴能拖一秒多；
+ * 不按手势聚合的话一次轻扫会连翻十几条视频。鼠标滚轮有意识地一格一格滚
+ * 时，间隔通常在 150ms 以上，每一格因此都是独立手势。
+ */
+export const SHORTS_PAGER_WHEEL_GESTURE_GAP_MS = 120;
+/** deltaMode=1（按行）时一行折算多少像素。 */
+export const SHORTS_WHEEL_LINE_HEIGHT_PX = 16;
 /** 起点标记：滑动手势不接管这个子树内按下的触摸（如底部进度条）。 */
 export const SHORTS_NO_SWIPE_ATTRIBUTE = "data-shorts-no-swipe";
 /** 这些元素上的 click 永远不能被合成 click 守卫吞掉。 */
@@ -207,6 +224,76 @@ export function applyShortsPagerEdgeResistance(input: {
     return input.min - Math.min(over * SHORTS_PAGER_EDGE_RESISTANCE, limit);
   }
   return input.value;
+}
+
+/** 把 wheel 的三种 deltaMode 统一换算成像素，后面只跟像素打交道。 */
+export function normalizeShortsWheelDelta(input: {
+  deltaY: number;
+  deltaMode: number;
+  viewportHeight: number;
+}): number {
+  if (!Number.isFinite(input.deltaY)) return 0;
+  // 1 = 按行（Firefox 常用），2 = 按页
+  if (input.deltaMode === 1) return input.deltaY * SHORTS_WHEEL_LINE_HEIGHT_PX;
+  if (input.deltaMode === 2) {
+    return input.deltaY * Math.max(1, input.viewportHeight);
+  }
+  return input.deltaY;
+}
+
+export type ShortsWheelGestureState = {
+  /** 上一次 wheel 事件的时间戳 */
+  lastEventAt: number;
+  /** 本次手势内累计的像素位移 */
+  accumulated: number;
+  /** 本次手势是否已经消费过一步——之后的惯性尾巴一律忽略 */
+  consumed: boolean;
+};
+
+export const INITIAL_SHORTS_WHEEL_STATE: ShortsWheelGestureState = {
+  lastEventAt: Number.NEGATIVE_INFINITY,
+  accumulated: 0,
+  consumed: false,
+};
+
+/**
+ * 一次 wheel 事件该不该切屏，以及切哪个方向。
+ *
+ * 规则与手指完全一致：**一次手势最多切一屏**。事件流按间隔切分成手势，
+ * 每个手势里累计位移第一次越过阈值就切一屏，之后这次手势里剩下的事件
+ * （触控板的惯性尾巴）全部忽略。
+ *
+ * 返回新的状态而不是就地修改：这样整条判定是纯函数，能脱离浏览器直接测。
+ */
+export function resolveShortsWheelStep(input: {
+  state: ShortsWheelGestureState;
+  deltaPx: number;
+  now: number;
+}): { state: ShortsWheelGestureState; step: -1 | 0 | 1 } {
+  const continuing =
+    input.now - input.state.lastEventAt < SHORTS_PAGER_WHEEL_GESTURE_GAP_MS;
+  const accumulated = continuing ? input.state.accumulated : 0;
+  const consumed = continuing ? input.state.consumed : false;
+
+  if (consumed) {
+    // 同一次手势已经切过屏，剩下的惯性照单全收但不产生动作。
+    return {
+      state: { lastEventAt: input.now, accumulated: 0, consumed: true },
+      step: 0,
+    };
+  }
+
+  const next = accumulated + input.deltaPx;
+  if (Math.abs(next) < SHORTS_PAGER_WHEEL_STEP_PX) {
+    return {
+      state: { lastEventAt: input.now, accumulated: next, consumed: false },
+      step: 0,
+    };
+  }
+  return {
+    state: { lastEventAt: input.now, accumulated: 0, consumed: true },
+    step: next > 0 ? 1 : -1,
+  };
 }
 
 /**
@@ -361,30 +448,6 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
         : root.scrollHeight - root.clientHeight
     );
 
-  // ---- 原生吸附的临时摘除 ----
-  // CSS 的吸附点是按元素**变换后**的位置算的。轨道一平移，吸附点就跟着移，
-  // `scroll-snap-type: mandatory` 会立刻把 scrollTop 反向拉回去补偿——净效果
-  // 正好抵消掉跟手位移，桌面上表现为"鼠标怎么拖画面都不动"。
-  //
-  // 触屏路径靠 .shorts-feed.is-touch-paged 常驻关掉吸附；桌面故意保留吸附让
-  // 滚轮和方向键继续走原生，所以只能在手势和落点动画期间临时摘掉，落定再还
-  // 回去。还回去时我们已经精确停在吸附点上，浏览器的重新吸附是空操作。
-  const snapHosts: HTMLElement[] = usesDocumentScroll
-    ? [document.documentElement, document.body]
-    : [root];
-  let snapSuspended = false;
-  const suspendSnap = () => {
-    if (snapSuspended) return;
-    snapSuspended = true;
-    for (const host of snapHosts) host.style.scrollSnapType = "none";
-  };
-  const restoreSnap = () => {
-    if (!snapSuspended) return;
-    snapSuspended = false;
-    // 清成空串而不是写死值：还给样式表决定，触屏路径那边本来就是 none。
-    for (const host of snapHosts) host.style.scrollSnapType = "";
-  };
-
   // ---- 轨道位移 ----
   /** 轨道当前的 translateY。等效滚动位置恒为 getScrollTop() - translate。 */
   let translate = 0;
@@ -461,8 +524,6 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     settling = false;
     detachSettleListeners();
     clearTranslate();
-    // 必须在 transform 清掉之后才还，否则浏览器会按带位移的吸附点重新吸附。
-    restoreSnap();
   };
 
   /** 返回是否真的打断了一次进行中的动画。 */
@@ -498,7 +559,6 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   const settleTo = (target: HTMLElement | null, committed: boolean) => {
     detachSettleListeners();
     settling = false;
-    suspendSnap();
 
     const live = readLiveTranslate();
     const from = getScrollTop();
@@ -519,8 +579,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     });
     if (duration <= 0) {
       clearTranslate();
-      restoreSnap();
-      return;
+        return;
     }
 
     settling = true;
@@ -704,8 +763,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       }
       drag.committed = true;
       setGestureActive(true);
-      suspendSnap();
-      // 鼠标拖到容器外面也要继续收事件；触摸本来就隐式捕获，这里是给桌面用的。
+        // 鼠标拖到容器外面也要继续收事件；触摸本来就隐式捕获，这里是给桌面用的。
       try {
         root.setPointerCapture(event.pointerId);
       } catch {
@@ -785,6 +843,52 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     settleTo(target, targetIndex !== current.anchorIndex);
   };
 
+  /**
+   * 把当前屏推进 / 退回一屏。滚轮和拖拽最终都汇到 settleTo，因此过渡完全
+   * 一致——用户不该从动画上看出自己刚才用的是手指、鼠标还是滚轮。
+   */
+  const stepBy = (direction: 1 | -1) => {
+    if (drag) return;
+    const slides = readSlides();
+    if (slides.length === 0) return;
+    const slideTops = readSlideTops();
+    // 用视觉位置定锚：动画途中再来一次滚轮，是从画面此刻所在的位置推进。
+    const index = findNearestShortsSlideIndex(slideTops, getEffectiveTop());
+    if (index < 0) return;
+    const target = clamp(index + direction, 0, slides.length - 1);
+    if (target === index) return;
+    settleTo(slides[target] ?? null, true);
+  };
+
+  let wheelState = INITIAL_SHORTS_WHEEL_STATE;
+
+  const handleWheel = (event: WheelEvent) => {
+    // 捏合缩放（Ctrl+滚轮）交还给浏览器。
+    if (event.ctrlKey) return;
+    const target = event.target as Element | null;
+    if (
+      typeof target?.closest === "function" &&
+      target.closest(`[${SHORTS_NO_SWIPE_ATTRIBUTE}]`)
+    ) {
+      return;
+    }
+    // 必须挡掉原生滚动：否则容器会一边被我们翻页、一边自己自由滚动。
+    if (event.cancelable) event.preventDefault();
+    if (drag) return;
+
+    const decision = resolveShortsWheelStep({
+      state: wheelState,
+      deltaPx: normalizeShortsWheelDelta({
+        deltaY: event.deltaY,
+        deltaMode: event.deltaMode,
+        viewportHeight: getViewportHeight(),
+      }),
+      now: performance.now(),
+    });
+    wheelState = decision.state;
+    if (decision.step !== 0) stepBy(decision.step);
+  };
+
   const handlePointerCancel = (event: PointerEvent) => {
     activePointers.delete(event.pointerId);
     if (dragPointerId !== null && event.pointerId !== dragPointerId) return;
@@ -808,7 +912,6 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     if (!slide) return;
     const top = readSlideTop(slide);
     clearTranslate();
-    restoreSnap();
     setScrollTop(clamp(top, 0, getMaxScrollTop()));
   };
   const handleViewportResize = () => {
@@ -828,6 +931,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }, 240);
   };
 
+  root.addEventListener("wheel", handleWheel, { passive: false });
   root.addEventListener("pointerdown", handlePointerDown, { passive: true });
   root.addEventListener("pointermove", handlePointerMove, { passive: false });
   root.addEventListener("pointerup", handlePointerUp);
@@ -849,10 +953,10 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }
     detachSettleListeners();
     releaseClickGuard();
-    restoreSnap();
     setGestureActive(false);
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);
+    root.removeEventListener("wheel", handleWheel);
     root.removeEventListener("pointerdown", handlePointerDown);
     root.removeEventListener("pointermove", handlePointerMove);
     root.removeEventListener("pointerup", handlePointerUp);

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -444,6 +444,9 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   const { root, track, usesDocumentScroll } = host;
 
   // ---- 滚动目标适配：容器滚动 / 文档滚动共用同一套位移逻辑 ----
+  // 文档滚动产生的 scroll 事件只会到达 document/window，不会向下传播给
+  // `.shorts-feed`；事件订阅必须和下面的读写操作使用同一个真实滚动宿主。
+  const scrollEventTarget = usesDocumentScroll ? window : root;
   const getScrollTop = () =>
     usesDocumentScroll ? window.scrollY : root.scrollTop;
   const setScrollTop = (value: number) => {
@@ -968,7 +971,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }, 240);
   };
 
-  root.addEventListener("scroll", handleScroll, { passive: true });
+  scrollEventTarget.addEventListener("scroll", handleScroll, { passive: true });
   root.addEventListener("wheel", handleWheel, { passive: false });
   root.addEventListener("pointerdown", handlePointerDown, { passive: true });
   root.addEventListener("pointermove", handlePointerMove, { passive: false });
@@ -995,7 +998,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);
     cancelAlignmentCheck();
-    root.removeEventListener("scroll", handleScroll);
+    scrollEventTarget.removeEventListener("scroll", handleScroll);
     root.removeEventListener("wheel", handleWheel);
     root.removeEventListener("pointerdown", handlePointerDown);
     root.removeEventListener("pointermove", handlePointerMove);

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -105,6 +105,18 @@ export const SHORTS_PAGER_WHEEL_STEP_PX = 40;
 export const SHORTS_PAGER_WHEEL_GESTURE_GAP_MS = 120;
 /** deltaMode=1（按行）时一行折算多少像素。 */
 export const SHORTS_WHEEL_LINE_HEIGHT_PX = 16;
+/**
+ * 静止时允许偏离吸附点的最大像素数，超过就自我纠正。
+ *
+ * 这是一条**不变量**而不是又一个特例修复："静止时画面绝不停在两条视频之间"。
+ * 关掉原生吸附之后，任何一条我们没预料到的路径——浏览器的滚动锚定、某个
+ * 漏掉 preventDefault 的输入、扩展程序、页内查找、无障碍工具——都会把滚动
+ * 位置留在半路，而没有任何机制会把它纠回来。与其逐个堵，不如让这条不变量
+ * 自己成立。
+ */
+export const SHORTS_PAGER_ALIGNMENT_TOLERANCE_PX = 2;
+/** 纠正前的防抖：等滚动真正停下来再判断，别和进行中的动作打架。 */
+export const SHORTS_PAGER_ALIGNMENT_CHECK_MS = 120;
 /** 起点标记：滑动手势不接管这个子树内按下的触摸（如底部进度条）。 */
 export const SHORTS_NO_SWIPE_ATTRIBUTE = "data-shorts-no-swipe";
 /** 这些元素上的 click 永远不能被合成 click 守卫吞掉。 */
@@ -863,16 +875,11 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   let wheelState = INITIAL_SHORTS_WHEEL_STATE;
 
   const handleWheel = (event: WheelEvent) => {
-    // 捏合缩放（Ctrl+滚轮）交还给浏览器。
+    // 捏合缩放（Ctrl+滚轮）交还给浏览器，其余一律接管。
     if (event.ctrlKey) return;
-    const target = event.target as Element | null;
-    if (
-      typeof target?.closest === "function" &&
-      target.closest(`[${SHORTS_NO_SWIPE_ATTRIBUTE}]`)
-    ) {
-      return;
-    }
-    // 必须挡掉原生滚动：否则容器会一边被我们翻页、一边自己自由滚动。
+    // 这里刻意**不**看 data-shorts-no-swipe：那个标记是给拖拽用的（进度条要
+    // 吃掉整根手指），滚轮没有理由认它。漏掉任何一处 preventDefault，原生
+    // 滚动就会从那里溜出去，而吸附已经关了，画面会停在两条视频中间。
     if (event.cancelable) event.preventDefault();
     if (drag) return;
 
@@ -899,6 +906,36 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     if (current && (current.committed || current.interrupted)) {
       settleToNearest();
     }
+  };
+
+  // ---- 兜底不变量：静止时绝不停在两条视频之间 ----
+  // 关掉原生吸附之后，没有任何机制会把意外的滚动偏移纠回来。这里不去逐个
+  // 堵源头（浏览器滚动锚定、漏掉的 preventDefault、扩展、页内查找……），
+  // 而是让"静止即对齐"这条不变量自己成立：滚动停下来之后一量，偏了就吸回去。
+  let alignmentCheckTimer: number | null = null;
+  const cancelAlignmentCheck = () => {
+    if (alignmentCheckTimer === null) return;
+    window.clearTimeout(alignmentCheckTimer);
+    alignmentCheckTimer = null;
+  };
+  const handleScroll = () => {
+    // 我们自己驱动的位移不算意外，跳过。
+    if (drag || settling) return;
+    cancelAlignmentCheck();
+    alignmentCheckTimer = window.setTimeout(() => {
+      alignmentCheckTimer = null;
+      if (drag || settling) return;
+      const slides = readSlides();
+      if (slides.length === 0) return;
+      const slideTops = readSlideTops();
+      const effectiveTop = getEffectiveTop();
+      const index = findNearestShortsSlideIndex(slideTops, effectiveTop);
+      if (index < 0) return;
+      const drift = Math.abs(slideTops[index] - effectiveTop);
+      if (drift <= SHORTS_PAGER_ALIGNMENT_TOLERANCE_PX) return;
+      // 就近吸附，用回弹时长——这不是一次切屏，只是把画面扶正。
+      settleTo(slides[index] ?? null, false);
+    }, SHORTS_PAGER_ALIGNMENT_CHECK_MS);
   };
 
   // ---- 视口尺寸变化后重新对齐 ----
@@ -931,6 +968,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }, 240);
   };
 
+  root.addEventListener("scroll", handleScroll, { passive: true });
   root.addEventListener("wheel", handleWheel, { passive: false });
   root.addEventListener("pointerdown", handlePointerDown, { passive: true });
   root.addEventListener("pointermove", handlePointerMove, { passive: false });
@@ -956,6 +994,8 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     setGestureActive(false);
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);
+    cancelAlignmentCheck();
+    root.removeEventListener("scroll", handleScroll);
     root.removeEventListener("wheel", handleWheel);
     root.removeEventListener("pointerdown", handlePointerDown);
     root.removeEventListener("pointermove", handlePointerMove);

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -43,14 +43,36 @@ export const SHORTS_PAGER_MIN_COMMIT_PX = 20;
 export const SHORTS_PAGER_COMMIT_RATIO = 1 / 3;
 /** 中间地带（位移够但不大）看抬手快慢：短于这个时长算轻扫，切屏。 */
 export const SHORTS_PAGER_FLICK_MS = 150;
-/** 落点动画时长区间；douyin 用的是固定 300ms，这里按速度在区间内浮动。 */
-export const SHORTS_PAGER_MIN_SETTLE_MS = 180;
-export const SHORTS_PAGER_MAX_SETTLE_MS = 380;
 /**
- * 落点缓动。这是 easeOutCubic 的 cubic-bezier 形式，起始斜率
- * 0.61 / 0.215 ≈ 2.84，与下面按 3×距离/时长 反解时长的假设吻合：动画第一帧
- * 的速度就接上手指离开时的速度，读起来是继续减速滑过去而不是重新起步。
- * 换缓动就必须同步改 resolveShortsPagerSettleDuration 里的系数。
+ * 中间地带的第二条通路：抬手速度够快也算轻扫。
+ *
+ * 只看整段按压时长（douyin 的做法）有个真实的糙点——先把手指搭在屏幕上停一会
+ * 再甩，elapsedMs 早就超过 150ms，必定被判回弹。而"点一下暂停、再甩走"是很
+ * 常见的用法。速度采样本来就在手里，用它补一条通路即可。
+ * 0.5 px/ms 意味着最后 100ms 内至少走了 50px，是明确的甩动而不是慢拖。
+ */
+export const SHORTS_PAGER_FLICK_VELOCITY_PX_PER_MS = 0.5;
+/**
+ * 切屏落点时长，固定值——douyin 用的也是固定 300ms。
+ *
+ * 这里曾经按抬手速度反解时长（3 × 距离 / 时长），前提是"动画首帧速度接上
+ * 手指离开时的速度"。但那个前提只在剩余距离与手指行程同量级时成立：FLIP
+ * 之后剩余距离恒为约一屏（补偿量 = 屏高 − 手指位移），而甩动行程只有几十
+ * 像素，反解出来的时长必然远超上限，整套机制退化成一个常数 380ms——甩得
+ * 越快反而越慢。douyin 和 TikTok 明确不做速度连续：固定时长、让动画起速就
+ * 快过手指，这才是"甩一下就翻过去"的手感来源。
+ */
+export const SHORTS_PAGER_COMMIT_SETTLE_MS = 300;
+/** 回弹时长区间：按剩余距离取，短距离回弹不拖泥带水。 */
+export const SHORTS_PAGER_MIN_SETTLE_MS = 180;
+export const SHORTS_PAGER_MAX_BOUNCE_MS = 260;
+/** 到头 / 到尾继续拖时的阻尼系数与最大越界距离（占一屏的比例）。 */
+export const SHORTS_PAGER_EDGE_RESISTANCE = 0.35;
+export const SHORTS_PAGER_EDGE_LIMIT_RATIO = 0.12;
+/**
+ * 落点缓动，easeOutCubic 的 cubic-bezier 形式。这是一条手调契约：起始斜率
+ * （≈2.84）要明显快于手指，终点斜率为 0 才不会"撞"上落点。300ms 配这条曲线
+ * 走完 95% 只要约 190ms，比 douyin 的 300ms 线性观感更干脆。
  */
 export const SHORTS_PAGER_SETTLE_EASING = "cubic-bezier(0.215, 0.61, 0.355, 1)";
 /** 抬手速度取这个时间窗内的平均值，避免最后一帧抖动主导结果。 */
@@ -60,8 +82,6 @@ export const SHORTS_PAGER_VELOCITY_WINDOW_MS = 100;
  * 这里只是保证 will-change 和内联 transform 不会一直挂在轨道上。
  */
 export const SHORTS_PAGER_SETTLE_FALLBACK_MS = 80;
-/** 低于这个速度就不按速度反解时长，直接按剩余距离取。 */
-const SHORTS_PAGER_MIN_VELOCITY_PX_PER_MS = 0.05;
 /**
  * 竖滑之后吞掉合成 click 的时间窗。合成 click 紧跟在同一次 touchend 之后
  * 到达，这个窗口只要覆盖住它即可；下一次按下也会立刻解除，用户真正的轻点
@@ -70,6 +90,9 @@ const SHORTS_PAGER_MIN_VELOCITY_PX_PER_MS = 0.05;
 const SHORTS_PAGER_CLICK_GUARD_MS = 300;
 /** 起点标记：滑动手势不接管这个子树内按下的触摸（如底部进度条）。 */
 export const SHORTS_NO_SWIPE_ATTRIBUTE = "data-shorts-no-swipe";
+/** 这些元素上的 click 永远不能被合成 click 守卫吞掉。 */
+export const SHORTS_INTERACTIVE_SELECTOR =
+  `button, a, input, [role="button"], [${SHORTS_NO_SWIPE_ATTRIBUTE}]`;
 
 export type ShortsPagerSample = { y: number; t: number };
 
@@ -98,6 +121,8 @@ export type ShortsPagerRelease = {
   deltaY: number;
   /** 按下到抬手的毫秒数。 */
   elapsedMs: number;
+  /** 抬手瞬间的纵向速度（px/ms，向下为正）。 */
+  velocityPxPerMs: number;
   /** 一屏高度。 */
   viewportHeight: number;
   /** 手势开始时贴合的那一屏。 */
@@ -114,17 +139,22 @@ export type ShortsPagerRelease = {
  * 最多切一屏，快速连滑靠多次手势叠加，不会一口气跳过中间的视频。
  */
 export function resolveShortsPagerTargetIndex(input: ShortsPagerRelease): number {
-  const { deltaY, elapsedMs, viewportHeight, anchorIndex, slideCount } = input;
+  const { deltaY, elapsedMs, velocityPxPerMs, viewportHeight, anchorIndex, slideCount } =
+    input;
   const lastIndex = Math.max(0, slideCount - 1);
   const distance = Math.abs(deltaY);
+  const stay = clamp(anchorIndex, 0, lastIndex);
 
-  let gapTime = elapsedMs;
-  if (distance < SHORTS_PAGER_MIN_COMMIT_PX) {
-    gapTime = Number.POSITIVE_INFINITY;
-  } else if (distance > viewportHeight * SHORTS_PAGER_COMMIT_RATIO) {
-    gapTime = 0;
+  if (distance < SHORTS_PAGER_MIN_COMMIT_PX) return stay;
+
+  if (distance <= viewportHeight * SHORTS_PAGER_COMMIT_RATIO) {
+    // 中间地带：短促轻扫才切屏。抬手速度与位移同向且够快时也算——
+    // 只看整段按压时长会把"先按住再甩"误判成回弹。
+    const flickedFast =
+      Math.abs(velocityPxPerMs) >= SHORTS_PAGER_FLICK_VELOCITY_PX_PER_MS &&
+      velocityPxPerMs < 0 === deltaY < 0;
+    if (elapsedMs >= SHORTS_PAGER_FLICK_MS && !flickedFast) return stay;
   }
-  if (gapTime >= SHORTS_PAGER_FLICK_MS) return clamp(anchorIndex, 0, lastIndex);
 
   const next = deltaY < 0 ? anchorIndex + 1 : anchorIndex - 1;
   // 到头/到尾时 clamp 会把目标压回 anchorIndex，等价于回弹。
@@ -132,34 +162,51 @@ export function resolveShortsPagerTargetIndex(input: ShortsPagerRelease): number
 }
 
 /**
- * 落点动画时长。SHORTS_PAGER_SETTLE_EASING 的起始速度约为 3 × 距离 / 时长，
- * 按抬手速度反解时长，动画第一帧就能接上手指离开时的速度。
+ * 落点动画时长。切屏用固定值，回弹按剩余距离取。
  *
- * 速度过低（慢慢拖到位再松手）时反解出来的时长会趋于无穷，改按剩余距离取：
- * 拖得越远收尾越长，短距离回弹不会拖泥带水。两条路径最后都夹在区间内。
- *
- * `velocityPxPerMs` 只取模：抬手瞬间的方向偶尔会和落点方向相反（滑过头又
- * 回带一点），那时用的是它的快慢而不是朝向。
+ * 切屏之所以是常数：见 SHORTS_PAGER_COMMIT_SETTLE_MS 的注释——"按抬手速度
+ * 反解"在 FLIP 的几何下永远被夹到上限，是一套写了但从不生效的机制。
+ * 回弹之所以按距离：拖 20px 松手和拖 400px 松手要是同样时长，短距离会显得
+ * 黏；按距离取之后回弹一定比切屏短，符合直觉。
  */
 export function resolveShortsPagerSettleDuration(input: {
   remainingPx: number;
-  velocityPxPerMs: number;
   viewportHeight: number;
+  /** true = 切到相邻一屏，false = 回弹到原处 */
+  committed: boolean;
 }): number {
   const remaining = Math.abs(input.remainingPx);
   if (remaining < 1) return 0;
-  const speed = Math.abs(input.velocityPxPerMs);
-  const ratio = clamp(remaining / Math.max(1, input.viewportHeight), 0, 1);
-  const duration =
-    speed > SHORTS_PAGER_MIN_VELOCITY_PX_PER_MS
-      ? (3 * remaining) / speed
-      : SHORTS_PAGER_MIN_SETTLE_MS +
-        (SHORTS_PAGER_MAX_SETTLE_MS - SHORTS_PAGER_MIN_SETTLE_MS) * ratio;
-  return clamp(
-    duration,
-    SHORTS_PAGER_MIN_SETTLE_MS,
-    SHORTS_PAGER_MAX_SETTLE_MS
+  if (input.committed) return SHORTS_PAGER_COMMIT_SETTLE_MS;
+  // 回弹距离最多就是半屏（超过就该切屏了），按这个量程归一化。
+  const span = Math.max(1, input.viewportHeight) / 2;
+  const ratio = clamp(remaining / span, 0, 1);
+  return (
+    SHORTS_PAGER_MIN_SETTLE_MS +
+    (SHORTS_PAGER_MAX_BOUNCE_MS - SHORTS_PAGER_MIN_SETTLE_MS) * ratio
   );
+}
+
+/**
+ * 到头 / 到尾继续拖时的阻尼。硬 clamp 会让画面完全不动，读起来像卡死；
+ * 给一段带阻尼的越界位移，手指能推动一点、松手弹回来，才是"到头了"。
+ */
+export function applyShortsPagerEdgeResistance(input: {
+  value: number;
+  min: number;
+  max: number;
+  viewportHeight: number;
+}): number {
+  const limit = Math.max(0, input.viewportHeight) * SHORTS_PAGER_EDGE_LIMIT_RATIO;
+  if (input.value > input.max) {
+    const over = input.value - input.max;
+    return input.max + Math.min(over * SHORTS_PAGER_EDGE_RESISTANCE, limit);
+  }
+  if (input.value < input.min) {
+    const over = input.min - input.value;
+    return input.min - Math.min(over * SHORTS_PAGER_EDGE_RESISTANCE, limit);
+  }
+  return input.value;
 }
 
 /**
@@ -279,6 +326,14 @@ export type ShortsSwipePagerHost = {
   usesDocumentScroll: boolean;
   /** 视口尺寸变化后用来重新对齐的当前屏。 */
   getAnchorSlide: () => HTMLElement | null;
+  /**
+   * 手指正在拖动（已判定为纵向）时通知一次 true，手势收尾时 false。
+   * 页面据此在跟手阶段冻结 IntersectionObserver 的活跃屏判定——IO 看的是
+   * 视觉位置，拖动中轨道 translate 一直在变，它会在一次滑动里反复翻转，
+   * 每翻一次就是一整套暂停/起播/预载授权清零/媒体监听重建，全砸在跟手那几帧上。
+   * douyin 同样只在 touchEnd 里推进 localIndex。
+   */
+  onGestureActiveChange?: (active: boolean) => void;
 };
 
 /**
@@ -414,7 +469,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
    * 发生在画面视觉越过 60% 的那一刻（easeOutCubic 前段快，约在动画前 1/4）。
    * 做不做 FLIP 在这一点上完全一样。
    */
-  const settleTo = (target: HTMLElement | null, velocityPxPerMs: number) => {
+  const settleTo = (target: HTMLElement | null, committed: boolean) => {
     detachSettleListeners();
     settling = false;
 
@@ -432,8 +487,8 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
 
     const duration = resolveShortsPagerSettleDuration({
       remainingPx: compensation,
-      velocityPxPerMs,
       viewportHeight: getViewportHeight(),
+      committed,
     });
     if (duration <= 0) {
       clearTranslate();
@@ -472,6 +527,16 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
   let clickGuardTimer: number | null = null;
   const swallowClick = (event: Event) => {
     releaseClickGuard();
+    // 只吞掉落在 slide 空白处的那一次——它唯一的去处是"单击切换播放/暂停"。
+    // 点赞、分享、隐藏、详情链接、进度条都必须放行：守卫在"按住把飞行中的
+    // 动画停下来"时也会武装，那一下如果正好按在按钮上，吞掉就是功能失灵。
+    const target = event.target as Element | null;
+    if (
+      typeof target?.closest === "function" &&
+      target.closest(SHORTS_INTERACTIVE_SELECTOR)
+    ) {
+      return;
+    }
     event.stopPropagation();
     event.preventDefault();
   };
@@ -492,6 +557,12 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
 
   // ---- 手势 ----
   let drag: PagerDrag | null = null;
+  let gestureActive = false;
+  const setGestureActive = (active: boolean) => {
+    if (gestureActive === active) return;
+    gestureActive = active;
+    host.onGestureActiveChange?.(active);
+  };
 
   /** 多指 / 取消等中断：就近吸附，不要停在两屏之间。 */
   const settleToNearest = () => {
@@ -499,7 +570,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     const slideTops = drag?.slideTops ?? readSlideTops();
     const index = findNearestShortsSlideIndex(slideTops, getEffectiveTop());
     if (index < 0) return;
-    settleTo(slides[index] ?? null, 0);
+    settleTo(slides[index] ?? null, false);
   };
 
   const handleTouchStart = (event: TouchEvent) => {
@@ -570,6 +641,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       // 第二根手指落下：交出手势，已经拖开的部分就近吸附回去。
       const shouldSettle = drag.committed || drag.interrupted;
       drag.abandoned = true;
+      setGestureActive(false);
       if (shouldSettle) settleToNearest();
       return;
     }
@@ -584,11 +656,13 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
       if (intent === "pending") return;
       if (intent === "seek") {
         drag.abandoned = true;
+        setGestureActive(false);
         // 横向 seek 与纵向落点互不干扰，被打断的那次动画照样要收尾。
         if (drag.interrupted) settleToNearest();
         return;
       }
       drag.committed = true;
+      setGestureActive(true);
       // 激活阈值那段位移不能再算进画面位移，否则接管的瞬间会跳一下。
       drag.baselineY = deltaY;
       track.style.willChange = "transform";
@@ -612,12 +686,20 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     // 位移纯粹由手指决定，不读 scrollTop——队列裁剪在拖动中途换坐标系时
     // 跟手也不会被带偏（裁剪同时改 slide 布局与 scrollTop，视觉是连续的）。
     const next = drag.originTranslate + (deltaY - drag.baselineY);
-    applyTranslate(clamp(next, drag.minTranslate, drag.maxTranslate));
+    applyTranslate(
+      applyShortsPagerEdgeResistance({
+        value: next,
+        min: drag.minTranslate,
+        max: drag.maxTranslate,
+        viewportHeight: drag.viewportHeight,
+      })
+    );
   };
 
   const handleTouchEnd = (event: TouchEvent) => {
     const current = drag;
     drag = null;
+    setGestureActive(false);
     if (!current || current.abandoned) return;
     if (!current.committed) {
       // 没构成滑动。若这一下只是"按住把飞行中的动画停下来"，同样要吸回
@@ -646,6 +728,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     const targetIndex = resolveShortsPagerTargetIndex({
       deltaY,
       elapsedMs: now - current.startTime,
+      velocityPxPerMs: computeShortsPagerVelocity(current.samples),
       viewportHeight: current.viewportHeight,
       anchorIndex: current.anchorIndex,
       slideCount: current.slides.length,
@@ -653,12 +736,13 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     // 记住目标**节点**而不是坐标：队列裁剪会在动画途中改坐标系，节点身份不会变。
     const target =
       current.slides[targetIndex] ?? current.slides[current.anchorIndex] ?? null;
-    settleTo(target, computeShortsPagerVelocity(current.samples));
+    settleTo(target, targetIndex !== current.anchorIndex);
   };
 
   const handleTouchCancel = () => {
     const current = drag;
     drag = null;
+    setGestureActive(false);
     if (current && (current.committed || current.interrupted)) {
       settleToNearest();
     }
@@ -715,6 +799,7 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
     }
     detachSettleListeners();
     releaseClickGuard();
+    setGestureActive(false);
     if (realignFrame !== null) window.cancelAnimationFrame(realignFrame);
     if (realignTimer !== null) window.clearTimeout(realignTimer);
     root.removeEventListener("touchstart", handleTouchStart);
@@ -733,6 +818,7 @@ export type ShortsSwipePagerOptions = {
   trackRef: React.RefObject<HTMLElement | null>;
   usesDocumentScroll: boolean;
   getAnchorSlide: () => HTMLElement | null;
+  onGestureActiveChange?: (active: boolean) => void;
 };
 
 /** React 侧只负责生命周期；判定和动画全在 createShortsSwipePager 里。 */
@@ -753,6 +839,8 @@ export function useShortsSwipePager(options: ShortsSwipePagerOptions) {
       usesDocumentScroll,
       // 走 ref 读取，回调换引用不会重挂监听。
       getAnchorSlide: () => optionsRef.current.getAnchorSlide(),
+      onGestureActiveChange: (active) =>
+        optionsRef.current.onGestureActiveChange?.(active),
     });
   }, [enabled, usesDocumentScroll]);
 }

--- a/src/shorts/useShortsSwipePager.ts
+++ b/src/shorts/useShortsSwipePager.ts
@@ -29,9 +29,9 @@ import { classifyTouchSeekIntent } from "./useShortsSlideGestures";
  *   然后让 `T` 动画归零**（FLIP）。画面是平滑滑过去的，但滚动位置在第 0
  *   毫秒就已经是新的了。
  *
- * 落点这样排有两个直接后果：IntersectionObserver 在松手当场就判出新的活跃屏
- * （下一条视频立刻起播，与 douyin 在 touchEnd 里推进 index 一致），以及位置
- * 提交完全不依赖 transitionend——那个事件丢了也只是 will-change 多留一会儿。
+ * 落点这样排是为了健壮性：位置提交不依赖 transitionend（那个事件在标签页
+ * 切走时会丢），也让队列裁剪的坐标平移天然连续。它**不**改变视频切换时机——
+ * 活跃屏仍由 IntersectionObserver 按视觉位置判定，详见 settleTo 的注释。
  *
  * 页面其余部分因此完全不用改：判活跃屏、长会话队列裁剪重贴、键盘
  * `scrollIntoView`、隐藏视频后跳下一条，全都仍然建立在 `scrollTop` 几何上。
@@ -403,15 +403,16 @@ export function createShortsSwipePager(host: ShortsSwipePagerHost) {
    * translate 抵消掉这次跳变，再让它动画归零——画面看起来是平滑滑过去的，
    * 但滚动位置在第 0 毫秒就已经是新的了。
    *
-   * 这么排有两个好处，都关乎手感和健壮性：
-   * 1. IntersectionObserver 在松手当场就判出新的活跃屏，下一条视频立刻起播，
-   *    不用等动画走完（douyin 也是在 touchEnd 里就推进 localIndex 的）。
-   *    也就不必去赌"合成器动画期间 IO 会不会被触发"。
-   * 2. 位置提交不依赖 transitionend。那个事件在标签页切走、动画被打断时会丢；
+   * 这么排换来的是健壮性：
+   * 1. 位置提交不依赖 transitionend。那个事件在标签页切走、合成器丢帧时会丢；
    *    在这个排法里丢了也只是 will-change 多留一会儿，绝不会卡在两屏之间。
+   * 2. 长会话队列裁剪天然连续：它保持 `scrollTop - slide 布局位置` 不变，
+   *    轨道上的 translate 原样继续，不需要任何额外处理。
    *
-   * 长会话队列裁剪同理：它保持 `scrollTop - slide 布局位置` 不变，轨道上的
-   * translate 原样继续，视觉完全连续，不需要任何额外处理。
+   * 注意它**不**改变视频切换的时机。活跃屏仍由 IntersectionObserver 判定，
+   * 而 IO 看的是视觉矩形——补偿量正是为了让视觉位置保持连续，所以切换依旧
+   * 发生在画面视觉越过 60% 的那一刻（easeOutCubic 前段快，约在动画前 1/4）。
+   * 做不做 FLIP 在这一点上完全一样。
    */
   const settleTo = (target: HTMLElement | null, velocityPxPerMs: number) => {
     detachSettleListeners();

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -258,6 +258,9 @@ html.shorts-document-scroll.is-touch-paged body {
   margin: auto;
   object-fit: contain; /* 横屏视频不裁切，多余处由 __bg 顶上 */
   z-index: 1;
+  /* 桌面上用鼠标拖动翻页时，别让浏览器把它当成"拖拽一张图片"。 */
+  -webkit-user-drag: none;
+  user-select: none;
 }
 
 /* 播放层保持稳定、完全不透明，避免 WebKit 在首帧解码期间还要混合和缩放

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -155,6 +155,16 @@ body.shorts-document-scroll::before {
   display: none;
 }
 
+/* 滑动位移的承载体。静止时它是一个完全透明的普通块——没有定位、没有
+   transform、没有 will-change，所以既不改变 slide 的 offsetTop / 兄弟关系，
+   也不会在 <video> 祖先上留下常驻合成层（本页在 iOS 合成路径上踩过坑）。
+   手势和落点动画进行中由 JS 写内联 translate3d，落定立刻清掉。 */
+.shorts-feed__track {
+  position: static;
+  transform: none;
+  will-change: auto;
+}
+
 /* 页面自己接管上下滑动时（移动端）：
    - touch-action: none —— 手指位移完全由 JS 写进 scrollTop，不和浏览器的
      滚动预测抢同一根手指；横向的进度条 seek 手势本来就是 JS 驱动，不受影响。

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -155,6 +155,32 @@ body.shorts-document-scroll::before {
   display: none;
 }
 
+/* 页面自己接管上下滑动时（移动端）：
+   - touch-action: none —— 手指位移完全由 JS 写进 scrollTop，不和浏览器的
+     滚动预测抢同一根手指；横向的进度条 seek 手势本来就是 JS 驱动，不受影响。
+   - scroll-snap-type: none —— 吸附点会把程序化的 scrollTop 写入重新对齐到
+     最近的一屏，那会把逐帧跟手和落点动画整个吃掉。切屏判定和落点动画改由
+     useShortsSwipePager 负责，尺寸变化后的重新对齐也在那里补上。
+   桌面 / 触控本不会加这个类，继续走上面的原生吸附。 */
+.shorts-feed.is-touch-paged {
+  touch-action: none;
+  scroll-snap-type: none;
+}
+
+.shorts-feed.is-touch-paged .shorts-slide {
+  scroll-snap-align: none;
+}
+
+/* 文档滚动模式（iPhone 浏览器壳）只有 ?shortsPager=1 时才会走到这里。 */
+html.shorts-document-scroll.is-touch-paged,
+html.shorts-document-scroll.is-touch-paged body {
+  scroll-snap-type: none;
+}
+
+.shorts-page.is-document-scroll.is-touch-paged {
+  touch-action: none;
+}
+
 /* ---------- 单屏 (高度锁定 svh 杜绝抖动) ---------- */
 .shorts-slide {
   position: relative;

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -192,6 +192,11 @@ body.shorts-document-scroll::-webkit-scrollbar {
 .shorts-feed.is-pager-driven {
   touch-action: none;
   scroll-snap-type: none;
+  /* 关掉浏览器的滚动锚定。快速翻页时 slide 会频繁挂载 / 卸载 <video> 和内容，
+     锚定会为了"保持内容稳定"自动微调 scrollTop——而这里的 scrollTop 是我们
+     精确管理的落点。以前有 mandatory 吸附兜着，微调会被纠正回去；吸附关掉
+     之后它就永久留在非吸附点上，表现为快速滚动后画面停在两条视频中间。 */
+  overflow-anchor: none;
 }
 
 .shorts-feed.is-pager-driven .shorts-slide {
@@ -202,6 +207,7 @@ body.shorts-document-scroll::-webkit-scrollbar {
 html.shorts-document-scroll.is-pager-driven,
 html.shorts-document-scroll.is-pager-driven body {
   scroll-snap-type: none;
+  overflow-anchor: none;
 }
 
 .shorts-page.is-document-scroll.is-pager-driven {

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -151,8 +151,25 @@ body.shorts-document-scroll::before {
   touch-action: pan-y;
   overscroll-behavior: contain;
 }
-.shorts-feed::-webkit-scrollbar {
+/* 滚动条抑制是"当前滚动宿主"的属性，不是某个具体元素的属性。
+   .shorts-feed（容器滚动）和 html.shorts-document-scroll（iPhone 文档滚动）
+   在两种模式下轮流担任宿主，必须一起抑制——当初把滚动主体从 feed 搬到 html
+   时只搬了滚动、没搬抑制，右侧那条滚动条就是这么漏出来的。
+   base.css 的 `* { scrollbar-width: thin }` 会命中 html，所以这里必须显式覆盖。 */
+.shorts-feed,
+html.shorts-document-scroll,
+body.shorts-document-scroll {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+/* WebKit 某些版本从 body 而不是 html 取视口滚动条的伪元素，两个都写上。 */
+.shorts-feed::-webkit-scrollbar,
+html.shorts-document-scroll::-webkit-scrollbar,
+body.shorts-document-scroll::-webkit-scrollbar {
   display: none;
+  width: 0;
+  height: 0;
 }
 
 /* 滑动位移的承载体。静止时它是一个完全透明的普通块——没有定位、没有
@@ -264,22 +281,19 @@ html.shorts-document-scroll.is-touch-paged body {
   opacity: 1;
 }
 
-.shorts-slide__poster {
-  /* 影院镜头变焦动效：非活跃状态下稍微缩小，切入时柔和放大并淡入 */
-  transform: scale(0.96);
-  opacity: 0.5;
-  transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-}
+/* 画面层（<video> 与兜底海报）必须共用同一套视觉契约：恒为全亮、无变换。
+   这里曾经给非活跃海报挂过 scale(.96)/opacity(.5) 的"影院变焦"入场动效，
+   结果是——手指刚开始下滑时，正在进入视野的下一屏盖着一张半透明的暗海报，
+   要等它覆盖视口 60%（IntersectionObserver 阈值）翻转 data-active 之后，
+   再走 600ms 才淡到全亮。也就是整个滑动过程的前 60% 画面都是暗的。
+   用户看到的"一张灰暗的静态封面图"有一半是这段 CSS 造成的，与解码快慢无关。
+   而且它和 <video> 的契约不一致：已挂载 video 的 slide 全亮、只有海报的 slide
+   半透明，同一个手势在不同预载状态下亮度还不一样。 */
 
 /* iOS 的共享 video 由父级创建一次，再在各 slide 的空插槽之间移动。
    z-index 比海报高一层，海报只作为切源期间的无闪烁兜底。 */
 .shorts-slide__video--ios-shared {
   z-index: 2;
-}
-
-.shorts-slide[data-active="true"] .shorts-slide__poster {
-  transform: scale(1);
-  opacity: 1;
 }
 
 /* 阴影只给静态海报，绝不给 <video>：WebKit 一旦要对视频元素应用 CSS
@@ -505,17 +519,6 @@ html.shorts-document-scroll.is-touch-paged body {
   flex-direction: column;
   gap: 8px;
   pointer-events: none;
-  
-  /* 影院文字浮现动效：切屏时，文字稍微往下位移并淡入 */
-  transform: translateY(15px);
-  opacity: 0;
-  transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-  transition-delay: 0.1s;
-}
-
-.shorts-slide[data-active="true"] .shorts-slide__overlay {
-  transform: translateY(0);
-  opacity: 1;
 }
 
 .shorts-slide__title {
@@ -561,18 +564,15 @@ html.shorts-document-scroll.is-touch-paged body {
   align-items: center;
   gap: 16px;
   z-index: 15;
-  
-  /* 影院动作条滑入动效：切屏时，右侧按钮向右微移并淡入 */
-  transform: translateX(18px);
-  opacity: 0;
-  transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-  transition-delay: 0.15s;
 }
 
-.shorts-slide[data-active="true"] .shorts-slide__actions {
-  transform: translateX(0);
-  opacity: 1;
-}
+/* 标题栏和操作栏都不做 [data-active] 入场动效。
+   它们是**贴在各自那条视频上**的图层，应该跟着视频一起滑进滑出——
+   TikTok 就是这样。原来的做法是非活跃时 opacity: 0，等切屏后再延迟
+   0.1~0.15s、花 0.5s 淡入，于是下一条视频滑进来时它的标题和按钮是隐形的，
+   等落屏了才"叠"上来，读起来像是这层 UI 事后被贴到屏幕上，而不是本来就
+   长在那条视频上。而且 500~600ms 的入场动效是落点动画（300ms）的两倍，
+   切屏过程中屏幕上会有两组文字同时在淡入淡出。 */
 
 /* 来源云盘圆形徽章，也是当前视频的详情链接。 */
 .shorts-drive-badge {

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -388,7 +388,7 @@ html.shorts-document-scroll.is-pager-driven body {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: min(280px, calc(100% - 48px));
+  width: min(240px, calc(100% - 48px));
   padding: 18px;
   border-radius: 18px;
   background: rgba(10, 10, 12, 0.82);
@@ -410,21 +410,10 @@ html.shorts-document-scroll.is-pager-driven body {
   color: #ff6a7f;
 }
 
-.shorts-slide__playback-error-copy {
-  display: grid;
-  gap: 3px;
-}
-
 .shorts-slide__playback-error-title {
   font-size: 16px;
   line-height: 1.35;
   font-weight: 700;
-}
-
-.shorts-slide__playback-error-message {
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 12px;
-  line-height: 1.5;
 }
 
 .shorts-slide__playback-retry {
@@ -440,7 +429,6 @@ html.shorts-document-scroll.is-pager-driven body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   transition: background-color 0.18s ease, transform 0.18s ease;

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -874,7 +874,7 @@ html.shorts-document-scroll.is-pager-driven body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 8px;
   z-index: 30;
   animation: hidden-fade-in 0.25s ease-out forwards;
   color: #fff;

--- a/src/styles/shorts.css
+++ b/src/styles/shorts.css
@@ -182,29 +182,29 @@ body.shorts-document-scroll::-webkit-scrollbar {
   will-change: auto;
 }
 
-/* 页面自己接管上下滑动时（移动端）：
-   - touch-action: none —— 手指位移完全由 JS 写进 scrollTop，不和浏览器的
-     滚动预测抢同一根手指；横向的进度条 seek 手势本来就是 JS 驱动，不受影响。
-   - scroll-snap-type: none —— 吸附点会把程序化的 scrollTop 写入重新对齐到
-     最近的一屏，那会把逐帧跟手和落点动画整个吃掉。切屏判定和落点动画改由
-     useShortsSwipePager 负责，尺寸变化后的重新对齐也在那里补上。
-   桌面 / 触控本不会加这个类，继续走上面的原生吸附。 */
-.shorts-feed.is-touch-paged {
+/* 页面接管全部滚动输入时（默认；`?shortsPager=0` 关掉）：
+   - touch-action: none —— 手指位移完全由 JS 写进轨道的 transform，不和浏览器
+     的滚动预测抢同一根手指；横向的进度条 seek 本来就是 JS 驱动，不受影响。
+   - scroll-snap-type: none —— 吸附点是按元素**变换后**的位置算的：轨道一平移
+     吸附点就跟着移，mandatory 会立刻反向拉 scrollTop 补偿，把跟手位移整个
+     抵消掉（桌面上表现为鼠标怎么拖都不动）。切屏判定、落点动画、尺寸变化后的
+     重新对齐全部改由 useShortsSwipePager 负责，滚轮也一并接管。 */
+.shorts-feed.is-pager-driven {
   touch-action: none;
   scroll-snap-type: none;
 }
 
-.shorts-feed.is-touch-paged .shorts-slide {
+.shorts-feed.is-pager-driven .shorts-slide {
   scroll-snap-align: none;
 }
 
-/* 文档滚动模式（iPhone 浏览器壳）只有 ?shortsPager=1 时才会走到这里。 */
-html.shorts-document-scroll.is-touch-paged,
-html.shorts-document-scroll.is-touch-paged body {
+/* 文档滚动模式（iPhone 浏览器壳）：滚动主体是 html/body，吸附也在那边。 */
+html.shorts-document-scroll.is-pager-driven,
+html.shorts-document-scroll.is-pager-driven body {
   scroll-snap-type: none;
 }
 
-.shorts-page.is-document-scroll.is-touch-paged {
+.shorts-page.is-document-scroll.is-pager-driven {
   touch-action: none;
 }
 

--- a/tests/shortsMediaBuffer.test.ts
+++ b/tests/shortsMediaBuffer.test.ts
@@ -221,19 +221,16 @@ test("video window slides forward with the highest viewed index", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 预载深度：让下一条"存在"和"后台囤积"是两件事
+// 预载深度：当前屏优先，健康后才开放后台带宽
 // ---------------------------------------------------------------------------
 
-test("the next video is always preloaded, however unhealthy the current one is", () => {
+test("aggressive preloading waits for the active video buffer", () => {
   // 授权拿到手：向后囤两条
   assert.equal(getPreloadAheadCount(true), PRELOAD_AHEAD_COUNT);
-  // 授权没拿到：下一条仍然无条件预载。这一条是"滑到就有画面"的底线——
-  // 授权每次切屏都会清零、要靠当前条起播并囤够 4~12 秒缓冲才挣得回来，
-  // 而正常刷短视频比这条链路走完还快，下一条会永远处在"还没开始加载"。
-  assert.equal(getPreloadAheadCount(false), 1);
-  // 无论如何都不会退化成 0（那意味着完全没有预载）
-  assert.ok(getPreloadAheadCount(false) >= 1);
-  assert.ok(getPreloadAheadCount(true) >= getPreloadAheadCount(false));
+  // 授权没拿到：不允许任何后续视频用 auto 抢当前视频的带宽。
+  // 下一条仍由页面挂源并用 metadata 轻量准备，不属于这个深度计算。
+  assert.equal(getPreloadAheadCount(false), 0);
+  assert.ok(getPreloadAheadCount(true) > getPreloadAheadCount(false));
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/shortsMediaBuffer.test.ts
+++ b/tests/shortsMediaBuffer.test.ts
@@ -9,7 +9,11 @@ import {
   VIDEO_WINDOW_SIZE,
   averageBytesPerSecond,
   bufferedAheadSeconds,
+  FIRST_FRAME_WARM_TIME,
+  getPreloadAheadCount,
   getVideoWindowBounds,
+  PRELOAD_AHEAD_COUNT,
+  shouldWarmFirstFrame,
   preloadBufferSecondsFor,
   preloadKeepSecondsFor,
   videoBufferIsCritical,
@@ -214,4 +218,60 @@ test("video window slides forward with the highest viewed index", () => {
   // 索引越界时收敛到队列末尾（空库后残留的高位索引）
   assert.deepEqual(getVideoWindowBounds(9, 4), { start: 0, end: 3 });
   assert.deepEqual(getVideoWindowBounds(3, 0), { start: 0, end: -1 });
+});
+
+// ---------------------------------------------------------------------------
+// 预载深度：让下一条"存在"和"后台囤积"是两件事
+// ---------------------------------------------------------------------------
+
+test("the next video is always preloaded, however unhealthy the current one is", () => {
+  // 授权拿到手：向后囤两条
+  assert.equal(getPreloadAheadCount(true), PRELOAD_AHEAD_COUNT);
+  // 授权没拿到：下一条仍然无条件预载。这一条是"滑到就有画面"的底线——
+  // 授权每次切屏都会清零、要靠当前条起播并囤够 4~12 秒缓冲才挣得回来，
+  // 而正常刷短视频比这条链路走完还快，下一条会永远处在"还没开始加载"。
+  assert.equal(getPreloadAheadCount(false), 1);
+  // 无论如何都不会退化成 0（那意味着完全没有预载）
+  assert.ok(getPreloadAheadCount(false) >= 1);
+  assert.ok(getPreloadAheadCount(true) >= getPreloadAheadCount(false));
+});
+
+// ---------------------------------------------------------------------------
+// 首帧预热：把字节下下来不等于有画面
+// ---------------------------------------------------------------------------
+
+function warmProbe(overrides: Partial<Parameters<typeof shouldWarmFirstFrame>[0]> = {}) {
+  return shouldWarmFirstFrame({
+    isActive: false,
+    shouldLoad: true,
+    usesSharedVideo: false,
+    readyState: 1,
+    currentTime: 0,
+    ...overrides,
+  });
+}
+
+test("preloaded videos are nudged into decoding their first frame", () => {
+  // 已绑源、已拿到元数据、还停在起点的非活跃条：正是要预热的对象
+  assert.equal(warmProbe(), true);
+  assert.equal(warmProbe({ readyState: 4 }), true);
+});
+
+test("first-frame warming leaves every other video alone", () => {
+  // 当前屏由 play() 负责，不需要也不该被 seek 打断
+  assert.equal(warmProbe({ isActive: true }), false);
+  // 没绑 src 的空壳，seek 无处可去
+  assert.equal(warmProbe({ shouldLoad: false }), false);
+  // iOS 共享元素有自己的生命周期，不参与
+  assert.equal(warmProbe({ usesSharedVideo: true }), false);
+  // 元数据都还没到，seek 会被丢弃；等 loadedmetadata 再试
+  assert.equal(warmProbe({ readyState: 0 }), false);
+  // 已经被推进过（预热过、或用户拖过进度）：不要把位置冲掉
+  assert.equal(warmProbe({ currentTime: 0.001 }), false);
+  assert.equal(warmProbe({ currentTime: 12.5 }), false);
+});
+
+test("the warm target is small enough to still read as the first frame", () => {
+  assert.ok(FIRST_FRAME_WARM_TIME > 0, "必须真的产生一次 seek");
+  assert.ok(FIRST_FRAME_WARM_TIME < 0.04, "小于一帧的时长，视觉上仍是首帧");
 });

--- a/tests/shortsMediaBuffer.test.ts
+++ b/tests/shortsMediaBuffer.test.ts
@@ -244,7 +244,7 @@ function warmProbe(overrides: Partial<Parameters<typeof shouldWarmFirstFrame>[0]
   return shouldWarmFirstFrame({
     isActive: false,
     shouldLoad: true,
-    usesSharedVideo: false,
+    isPlaybackElement: false,
     readyState: 1,
     currentTime: 0,
     ...overrides,
@@ -262,8 +262,8 @@ test("first-frame warming leaves every other video alone", () => {
   assert.equal(warmProbe({ isActive: true }), false);
   // 没绑 src 的空壳，seek 无处可去
   assert.equal(warmProbe({ shouldLoad: false }), false);
-  // iOS 共享元素有自己的生命周期，不参与
-  assert.equal(warmProbe({ usesSharedVideo: true }), false);
+  // 播放位由 play() 负责清掉 poster 标志，seek 它只会打断起播
+  assert.equal(warmProbe({ isPlaybackElement: true }), false);
   // 元数据都还没到，seek 会被丢弃；等 loadedmetadata 再试
   assert.equal(warmProbe({ readyState: 0 }), false);
   // 已经被推进过（预热过、或用户拖过进度）：不要把位置冲掉

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -532,13 +532,15 @@ test("shorts loading spinner covers video buffering and initial feed loading", (
   assert.doesNotMatch(mobileBufferingRule, /width:\s*56px|height:\s*56px/);
 });
 
-test("shorts always preloads the next video and gates only the ones after it", () => {
+test("shorts prepares the next video lightly until the active buffer is healthy", () => {
   assert.match(shortsPageSource, /const \[activeReadyForPreload, setActiveReadyForPreload\] = useState\(false\);/);
   assert.match(mediaBufferSource, /const ACTIVE_PRELOAD_BUFFER_SECONDS = 12;/);
   assert.match(mediaBufferSource, /export const PRELOAD_AHEAD_COUNT = 2;/);
-  // 预载深度由授权决定，但下一条永远无条件预载——"让下一条存在"和
-  // "后台囤积"是两件成本差一个数量级的事，不能共用一个开关。
-  // 深度换算的行为用例见 shortsMediaBuffer.test.ts。
+  // 下一条始终保留 src，但只有授权后才能和更后面的条目一起用 auto。
+  assert.match(
+    shortsPageSource,
+    /const shouldPrepareNext =\s*!useIOSSharedVideo && preloadOffset === 1;/
+  );
   assert.match(
     shortsPageSource,
     /const preloadOffset = index - activeIndex;[\s\S]*?preloadOffset > 0 &&[\s\S]*?preloadOffset <= getPreloadAheadCount\(activeReadyForPreload\);/
@@ -547,7 +549,18 @@ test("shorts always preloads the next video and gates only the ones after it", (
     shortsPageSource,
     /const shouldPreload =\s*!useIOSSharedVideo &&\s*activeReadyForPreload/
   );
-  assert.match(shortsPageSource, /const shouldLoad = isActiveSlide \|\| shouldPreload \|\| shouldRetainCached;/);
+  assert.match(
+    shortsPageSource,
+    /const shouldLoad =\s*isActiveSlide \|\|\s*shouldPrepareNext \|\|\s*shouldPreload \|\|\s*shouldRetainCached;/
+  );
+  assert.match(
+    shortsPageSource,
+    /const shouldEagerLoad = isActiveSlide \|\| shouldPreload;/
+  );
+  assert.match(
+    shortsPageSource,
+    /preload=\{shouldLoad \? \(shouldEagerLoad \? "auto" : "metadata"\) : "none"\}/
+  );
   assert.match(shortsPageSource, /shouldLoad=\{shouldLoad\}/);
   assert.match(shortsPageSource, /setActiveReadyForPreload\(false\);\s*setActiveIndex\(bestIndex\);/);
   assert.match(shortsPageSource, /function syncActivePreloadReadiness\(currentVideo: HTMLVideoElement\)/);
@@ -769,7 +782,7 @@ test("shorts keeps buffered sources inside a four video window", () => {
   );
   assert.match(
     shortsPageSource,
-    /const shouldMount =\s*isActiveSlide \|\|\s*\(!useIOSSharedVideo && \(isInCacheWindow \|\| shouldPreload\)\);/
+    /const shouldMount =\s*isActiveSlide \|\|\s*\(!useIOSSharedVideo &&\s*\(isInCacheWindow \|\| shouldPrepareNext \|\| shouldPreload\)\);/
   );
   // 视频窗口内已缓冲过的视频都保留 src，来回切换均复用缓存
   assert.match(
@@ -889,11 +902,15 @@ test("iOS preloads the next video on a standby element and promotes it on swipe"
     shortsPageSource,
     /const iosStandbyVideoRef = useRef<HTMLVideoElement \| null>\(null\);/
   );
-  // Preloading starts on the same high/low watermark the desktop branch uses,
-  // so it never steals bandwidth from a still-buffering active video.
+  // The standby keeps the next src but switches between metadata and auto on
+  // the same high/low watermark as the desktop branch.
   assert.match(
     shortsPageSource,
     /if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled\) return;[\s\S]*?const nextIndex = activeIndex \+ browseDirectionRef\.current;/
+  );
+  assert.match(
+    shortsPageSource,
+    /applyIOSVideoRole\(standby, "standby"\);\s*standby\.preload = activeReadyForPreload \? "auto" : "metadata";/
   );
   assert.match(
     shortsPageSource,
@@ -1374,12 +1391,14 @@ test("shorts keeps per-swipe work off the queue length", () => {
     shortsPageSource,
     /useEffect\(\(\) => \{\s*if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled\) return;/
   );
-  // 备用元素承担的是"下一条"这一档，和非 iOS 路径的 getPreloadAheadCount
-  // 下限 1 同一条规则：绝不能挂在每次切屏都清零的 activeReadyForPreload 上，
-  // 否则滑到位时下一条一个字节都还没请求过。
+  // 备用元素始终保留下一条的源，但全速预载受当前视频健康状态控制。
   assert.doesNotMatch(
     shortsPageSource,
     /iosStandbyPreloadDisabled \|\| !activeReadyForPreload/
+  );
+  assert.match(
+    shortsPageSource,
+    /standby\.preload = activeReadyForPreload \? "auto" : "metadata";/
   );
   // 拉下字节还不够：video 在真正播放前一直画 poster，要 seek 一次逼出首帧
   assert.match(shortsPageSource, /warmStandbyFirstFrame\(standby\);/);

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -972,7 +972,7 @@ test("iOS standby preload has a kill switch for on-device A/B", () => {
 test("the sound toggle also grants unmuted playback to the iOS standby element", () => {
   assert.match(
     shortsPageSource,
-    /const standbyVideo = iosStandbyVideoRef\.current;\s*if \(standbyVideo && standbyVideo !== activeVideo\) \{\s*unlockVideoAudioPlayback\(standbyVideo\);/
+    /if \(useIOSSharedVideo\) \{\s*const standbyVideo = iosStandbyVideoRef\.current;\s*if \(standbyVideo && standbyVideo !== activeVideo\) \{\s*unlockVideoAudioPlayback\(standbyVideo\);/
   );
   assert.match(
     shortsPageSource,
@@ -1209,7 +1209,7 @@ test("shorts grants preload only after the active video really started", () => {
   );
 });
 
-test("shorts sound toggle grants playback in the direct user click", () => {
+test("shorts sound toggle limits playback recovery to the iOS media path", () => {
   assert.match(shortsPageSource, /function applyVideoMutedState/);
   assert.doesNotMatch(shortsPageSource, /onFirstPointer/);
   assert.doesNotMatch(shortsPageSource, /currentPage\.addEventListener\("pointerdown"/);
@@ -1223,12 +1223,11 @@ test("shorts sound toggle grants playback in the direct user click", () => {
   assert.match(shortsPageSource, /onTouchStart=\{stopHeaderControlPropagation\}/);
   assert.match(shortsPageSource, /function normalizeVideoPlaybackRate/);
   assert.match(shortsPageSource, /function stabilizeVideoAfterAudioToggle/);
-  assert.match(shortsPageSource, /normalizeVideoPlaybackRate\(activeVideo\);/);
-  assert.match(shortsPageSource, /getVideoAtIndex\(activeIndexRef\.current\) === activeVideo/);
   assert.match(
     shortsPageSource,
-    /applyVideoMutedState\(activeVideo, next\);[\s\S]*?activeVideo\.play\(\)\.catch[\s\S]*?setMuted\(next\);/
+    /if \(!useIOSSharedVideo\) \{\s*applyVideoMutedState\(activeVideo, next\);\s*\} else \{[\s\S]*?normalizeVideoPlaybackRate\(activeVideo\);\s*applyVideoMutedState\(activeVideo, next\);[\s\S]*?activeVideo\.play\(\)\.catch[\s\S]*?stabilizeVideoAfterAudioToggle/
   );
+  assert.match(shortsPageSource, /getVideoAtIndex\(activeIndexRef\.current\) === activeVideo/);
   assert.match(shortsPageSource, /stabilizeVideoAfterAudioToggle\(\s*activeVideo,\s*canResumeActiveVideo\s*\);/);
   assert.match(shortsPageSource, /if \(shouldResume\(\) && video\.paused && !video\.ended\) \{/);
   assert.match(shortsPageSource, /for \(const delay of \[80, 240, 600\]\)/);

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -319,7 +319,22 @@ test("shorts exposes media failures separately from pause and retries in place",
   );
   assert.match(
     shortsPageSource,
-    /className="shorts-slide__playback-error"\s*role="alert"[\s\S]*?<div className="shorts-slide__playback-error-title">播放失败<\/div>[\s\S]*?className="shorts-slide__playback-retry"[\s\S]*?<span>重新播放<\/span>/
+    /className="shorts-slide__playback-error"\s*role="alert"[\s\S]*?<div className="shorts-slide__playback-error-title">播放失败<\/div>[\s\S]*?className="shorts-slide__playback-retry"[\s\S]*?>\s*重试播放\s*<\/button>/
+  );
+  assert.doesNotMatch(shortsPageSource, /视频暂时无法播放|>重新播放</);
+  const retryButtonMarkup =
+    /<button\s+[^>]*className="shorts-slide__playback-retry"[^>]*>[\s\S]*?<\/button>/.exec(
+      shortsPageSource
+    );
+  assert.ok(retryButtonMarkup, "playback retry button should be present");
+  assert.doesNotMatch(
+    retryButtonMarkup[0],
+    /<Play/,
+    "playback retry button should not contain an icon"
+  );
+  assert.doesNotMatch(
+    shortsCssSource,
+    /shorts-slide__playback-error-copy|shorts-slide__playback-error-message/
   );
 
   const retryStart = shortsPageSource.indexOf("function handlePlaybackRetry(");
@@ -339,7 +354,7 @@ test("shorts exposes media failures separately from pause and retries in place",
   );
   assert.match(
     shortsCssSource,
-    /\.shorts-slide__playback-error \{[\s\S]*?z-index: 18;[\s\S]*?backdrop-filter: blur\(14px\);/
+    /\.shorts-slide__playback-error \{[\s\S]*?width:\s*min\(240px, calc\(100% - 48px\)\);[\s\S]*?z-index: 18;[\s\S]*?backdrop-filter: blur\(14px\);/
   );
 });
 

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -893,7 +893,7 @@ test("iOS preloads the next video on a standby element and promotes it on swipe"
   // so it never steals bandwidth from a still-buffering active video.
   assert.match(
     shortsPageSource,
-    /if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled \|\| !activeReadyForPreload\) \{\s*return;\s*\}\s*const nextIndex = activeIndex \+ 1;/
+    /if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled\) return;\s*const nextIndex = activeIndex \+ 1;/
   );
   assert.match(
     shortsPageSource,
@@ -1372,7 +1372,24 @@ test("shorts keeps per-swipe work off the queue length", () => {
   // ③ 备用元素预载不占绘制前的同步块；提升那一条仍然必须是 layout effect。
   assert.match(
     shortsPageSource,
-    /useEffect\(\(\) => \{\s*if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled \|\| !activeReadyForPreload\)/
+    /useEffect\(\(\) => \{\s*if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled\) return;/
+  );
+  // 备用元素承担的是"下一条"这一档，和非 iOS 路径的 getPreloadAheadCount
+  // 下限 1 同一条规则：绝不能挂在每次切屏都清零的 activeReadyForPreload 上，
+  // 否则滑到位时下一条一个字节都还没请求过。
+  assert.doesNotMatch(
+    shortsPageSource,
+    /iosStandbyPreloadDisabled \|\| !activeReadyForPreload/
+  );
+  // 拉下字节还不够：video 在真正播放前一直画 poster，要 seek 一次逼出首帧
+  assert.match(shortsPageSource, /warmStandbyFirstFrame\(standby\);/);
+  assert.match(
+    shortsPageSource,
+    /function warmStandbyFirstFrame\(video: HTMLVideoElement\)/
+  );
+  assert.match(
+    shortsPageSource,
+    /video\.addEventListener\("loadedmetadata", nudge, \{ once: true \}\)/
   );
   assert.match(
     shortsPageSource,

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -532,13 +532,20 @@ test("shorts loading spinner covers video buffering and initial feed loading", (
   assert.doesNotMatch(mobileBufferingRule, /width:\s*56px|height:\s*56px/);
 });
 
-test("shorts preloads the next two original videos only after the active video has comfortable buffer", () => {
+test("shorts always preloads the next video and gates only the ones after it", () => {
   assert.match(shortsPageSource, /const \[activeReadyForPreload, setActiveReadyForPreload\] = useState\(false\);/);
   assert.match(mediaBufferSource, /const ACTIVE_PRELOAD_BUFFER_SECONDS = 12;/);
-  assert.match(shortsPageSource, /const PRELOAD_AHEAD_COUNT = 2;/);
+  assert.match(mediaBufferSource, /export const PRELOAD_AHEAD_COUNT = 2;/);
+  // 预载深度由授权决定，但下一条永远无条件预载——"让下一条存在"和
+  // "后台囤积"是两件成本差一个数量级的事，不能共用一个开关。
+  // 深度换算的行为用例见 shortsMediaBuffer.test.ts。
   assert.match(
     shortsPageSource,
-    /const preloadOffset = index - activeIndex;[\s\S]*?preloadOffset > 0 &&[\s\S]*?preloadOffset <= PRELOAD_AHEAD_COUNT;/
+    /const preloadOffset = index - activeIndex;[\s\S]*?preloadOffset > 0 &&[\s\S]*?preloadOffset <= getPreloadAheadCount\(activeReadyForPreload\);/
+  );
+  assert.doesNotMatch(
+    shortsPageSource,
+    /const shouldPreload =\s*!useIOSSharedVideo &&\s*activeReadyForPreload/
   );
   assert.match(shortsPageSource, /const shouldLoad = isActiveSlide \|\| shouldPreload \|\| shouldRetainCached;/);
   assert.match(shortsPageSource, /shouldLoad=\{shouldLoad\}/);
@@ -850,9 +857,10 @@ test("shorts reuses one persistent media element across iOS slides", () => {
   assert.match(shortsPlatformSource, /function shouldUseIOSSharedVideo\(\)/);
   assert.match(shortsPlatformSource, /\\biPhone\\b\|\\biPad\\b\|\\biPod\\b/);
   assert.match(shortsPlatformSource, /navigator\.platform === "MacIntel" && navigator\.maxTouchPoints > 1/);
+  // iOS 走共享元素分支，完全不参与上面那套 <video> 预载
   assert.match(
     shortsPageSource,
-    /const shouldPreload =\s*!useIOSSharedVideo &&\s*activeReadyForPreload/
+    /const shouldPreload =\s*!useIOSSharedVideo &&/
   );
   assert.match(shortsPageSource, /const iosSharedVideoRef = useRef<HTMLVideoElement \| null>\(null\);/);
   assert.match(shortsPageSource, /if \(!video\) \{\s*video = document\.createElement\("video"\);/);
@@ -1260,7 +1268,7 @@ test("Windows viewport resize keeps the current short aligned", () => {
   );
   assert.match(
     shortsPageSource,
-    /const observer = new IntersectionObserver\(\s*\(entries\) => \{\s*if \(\s*viewportResizeAnchorIndexRef\.current !== null \|\|\s*queueTrimInProgressRef\.current\s*\) \{\s*return;\s*\}/
+    /const observer = new IntersectionObserver\(\s*\(entries\) => \{\s*if \(\s*viewportResizeAnchorIndexRef\.current !== null \|\|\s*queueTrimInProgressRef\.current \|\|\s*pagerGestureActiveRef\.current\s*\) \{\s*return;\s*\}/
   );
 });
 

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -413,7 +413,7 @@ test("shorts keeps the full heart animation when reduced motion is enabled", () 
   );
 });
 
-test("desktop held arrow-key seeking previews progress and commits once", () => {
+test("desktop left-key seeking and held right-key playback keep distinct semantics", () => {
   assert.match(
     useShortsKeyboardSource,
     /type ShortsKeyboardSeekPreview = \{[\s\S]*?videoIndex: number;[\s\S]*?currentTime: number;[\s\S]*?duration: number;/
@@ -428,7 +428,7 @@ test("desktop held arrow-key seeking previews progress and commits once", () => 
   );
   assert.match(
     useShortsKeyboardSource,
-    /const handleKeyUp = \(e: KeyboardEvent\) => \{[\s\S]*?keyboardSeekHeldKeysRef\.current\.delete\(e\.key\);[\s\S]*?size === 0\) finishKeyboardSeek\(\)/
+    /if \(e\.key !== "ArrowLeft"\) return;[\s\S]*?keyboardSeekHeldKeysRef\.current\.delete\(e\.key\);[\s\S]*?size === 0\) finishKeyboardSeek\(\)/
   );
   const previewStart = useShortsKeyboardSource.indexOf("const previewKeyboardSeek");
   const keydownStart = useShortsKeyboardSource.indexOf("const handleKeyDown", previewStart);
@@ -445,6 +445,34 @@ test("desktop held arrow-key seeking previews progress and commits once", () => 
     useShortsKeyboardSource,
     /SHORTS_KEYBOARD_SEEK_IDLE_COMMIT_MS[\s\S]*?scheduleKeyboardSeekIdleCommit/
   );
+  assert.match(
+    useShortsKeyboardSource,
+    /const SHORTS_KEYBOARD_FAST_PLAYBACK_DELAY_MS = 400;/
+  );
+  assert.match(
+    useShortsKeyboardSource,
+    /else if \(e\.key === "ArrowRight"\) \{\s*e\.preventDefault\(\);\s*if \(e\.repeat\) return;\s*startKeyboardRightPress\(\);/
+  );
+  assert.match(
+    useShortsKeyboardSource,
+    /keyboardRightPressTimer = window\.setTimeout\([\s\S]*?target\.video\.playbackRate = 2;[\s\S]*?setKeyboardFastPlaybackIndex\(target\.videoIndex\);[\s\S]*?SHORTS_KEYBOARD_FAST_PLAYBACK_DELAY_MS/
+  );
+  assert.match(
+    useShortsKeyboardSource,
+    /if \(target\.fastPlaybackActive\) \{[\s\S]*?target\.video\.playbackRate = 1;[\s\S]*?setKeyboardFastPlaybackIndex\(null\);/
+  );
+  assert.match(
+    useShortsKeyboardSource,
+    /if \(e\.key === "ArrowRight"\) \{[\s\S]*?finishKeyboardRightPress\(true\);/
+  );
+  assert.match(
+    useShortsKeyboardSource,
+    /seekOnShortPress[\s\S]*?previewKeyboardSeek\(\s*SHORTS_KEYBOARD_SEEK_SECONDS,\s*"ArrowRight"\s*\);/
+  );
+  assert.match(
+    useShortsKeyboardSource,
+    /const handleWindowBlur = \(\) => \{\s*finishKeyboardRightPress\(false\);/
+  );
   assert.match(useShortsKeyboardSource, /window\.addEventListener\("keyup", handleKeyUp\);/);
   assert.match(
     shortsPageSource,
@@ -457,6 +485,14 @@ test("desktop held arrow-key seeking previews progress and commits once", () => 
   assert.match(
     shortsPageSource,
     /keyboardSeekPreview=\{[\s\S]*?keyboardSeekPreview\?\.videoIndex === index[\s\S]*?\? keyboardSeekPreview/
+  );
+  assert.match(
+    shortsPageSource,
+    /keyboardFastPlayback=\{keyboardFastPlaybackIndex === index\}/
+  );
+  assert.match(
+    shortsPageSource,
+    /\{\(fastActive \|\| keyboardFastPlayback\) && \([\s\S]*?2x 速播放中/
   );
   assert.match(
     shortsPageSource,

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -893,7 +893,7 @@ test("iOS preloads the next video on a standby element and promotes it on swipe"
   // so it never steals bandwidth from a still-buffering active video.
   assert.match(
     shortsPageSource,
-    /if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled\) return;\s*const nextIndex = activeIndex \+ 1;/
+    /if \(!useIOSSharedVideo \|\| iosStandbyPreloadDisabled\) return;[\s\S]*?const nextIndex = activeIndex \+ browseDirectionRef\.current;/
   );
   assert.match(
     shortsPageSource,
@@ -1383,6 +1383,17 @@ test("shorts keeps per-swipe work off the queue length", () => {
   );
   // 拉下字节还不够：video 在真正播放前一直画 poster，要 seek 一次逼出首帧
   assert.match(shortsPageSource, /warmStandbyFirstFrame\(standby\);/);
+  // 备用元素跟着浏览方向放：只盯 activeIndex+1 的话，往回看每一条都是冷启动
+  assert.match(shortsPageSource, /const browseDirectionRef = useRef\(1\);/);
+  assert.match(
+    shortsPageSource,
+    /browseDirectionRef\.current = activeIndex > previous \? 1 : -1;/
+  );
+  // 队列裁剪的索引重排不代表浏览方向
+  assert.match(
+    shortsPageSource,
+    /if \(!queueTrimInProgressRef\.current && activeIndex !== previous\)/
+  );
   assert.match(
     shortsPageSource,
     /function warmStandbyFirstFrame\(video: HTMLVideoElement\)/

--- a/tests/shortsPreference.test.ts
+++ b/tests/shortsPreference.test.ts
@@ -315,7 +315,7 @@ test("shorts exposes media failures separately from pause and retries in place",
   assert.match(shortsPageSource, /exposePlaybackFailure\("loop-restart"\);/);
   assert.match(
     shortsPageSource,
-    /\{paused && !playbackFailure && isActive && !scrubbing && \(/
+    /\{paused &&\s*!playbackFailure &&\s*isActive &&\s*!scrubbing &&\s*!isMarkedHidden && \(/
   );
   assert.match(
     shortsPageSource,
@@ -462,7 +462,7 @@ test("shorts play pause does not render transient center hud", () => {
   assert.doesNotMatch(shortsCssSource, /@keyframes shorts-hud-pop/);
   assert.match(
     shortsPageSource,
-    /\{paused && !playbackFailure && isActive && !scrubbing && \(\s*<div className="shorts-slide__paused"/
+    /\{paused &&\s*!playbackFailure &&\s*isActive &&\s*!scrubbing &&\s*!isMarkedHidden && \(\s*<div className="shorts-slide__paused"/
   );
   assert.match(
     shortsPageSource,
@@ -703,6 +703,14 @@ test("shorts empty library reuses the homepage empty visual", () => {
 
 test("shorts hidden overlay keeps only the concise confirmation", () => {
   assert.match(shortsPageSource, /shorts-slide__hidden-title">已隐藏该视频/);
+  assert.match(
+    shortsCssSource,
+    /\.shorts-slide__hidden-overlay\s*\{[\s\S]*?gap:\s*8px;/
+  );
+  assert.match(
+    shortsPageSource,
+    /\{paused &&\s*!playbackFailure &&\s*isActive &&\s*!scrubbing &&\s*!isMarkedHidden && \(/
+  );
   assert.doesNotMatch(
     shortsPageSource,
     /系统将不会再次在任何地方向您展示此视频|shorts-slide__hidden-desc/

--- a/tests/shortsSwipePager.test.ts
+++ b/tests/shortsSwipePager.test.ts
@@ -1,0 +1,392 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  SHORTS_PAGER_FLICK_MS,
+  SHORTS_PAGER_MAX_SETTLE_MS,
+  SHORTS_PAGER_MIN_COMMIT_PX,
+  SHORTS_PAGER_MIN_SETTLE_MS,
+  SHORTS_PAGER_VELOCITY_WINDOW_MS,
+  computeShortsPagerVelocity,
+  findNearestShortsSlideIndex,
+  measureOffsetWithinSlide,
+  resolveShortsPagerSettleDuration,
+  resolveShortsPagerTargetIndex,
+  shortsPagerEase,
+} from "../src/shorts/useShortsSwipePager";
+import { shouldUseShortsTouchPager } from "../src/shorts/platform";
+
+const VIEWPORT = 900;
+
+function release(overrides: {
+  deltaY: number;
+  elapsedMs: number;
+  anchorIndex?: number;
+  slideCount?: number;
+  viewportHeight?: number;
+}) {
+  return resolveShortsPagerTargetIndex({
+    deltaY: overrides.deltaY,
+    elapsedMs: overrides.elapsedMs,
+    viewportHeight: overrides.viewportHeight ?? VIEWPORT,
+    anchorIndex: overrides.anchorIndex ?? 5,
+    slideCount: overrides.slideCount ?? 20,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 切屏判定（对齐 zyronon/douyin utils/slide.ts 的三段式规则）
+// ---------------------------------------------------------------------------
+
+test("tiny swipes never switch videos, however fast they are", () => {
+  // 距离不足门槛：再快也当误触，回弹到当前视频
+  assert.equal(release({ deltaY: -19, elapsedMs: 10 }), 5);
+  assert.equal(release({ deltaY: 19, elapsedMs: 10 }), 5);
+  assert.equal(release({ deltaY: 0, elapsedMs: 1 }), 5);
+  // 恰好等于门槛就不再算"太短"，此时按时间判定
+  assert.equal(release({ deltaY: -SHORTS_PAGER_MIN_COMMIT_PX, elapsedMs: 10 }), 6);
+});
+
+test("swipes past one third of the screen switch even when they are slow", () => {
+  const past = -(VIEWPORT / 3) - 1;
+  assert.equal(release({ deltaY: past, elapsedMs: 5_000 }), 6);
+  assert.equal(release({ deltaY: -past, elapsedMs: 5_000 }), 4);
+  // 恰好等于 1/3 不算"够长"，退回按时间判定
+  assert.equal(release({ deltaY: -VIEWPORT / 3, elapsedMs: 5_000 }), 5);
+  assert.equal(release({ deltaY: -VIEWPORT / 3, elapsedMs: 100 }), 6);
+});
+
+test("mid-range swipes fall back to how fast the finger left the screen", () => {
+  assert.equal(release({ deltaY: -60, elapsedMs: SHORTS_PAGER_FLICK_MS - 1 }), 6);
+  assert.equal(release({ deltaY: 60, elapsedMs: SHORTS_PAGER_FLICK_MS - 1 }), 4);
+  // 慢慢拖一小段再松手：回弹，防止误触
+  assert.equal(release({ deltaY: -60, elapsedMs: SHORTS_PAGER_FLICK_MS }), 5);
+  assert.equal(release({ deltaY: -60, elapsedMs: 900 }), 5);
+});
+
+test("a gesture never skips a video, and never runs off either end", () => {
+  // 一次手势最多切一屏
+  assert.equal(release({ deltaY: -VIEWPORT * 3, elapsedMs: 20 }), 6);
+  // 首屏继续下拉 / 末屏继续上滑都只能回弹
+  assert.equal(release({ deltaY: 400, elapsedMs: 20, anchorIndex: 0 }), 0);
+  assert.equal(
+    release({ deltaY: -400, elapsedMs: 20, anchorIndex: 19, slideCount: 20 }),
+    19
+  );
+  // 队列还没有内容时不会算出负数下标
+  assert.equal(release({ deltaY: -400, elapsedMs: 20, anchorIndex: 0, slideCount: 0 }), 0);
+  assert.equal(release({ deltaY: -400, elapsedMs: 20, anchorIndex: 7, slideCount: 3 }), 2);
+});
+
+// ---------------------------------------------------------------------------
+// 惯性收尾
+// ---------------------------------------------------------------------------
+
+test("settling matches the release speed so the slide keeps decelerating", () => {
+  // easeOutCubic 起速 = 3 × 距离 / 时长；按抬手速度反解出来的时长满足这条式子
+  const duration = resolveShortsPagerSettleDuration({
+    remainingPx: 300,
+    velocityPxPerMs: 3,
+    viewportHeight: VIEWPORT,
+  });
+  assert.equal(duration, 300);
+  assert.equal((3 * 300) / duration, 3);
+});
+
+test("settling stays inside a hand-tuned duration range", () => {
+  // 甩得极快：时长压到下限，切屏干脆
+  assert.equal(
+    resolveShortsPagerSettleDuration({
+      remainingPx: 100,
+      velocityPxPerMs: 20,
+      viewportHeight: VIEWPORT,
+    }),
+    SHORTS_PAGER_MIN_SETTLE_MS
+  );
+  // 慢慢拖了大半屏才松手：按距离取时长，且不超过上限
+  assert.equal(
+    resolveShortsPagerSettleDuration({
+      remainingPx: VIEWPORT,
+      velocityPxPerMs: 0,
+      viewportHeight: VIEWPORT,
+    }),
+    SHORTS_PAGER_MAX_SETTLE_MS
+  );
+  // 速度低于阈值时不按速度反解（否则时长会趋于无穷再被夹到上限）
+  const nearlyStill = resolveShortsPagerSettleDuration({
+    remainingPx: 90,
+    velocityPxPerMs: 0.01,
+    viewportHeight: VIEWPORT,
+  });
+  assert.ok(nearlyStill > SHORTS_PAGER_MIN_SETTLE_MS);
+  assert.ok(nearlyStill < SHORTS_PAGER_MAX_SETTLE_MS);
+  // 抬手方向和落点方向相反时只取快慢，不取朝向
+  assert.equal(
+    resolveShortsPagerSettleDuration({
+      remainingPx: -300,
+      velocityPxPerMs: -3,
+      viewportHeight: VIEWPORT,
+    }),
+    300
+  );
+});
+
+test("an already-settled position needs no animation at all", () => {
+  assert.equal(
+    resolveShortsPagerSettleDuration({
+      remainingPx: 0,
+      velocityPxPerMs: 5,
+      viewportHeight: VIEWPORT,
+    }),
+    0
+  );
+  assert.equal(
+    resolveShortsPagerSettleDuration({
+      remainingPx: 0.4,
+      velocityPxPerMs: 0,
+      viewportHeight: VIEWPORT,
+    }),
+    0
+  );
+  // 视口高度异常时按 1px 兜底，不产生除零
+  assert.ok(
+    Number.isFinite(
+      resolveShortsPagerSettleDuration({
+        remainingPx: 50,
+        velocityPxPerMs: 0,
+        viewportHeight: 0,
+      })
+    )
+  );
+});
+
+test("the settle curve starts fast and eases out", () => {
+  assert.equal(shortsPagerEase(0), 0);
+  assert.equal(shortsPagerEase(1), 1);
+  // 定义域外夹紧，动画被拖长/回拨也不会越过端点
+  assert.equal(shortsPagerEase(-1), 0);
+  assert.equal(shortsPagerEase(2), 1);
+  // 前半程走完大半路程才叫惯性减速
+  assert.ok(shortsPagerEase(0.5) > 0.8);
+  assert.ok(shortsPagerEase(0.25) > 0.5);
+  let previous = -1;
+  for (let step = 0; step <= 10; step += 1) {
+    const value = shortsPagerEase(step / 10);
+    assert.ok(value > previous);
+    previous = value;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 抬手速度采样
+// ---------------------------------------------------------------------------
+
+test("release speed comes from the recent sample window, not the whole gesture", () => {
+  // 采样不足两个点：无速度可言
+  assert.equal(computeShortsPagerVelocity([]), 0);
+  assert.equal(computeShortsPagerVelocity([{ y: 10, t: 0 }]), 0);
+  // 两点直接求斜率
+  assert.equal(
+    computeShortsPagerVelocity([
+      { y: 100, t: 0 },
+      { y: 50, t: 25 },
+    ]),
+    -2
+  );
+  // 手势前段先停顿再甩：窗口外的点不能把速度拉平
+  const start = 1_000;
+  const velocity = computeShortsPagerVelocity([
+    { y: 400, t: start },
+    { y: 400, t: start + SHORTS_PAGER_VELOCITY_WINDOW_MS + 50 },
+    { y: 200, t: start + SHORTS_PAGER_VELOCITY_WINDOW_MS + 150 },
+  ]);
+  assert.equal(velocity, -2);
+  // 同一时间戳的重复采样不产生除零
+  assert.equal(
+    computeShortsPagerVelocity([
+      { y: 10, t: 5 },
+      { y: 90, t: 5 },
+    ]),
+    0
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 锚点定位 / 裁剪偏移
+// ---------------------------------------------------------------------------
+
+test("the anchor slide is the one the viewport is closest to", () => {
+  const tops = [0, 900, 1800, 2700];
+  assert.equal(findNearestShortsSlideIndex(tops, 0), 0);
+  assert.equal(findNearestShortsSlideIndex(tops, 449), 0);
+  assert.equal(findNearestShortsSlideIndex(tops, 451), 1);
+  assert.equal(findNearestShortsSlideIndex(tops, 2_700), 3);
+  // 越过末屏（回弹中）仍然锚在末屏
+  assert.equal(findNearestShortsSlideIndex(tops, 9_999), 3);
+  // 正中间平手时取靠前的一条，结果稳定
+  assert.equal(findNearestShortsSlideIndex(tops, 450), 0);
+  // 队列还没有 slide
+  assert.equal(findNearestShortsSlideIndex([], 100), -1);
+});
+
+test("queue trimming carries the in-flight offset into the new coordinates", () => {
+  // 正好贴在吸附点上：没有偏移要还原
+  assert.equal(measureOffsetWithinSlide({ slideTop: 0, viewportHeight: VIEWPORT }), 0);
+  // 切屏动画走到 40%：锚点已经被顶出去 360px，重贴时要原样还回来
+  assert.equal(
+    measureOffsetWithinSlide({ slideTop: -360, viewportHeight: VIEWPORT }),
+    360
+  );
+  assert.equal(
+    measureOffsetWithinSlide({ slideTop: 200, viewportHeight: VIEWPORT }),
+    -200
+  );
+  // 几何异常时夹在一屏内，不会把滚动位置甩飞
+  assert.equal(
+    measureOffsetWithinSlide({ slideTop: -50_000, viewportHeight: VIEWPORT }),
+    VIEWPORT
+  );
+  assert.equal(
+    measureOffsetWithinSlide({ slideTop: 50_000, viewportHeight: VIEWPORT }),
+    -VIEWPORT
+  );
+  assert.equal(measureOffsetWithinSlide({ slideTop: -10, viewportHeight: 0 }), 0);
+});
+
+// ---------------------------------------------------------------------------
+// 启用条件
+// ---------------------------------------------------------------------------
+
+function withWindow<T>(
+  options: { search: string; coarsePointer?: boolean },
+  run: () => T
+): T {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      location: { search: options.search },
+      matchMedia:
+        options.coarsePointer === undefined
+          ? undefined
+          : (query: string) => ({
+              matches:
+                options.coarsePointer === true &&
+                query === "(hover: none) and (pointer: coarse)",
+            }),
+    },
+    configurable: true,
+    writable: true,
+  });
+  try {
+    return run();
+  } finally {
+    if (original) Object.defineProperty(globalThis, "window", original);
+    else delete (globalThis as { window?: unknown }).window;
+  }
+}
+
+test("the touch pager takes over only where touch is the primary input", () => {
+  withWindow({ search: "", coarsePointer: true }, () => {
+    assert.equal(shouldUseShortsTouchPager(false), true);
+  });
+  // 桌面 / 触控本仍然走原生 scroll-snap + 滚轮 + 方向键
+  withWindow({ search: "", coarsePointer: false }, () => {
+    assert.equal(shouldUseShortsTouchPager(false), false);
+  });
+  // 不支持 matchMedia 的环境不能抛错，按不启用处理
+  withWindow({ search: "" }, () => {
+    assert.equal(shouldUseShortsTouchPager(false), false);
+  });
+});
+
+test("iPhone document scrolling keeps its native snapping by default", () => {
+  // 文档滚动是为了让 Safari 工具栏随刷动收起，接管触摸会让它永远展开
+  withWindow({ search: "", coarsePointer: true }, () => {
+    assert.equal(shouldUseShortsTouchPager(true), false);
+  });
+  // 但可以显式强制开启做同机对照
+  withWindow({ search: "?shortsPager=1", coarsePointer: true }, () => {
+    assert.equal(shouldUseShortsTouchPager(true), true);
+  });
+});
+
+test("the touch pager has an explicit escape hatch in both directions", () => {
+  withWindow({ search: "?shortsPager=0", coarsePointer: true }, () => {
+    assert.equal(shouldUseShortsTouchPager(false), false);
+  });
+  // 桌面上强制开启，便于在开发机上验证手势逻辑
+  withWindow({ search: "?shortsPager=1", coarsePointer: false }, () => {
+    assert.equal(shouldUseShortsTouchPager(false), true);
+  });
+  // 无关取值不改变默认判定
+  withWindow({ search: "?shortsPager=yes", coarsePointer: false }, () => {
+    assert.equal(shouldUseShortsTouchPager(false), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 接线：样式与页面
+// ---------------------------------------------------------------------------
+
+const shortsCss = readFileSync(
+  new URL("../src/styles/shorts.css", import.meta.url),
+  "utf8"
+);
+const shortsPageSource = readFileSync(
+  new URL("../src/pages/ShortsPage.tsx", import.meta.url),
+  "utf8"
+);
+
+test("taking over the gesture also turns off the browser's own scrolling", () => {
+  const pagedRule = /^\.shorts-feed\.is-touch-paged \{[\s\S]*?\}/m.exec(shortsCss);
+  assert.ok(pagedRule, ".shorts-feed.is-touch-paged rule should exist");
+  // 手指位移完全由 JS 写进 scrollTop，不能再和浏览器抢同一根手指
+  assert.match(pagedRule[0], /touch-action:\s*none/);
+  // 吸附点会把程序化写入重新对齐，逐帧跟手和落点动画都会被它吃掉
+  assert.match(pagedRule[0], /scroll-snap-type:\s*none/);
+  assert.match(
+    shortsCss,
+    /\.shorts-feed\.is-touch-paged \.shorts-slide \{[\s\S]*?scroll-snap-align:\s*none/
+  );
+});
+
+test("desktop keeps the native snapping path untouched", () => {
+  // 行首锚定：文档滚动模式的覆盖规则里也含有 `.shorts-feed {` 这段文本
+  const baseRule = /^\.shorts-feed \{[\s\S]*?\}/m.exec(shortsCss);
+  assert.ok(baseRule, ".shorts-feed rule should exist");
+  assert.match(baseRule[0], /scroll-snap-type:\s*y mandatory/);
+  assert.doesNotMatch(baseRule[0], /touch-action:\s*none/);
+  const slideRule = /^\.shorts-slide \{[\s\S]*?\}/m.exec(shortsCss);
+  assert.ok(slideRule, ".shorts-slide rule should exist");
+  assert.match(slideRule[0], /scroll-snap-align:\s*start/);
+});
+
+test("the shorts page wires the pager to the same scroll container", () => {
+  assert.match(shortsPageSource, /useShortsSwipePager\(\{/);
+  assert.match(shortsPageSource, /enabled:\s*useTouchPager/);
+  assert.match(shortsPageSource, /containerRef,/);
+  assert.match(shortsPageSource, /usesDocumentScroll:\s*useDocumentScroll/);
+  assert.match(
+    shortsPageSource,
+    /className=\{`shorts-feed\$\{useTouchPager \? " is-touch-paged" : ""\}`\}/
+  );
+  // activeIndex 仍然只由 IntersectionObserver 决定，播放/预载链路不变
+  assert.doesNotMatch(shortsPageSource, /pager[\s\S]{0,40}setActiveIndex/i);
+});
+
+test("the progress bar keeps the whole finger to itself", () => {
+  assert.match(shortsPageSource, /data-shorts-no-swipe=""/);
+  const progressBlock = /className=\{`shorts-slide__progress [\s\S]*?onPointerDown/.exec(
+    shortsPageSource
+  );
+  assert.ok(progressBlock, "progress bar block should exist");
+  assert.match(progressBlock[0], /data-shorts-no-swipe=""/);
+});
+
+test("queue trimming re-anchors without discarding the in-flight offset", () => {
+  assert.match(shortsPageSource, /offsetWithinAnchor: measureOffsetWithinActiveSlide\(/);
+  assert.match(
+    shortsPageSource,
+    /root\.scrollTop = Math\.max\(0, slide\.offsetTop \+ offsetWithinAnchor\)/
+  );
+});

--- a/tests/shortsSwipePager.test.ts
+++ b/tests/shortsSwipePager.test.ts
@@ -12,16 +12,19 @@ import {
   SHORTS_PAGER_VELOCITY_WINDOW_MS,
   computeShortsPagerVelocity,
   findNearestShortsSlideIndex,
+  INITIAL_SHORTS_WHEEL_STATE,
+  SHORTS_PAGER_WHEEL_GESTURE_GAP_MS,
+  SHORTS_PAGER_WHEEL_STEP_PX,
+  SHORTS_WHEEL_LINE_HEIGHT_PX,
   applyShortsPagerEdgeResistance,
+  normalizeShortsWheelDelta,
+  resolveShortsWheelStep,
   measureOffsetWithinSlide,
   parseTranslateY,
   resolveShortsPagerSettleDuration,
   resolveShortsPagerTargetIndex,
 } from "../src/shorts/useShortsSwipePager";
-import {
-  shouldTakeOverShortsScrolling,
-  shouldUseShortsSwipePager,
-} from "../src/shorts/platform";
+import { shouldUseShortsSwipePager } from "../src/shorts/platform";
 
 const VIEWPORT = 900;
 
@@ -407,34 +410,17 @@ test("the gesture controller is mounted on every device, mouse included", () => 
   });
 });
 
-test("only touch devices hand native scrolling over to the pager", () => {
-  // 触屏：手指位移必须完全由我们写，不能和浏览器的滚动预测抢同一根手指。
-  // iPhone 文档滚动模式也一视同仁——它当初被排除是为了保住"Safari 工具栏
-  // 随刷动收起"，而真机截图证明有 scroll-snap 在时工具栏根本收不起来。
-  withWindow({ search: "", coarsePointer: true }, () => {
-    assert.equal(shouldTakeOverShortsScrolling(), true);
-  });
-  // 桌面保留原生吸附：滚轮和方向键本来就好用，没理由替浏览器重写一遍。
-  // 鼠标拖拽是叠加上去的，只写 transform，与吸附不冲突。
-  withWindow({ search: "", coarsePointer: false }, () => {
-    assert.equal(shouldTakeOverShortsScrolling(), false);
-  });
-  withWindow({ search: "" }, () => {
-    assert.equal(shouldTakeOverShortsScrolling(), false);
-  });
-});
-
 test("the pager has an explicit escape hatch in both directions", () => {
   withWindow({ search: "?shortsPager=0", coarsePointer: true }, () => {
-    assert.equal(shouldTakeOverShortsScrolling(), false);
+    assert.equal(shouldUseShortsSwipePager(), false);
   });
-  // 桌面上强制走触屏那套，便于同机对照
+  // 桌面同样接管：滚轮和拖拽都走我们自己的判定与落点
   withWindow({ search: "?shortsPager=1", coarsePointer: false }, () => {
-    assert.equal(shouldTakeOverShortsScrolling(), true);
+    assert.equal(shouldUseShortsSwipePager(), true);
   });
-  // 无关取值不改变默认判定
+  // 无关取值不改变默认判定（默认就是开）
   withWindow({ search: "?shortsPager=yes", coarsePointer: false }, () => {
-    assert.equal(shouldTakeOverShortsScrolling(), false);
+    assert.equal(shouldUseShortsSwipePager(), true);
   });
 });
 
@@ -452,15 +438,15 @@ const shortsPageSource = readFileSync(
 );
 
 test("taking over the gesture also turns off the browser's own scrolling", () => {
-  const pagedRule = /^\.shorts-feed\.is-touch-paged \{[\s\S]*?\}/m.exec(shortsCss);
-  assert.ok(pagedRule, ".shorts-feed.is-touch-paged rule should exist");
+  const pagedRule = /^\.shorts-feed\.is-pager-driven \{[\s\S]*?\}/m.exec(shortsCss);
+  assert.ok(pagedRule, ".shorts-feed.is-pager-driven rule should exist");
   // 手指位移完全由 JS 写进 scrollTop，不能再和浏览器抢同一根手指
   assert.match(pagedRule[0], /touch-action:\s*none/);
   // 吸附点会把程序化写入重新对齐，逐帧跟手和落点动画都会被它吃掉
   assert.match(pagedRule[0], /scroll-snap-type:\s*none/);
   assert.match(
     shortsCss,
-    /\.shorts-feed\.is-touch-paged \.shorts-slide \{[\s\S]*?scroll-snap-align:\s*none/
+    /\.shorts-feed\.is-pager-driven \.shorts-slide \{[\s\S]*?scroll-snap-align:\s*none/
   );
 });
 
@@ -483,7 +469,7 @@ test("the shorts page wires the pager to the same scroll container", () => {
   assert.match(shortsPageSource, /usesDocumentScroll:\s*useDocumentScroll/);
   assert.match(
     shortsPageSource,
-    /className=\{`shorts-feed\$\{takeOverScrolling \? " is-touch-paged" : ""\}`\}/
+    /className=\{`shorts-feed\$\{usePagerGestures \? " is-pager-driven" : ""\}`\}/
   );
   // activeIndex 仍然只由 IntersectionObserver 决定，播放/预载链路不变
   assert.doesNotMatch(shortsPageSource, /pager[\s\S]{0,40}setActiveIndex/i);
@@ -534,5 +520,100 @@ test("queue trimming re-anchors without discarding the in-flight offset", () => 
   assert.doesNotMatch(
     shortsPageSource,
     /slideTop:[\s\S]{0,80}getBoundingClientRect\(\)\.top - base/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 滚轮：一次手势 = 一条视频
+// ---------------------------------------------------------------------------
+
+test("wheel deltas are normalised across the three delta modes", () => {
+  const viewportHeight = VIEWPORT;
+  // 0 = 像素（Chrome 一格约 100）
+  assert.equal(normalizeShortsWheelDelta({ deltaY: 100, deltaMode: 0, viewportHeight }), 100);
+  // 1 = 行（Firefox 一格 3 行）
+  assert.equal(
+    normalizeShortsWheelDelta({ deltaY: 3, deltaMode: 1, viewportHeight }),
+    3 * SHORTS_WHEEL_LINE_HEIGHT_PX
+  );
+  // 2 = 页
+  assert.equal(
+    normalizeShortsWheelDelta({ deltaY: 1, deltaMode: 2, viewportHeight }),
+    VIEWPORT
+  );
+  // 方向保留
+  assert.ok(normalizeShortsWheelDelta({ deltaY: -3, deltaMode: 1, viewportHeight }) < 0);
+  // 视口高度异常时按 1px 兜底；脏输入不产生 NaN
+  assert.equal(normalizeShortsWheelDelta({ deltaY: 2, deltaMode: 2, viewportHeight: 0 }), 2);
+  assert.equal(normalizeShortsWheelDelta({ deltaY: NaN, deltaMode: 0, viewportHeight }), 0);
+});
+
+function wheelRun(events: Array<{ delta: number; at: number }>) {
+  let state = INITIAL_SHORTS_WHEEL_STATE;
+  const steps: number[] = [];
+  for (const event of events) {
+    const decision = resolveShortsWheelStep({
+      state,
+      deltaPx: event.delta,
+      now: event.at,
+    });
+    state = decision.state;
+    if (decision.step !== 0) steps.push(decision.step);
+  }
+  return steps;
+}
+
+test("small deltas accumulate until they add up to a deliberate scroll", () => {
+  // 单个事件不够，累计够了才切
+  assert.deepEqual(wheelRun([{ delta: 15, at: 0 }, { delta: 15, at: 10 }]), []);
+  assert.deepEqual(
+    wheelRun([
+      { delta: 15, at: 0 },
+      { delta: 15, at: 10 },
+      { delta: 15, at: 20 },
+    ]),
+    [1]
+  );
+  // 一格鼠标滚轮本身就够
+  assert.deepEqual(wheelRun([{ delta: SHORTS_PAGER_WHEEL_STEP_PX, at: 0 }]), [1]);
+  assert.deepEqual(wheelRun([{ delta: -SHORTS_PAGER_WHEEL_STEP_PX, at: 0 }]), [-1]);
+});
+
+test("one continuous wheel gesture only ever moves one video", () => {
+  // 触控板一次轻扫：连发大量事件、间隔十几毫秒、尾巴很长
+  const flick = Array.from({ length: 60 }, (_, i) => ({ delta: 30, at: i * 12 }));
+  assert.deepEqual(wheelRun(flick), [1], "惯性尾巴不该继续翻页");
+});
+
+test("a pause between wheel events starts a new gesture", () => {
+  const gap = SHORTS_PAGER_WHEEL_GESTURE_GAP_MS;
+  assert.deepEqual(
+    wheelRun([
+      { delta: 100, at: 0 },
+      { delta: 100, at: gap - 1 }, // 仍属同一次手势
+      { delta: 100, at: gap - 1 + gap }, // 间隔够了 → 新手势
+    ]),
+    [1, 1]
+  );
+  // 累计量也跟着手势重置：跨手势的零碎位移不该攒成一步
+  assert.deepEqual(
+    wheelRun([
+      { delta: 30, at: 0 },
+      { delta: 30, at: 1_000 },
+      { delta: 30, at: 2_000 },
+    ]),
+    []
+  );
+});
+
+test("reversing direction mid-tail does not double back", () => {
+  // 同一次手势内先向下越过阈值，之后无论来什么都不再产生动作
+  assert.deepEqual(
+    wheelRun([
+      { delta: 100, at: 0 },
+      { delta: -100, at: 10 },
+      { delta: -100, at: 20 },
+    ]),
+    [1]
   );
 });

--- a/tests/shortsSwipePager.test.ts
+++ b/tests/shortsSwipePager.test.ts
@@ -3,13 +3,16 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   SHORTS_PAGER_FLICK_MS,
-  SHORTS_PAGER_MAX_SETTLE_MS,
+  SHORTS_PAGER_COMMIT_SETTLE_MS,
+  SHORTS_PAGER_FLICK_VELOCITY_PX_PER_MS,
+  SHORTS_PAGER_MAX_BOUNCE_MS,
   SHORTS_PAGER_MIN_COMMIT_PX,
   SHORTS_PAGER_MIN_SETTLE_MS,
   SHORTS_PAGER_SETTLE_EASING,
   SHORTS_PAGER_VELOCITY_WINDOW_MS,
   computeShortsPagerVelocity,
   findNearestShortsSlideIndex,
+  applyShortsPagerEdgeResistance,
   measureOffsetWithinSlide,
   parseTranslateY,
   resolveShortsPagerSettleDuration,
@@ -22,6 +25,7 @@ const VIEWPORT = 900;
 function release(overrides: {
   deltaY: number;
   elapsedMs: number;
+  velocityPxPerMs?: number;
   anchorIndex?: number;
   slideCount?: number;
   viewportHeight?: number;
@@ -29,6 +33,8 @@ function release(overrides: {
   return resolveShortsPagerTargetIndex({
     deltaY: overrides.deltaY,
     elapsedMs: overrides.elapsedMs,
+    // 默认按"慢拖到位"处理，速度通路单独测
+    velocityPxPerMs: overrides.velocityPxPerMs ?? 0,
     viewportHeight: overrides.viewportHeight ?? VIEWPORT,
     anchorIndex: overrides.anchorIndex ?? 5,
     slideCount: overrides.slideCount ?? 20,
@@ -83,52 +89,74 @@ test("a gesture never skips a video, and never runs off either end", () => {
 // 惯性收尾
 // ---------------------------------------------------------------------------
 
-test("settling matches the release speed so the slide keeps decelerating", () => {
-  // easeOutCubic 起速 = 3 × 距离 / 时长；按抬手速度反解出来的时长满足这条式子
-  const duration = resolveShortsPagerSettleDuration({
-    remainingPx: 300,
-    velocityPxPerMs: 3,
-    viewportHeight: VIEWPORT,
-  });
-  assert.equal(duration, 300);
-  assert.equal((3 * 300) / duration, 3);
+test("mid-range swipes also commit on a fast flick, not just a short press", () => {
+  // 先把手指搭在屏幕上停一会再甩：按压总时长早就超了，但这明显是一次甩动
+  const fast = -SHORTS_PAGER_FLICK_VELOCITY_PX_PER_MS;
+  assert.equal(release({ deltaY: -60, elapsedMs: 900, velocityPxPerMs: fast }), 6);
+  assert.equal(release({ deltaY: 60, elapsedMs: 900, velocityPxPerMs: -fast }), 4);
+  // 速度不够快，仍然回弹
+  assert.equal(
+    release({ deltaY: -60, elapsedMs: 900, velocityPxPerMs: fast * 0.99 }),
+    5
+  );
+  // 速度方向和位移方向相反（滑过头又回带）：不认这条通路
+  assert.equal(release({ deltaY: -60, elapsedMs: 900, velocityPxPerMs: -fast }), 5);
+  // 距离仍然是硬门槛，再快也不能低于 20px
+  assert.equal(release({ deltaY: -19, elapsedMs: 900, velocityPxPerMs: fast * 10 }), 5);
 });
 
-test("settling stays inside a hand-tuned duration range", () => {
-  // 甩得极快：时长压到下限，切屏干脆
+// ---------------------------------------------------------------------------
+// 落点时长
+// ---------------------------------------------------------------------------
+
+test("switching to a neighbouring video always takes the same time", () => {
+  // 「按抬手速度反解时长」在 FLIP 的几何下永远被夹到上限，是写了但从不生效
+  // 的机制。切屏改成固定值——douyin/TikTok 也是固定时长。
+  for (const remainingPx of [200, 600, 870, 1_500]) {
+    assert.equal(
+      resolveShortsPagerSettleDuration({
+        remainingPx,
+        viewportHeight: VIEWPORT,
+        committed: true,
+      }),
+      SHORTS_PAGER_COMMIT_SETTLE_MS
+    );
+  }
+  // 方向不影响时长
   assert.equal(
     resolveShortsPagerSettleDuration({
-      remainingPx: 100,
-      velocityPxPerMs: 20,
+      remainingPx: -870,
       viewportHeight: VIEWPORT,
+      committed: true,
     }),
-    SHORTS_PAGER_MIN_SETTLE_MS
+    SHORTS_PAGER_COMMIT_SETTLE_MS
   );
-  // 慢慢拖了大半屏才松手：按距离取时长，且不超过上限
-  assert.equal(
-    resolveShortsPagerSettleDuration({
-      remainingPx: VIEWPORT,
-      velocityPxPerMs: 0,
-      viewportHeight: VIEWPORT,
-    }),
-    SHORTS_PAGER_MAX_SETTLE_MS
-  );
-  // 速度低于阈值时不按速度反解（否则时长会趋于无穷再被夹到上限）
-  const nearlyStill = resolveShortsPagerSettleDuration({
-    remainingPx: 90,
-    velocityPxPerMs: 0.01,
+});
+
+test("bouncing back scales with distance and is always quicker than a switch", () => {
+  const near = resolveShortsPagerSettleDuration({
+    remainingPx: 30,
     viewportHeight: VIEWPORT,
+    committed: false,
   });
-  assert.ok(nearlyStill > SHORTS_PAGER_MIN_SETTLE_MS);
-  assert.ok(nearlyStill < SHORTS_PAGER_MAX_SETTLE_MS);
-  // 抬手方向和落点方向相反时只取快慢，不取朝向
+  const far = resolveShortsPagerSettleDuration({
+    remainingPx: VIEWPORT / 2,
+    viewportHeight: VIEWPORT,
+    committed: false,
+  });
+  assert.ok(near >= SHORTS_PAGER_MIN_SETTLE_MS);
+  assert.ok(near < far);
+  assert.equal(far, SHORTS_PAGER_MAX_BOUNCE_MS);
+  // 回弹不可能比切屏还慢，否则"没切成"读起来比"切成了"更拖沓
+  assert.ok(far < SHORTS_PAGER_COMMIT_SETTLE_MS);
+  // 超过半屏的回弹（边缘阻尼下可能出现）不会突破上限
   assert.equal(
     resolveShortsPagerSettleDuration({
-      remainingPx: -300,
-      velocityPxPerMs: -3,
+      remainingPx: VIEWPORT * 2,
       viewportHeight: VIEWPORT,
+      committed: false,
     }),
-    300
+    SHORTS_PAGER_MAX_BOUNCE_MS
   );
 });
 
@@ -136,16 +164,16 @@ test("an already-settled position needs no animation at all", () => {
   assert.equal(
     resolveShortsPagerSettleDuration({
       remainingPx: 0,
-      velocityPxPerMs: 5,
       viewportHeight: VIEWPORT,
+      committed: true,
     }),
     0
   );
   assert.equal(
     resolveShortsPagerSettleDuration({
       remainingPx: 0.4,
-      velocityPxPerMs: 0,
       viewportHeight: VIEWPORT,
+      committed: false,
     }),
     0
   );
@@ -154,25 +182,52 @@ test("an already-settled position needs no animation at all", () => {
     Number.isFinite(
       resolveShortsPagerSettleDuration({
         remainingPx: 50,
-        velocityPxPerMs: 0,
         viewportHeight: 0,
+        committed: false,
       })
     )
   );
 });
 
-test("the settle curve is easeOutCubic, matching the duration formula", () => {
-  // 缓动交给 CSS（合成器线程），但它的起始斜率必须和上面按 3×距离/时长
-  // 反解时长的假设对得上，否则动画第一帧接不上手指的速度。
+test("the settle curve keeps its hand-tuned shape", () => {
+  // 缓动交给 CSS（合成器线程）。契约：起速要明显快过手指，终点斜率为 0。
   const control = /^cubic-bezier\(([\d.]+), ([\d.]+), ([\d.]+), ([\d.]+)\)$/.exec(
     SHORTS_PAGER_SETTLE_EASING
   );
   assert.ok(control, "easing should be an explicit cubic-bezier");
   const [x1, y1, , y2] = control.slice(1).map(Number);
-  const initialSlope = y1 / x1;
-  assert.ok(initialSlope > 2.5 && initialSlope < 3.5, `slope ${initialSlope}`);
-  // 收尾必须停住（终点斜率为 0），否则落点会显得"撞上去"
+  assert.ok(y1 / x1 > 2.5, "should leave the finger behind immediately");
+  // 收尾必须停住，否则落点会显得"撞上去"
   assert.equal(y2, 1);
+});
+
+// ---------------------------------------------------------------------------
+// 到头 / 到尾的阻尼
+// ---------------------------------------------------------------------------
+
+test("the ends give a little instead of freezing solid", () => {
+  const bounds = { min: -900, max: 0, viewportHeight: VIEWPORT };
+  // 范围内原样通过
+  assert.equal(applyShortsPagerEdgeResistance({ value: -450, ...bounds }), -450);
+  assert.equal(applyShortsPagerEdgeResistance({ value: 0, ...bounds }), 0);
+  assert.equal(applyShortsPagerEdgeResistance({ value: -900, ...bounds }), -900);
+  // 越界：能推动，但只有原位移的一小部分
+  const pulled = applyShortsPagerEdgeResistance({ value: 100, ...bounds });
+  assert.ok(pulled > 0 && pulled < 100);
+  const pushed = applyShortsPagerEdgeResistance({ value: -1_000, ...bounds });
+  assert.ok(pushed < -900 && pushed > -1_000);
+  // 再怎么拽也有上限，画面不会被拉走大半屏
+  const limit = VIEWPORT * 0.12;
+  assert.equal(applyShortsPagerEdgeResistance({ value: 99_999, ...bounds }), limit);
+  assert.equal(
+    applyShortsPagerEdgeResistance({ value: -99_999, ...bounds }),
+    -900 - limit
+  );
+  // 视口高度为 0 时退化成硬 clamp，不产生 NaN
+  assert.equal(
+    applyShortsPagerEdgeResistance({ value: 500, min: -900, max: 0, viewportHeight: 0 }),
+    0
+  );
 });
 
 test("the live track offset is readable from both inline and computed values", () => {
@@ -330,42 +385,33 @@ function withWindow<T>(
   }
 }
 
-test("the touch pager takes over only where touch is the primary input", () => {
+test("the touch pager takes over wherever touch is the primary input", () => {
+  // iPhone 文档滚动模式也一视同仁：它当初被排除是为了保住"Safari 工具栏
+  // 随刷动收起"，而真机截图证明有 scroll-snap 在时工具栏根本收不起来。
   withWindow({ search: "", coarsePointer: true }, () => {
-    assert.equal(shouldUseShortsTouchPager(false), true);
+    assert.equal(shouldUseShortsTouchPager(), true);
   });
   // 桌面 / 触控本仍然走原生 scroll-snap + 滚轮 + 方向键
   withWindow({ search: "", coarsePointer: false }, () => {
-    assert.equal(shouldUseShortsTouchPager(false), false);
+    assert.equal(shouldUseShortsTouchPager(), false);
   });
   // 不支持 matchMedia 的环境不能抛错，按不启用处理
   withWindow({ search: "" }, () => {
-    assert.equal(shouldUseShortsTouchPager(false), false);
-  });
-});
-
-test("iPhone document scrolling keeps its native snapping by default", () => {
-  // 文档滚动是为了让 Safari 工具栏随刷动收起，接管触摸会让它永远展开
-  withWindow({ search: "", coarsePointer: true }, () => {
-    assert.equal(shouldUseShortsTouchPager(true), false);
-  });
-  // 但可以显式强制开启做同机对照
-  withWindow({ search: "?shortsPager=1", coarsePointer: true }, () => {
-    assert.equal(shouldUseShortsTouchPager(true), true);
+    assert.equal(shouldUseShortsTouchPager(), false);
   });
 });
 
 test("the touch pager has an explicit escape hatch in both directions", () => {
   withWindow({ search: "?shortsPager=0", coarsePointer: true }, () => {
-    assert.equal(shouldUseShortsTouchPager(false), false);
+    assert.equal(shouldUseShortsTouchPager(), false);
   });
   // 桌面上强制开启，便于在开发机上验证手势逻辑
   withWindow({ search: "?shortsPager=1", coarsePointer: false }, () => {
-    assert.equal(shouldUseShortsTouchPager(false), true);
+    assert.equal(shouldUseShortsTouchPager(), true);
   });
   // 无关取值不改变默认判定
   withWindow({ search: "?shortsPager=yes", coarsePointer: false }, () => {
-    assert.equal(shouldUseShortsTouchPager(false), false);
+    assert.equal(shouldUseShortsTouchPager(), false);
   });
 });
 

--- a/tests/shortsSwipePager.test.ts
+++ b/tests/shortsSwipePager.test.ts
@@ -6,13 +6,14 @@ import {
   SHORTS_PAGER_MAX_SETTLE_MS,
   SHORTS_PAGER_MIN_COMMIT_PX,
   SHORTS_PAGER_MIN_SETTLE_MS,
+  SHORTS_PAGER_SETTLE_EASING,
   SHORTS_PAGER_VELOCITY_WINDOW_MS,
   computeShortsPagerVelocity,
   findNearestShortsSlideIndex,
   measureOffsetWithinSlide,
+  parseTranslateY,
   resolveShortsPagerSettleDuration,
   resolveShortsPagerTargetIndex,
-  shortsPagerEase,
 } from "../src/shorts/useShortsSwipePager";
 import { shouldUseShortsTouchPager } from "../src/shorts/platform";
 
@@ -160,21 +161,39 @@ test("an already-settled position needs no animation at all", () => {
   );
 });
 
-test("the settle curve starts fast and eases out", () => {
-  assert.equal(shortsPagerEase(0), 0);
-  assert.equal(shortsPagerEase(1), 1);
-  // 定义域外夹紧，动画被拖长/回拨也不会越过端点
-  assert.equal(shortsPagerEase(-1), 0);
-  assert.equal(shortsPagerEase(2), 1);
-  // 前半程走完大半路程才叫惯性减速
-  assert.ok(shortsPagerEase(0.5) > 0.8);
-  assert.ok(shortsPagerEase(0.25) > 0.5);
-  let previous = -1;
-  for (let step = 0; step <= 10; step += 1) {
-    const value = shortsPagerEase(step / 10);
-    assert.ok(value > previous);
-    previous = value;
-  }
+test("the settle curve is easeOutCubic, matching the duration formula", () => {
+  // 缓动交给 CSS（合成器线程），但它的起始斜率必须和上面按 3×距离/时长
+  // 反解时长的假设对得上，否则动画第一帧接不上手指的速度。
+  const control = /^cubic-bezier\(([\d.]+), ([\d.]+), ([\d.]+), ([\d.]+)\)$/.exec(
+    SHORTS_PAGER_SETTLE_EASING
+  );
+  assert.ok(control, "easing should be an explicit cubic-bezier");
+  const [x1, y1, , y2] = control.slice(1).map(Number);
+  const initialSlope = y1 / x1;
+  assert.ok(initialSlope > 2.5 && initialSlope < 3.5, `slope ${initialSlope}`);
+  // 收尾必须停住（终点斜率为 0），否则落点会显得"撞上去"
+  assert.equal(y2, 1);
+});
+
+test("the live track offset is readable from both inline and computed values", () => {
+  // 我们自己写进去的内联值
+  assert.equal(parseTranslateY("translate3d(0, -240px, 0)"), -240);
+  assert.equal(parseTranslateY("translate3d(0px, 37.5px, 0px)"), 37.5);
+  assert.equal(parseTranslateY("translateY(-12px)"), -12);
+  // 动画进行中只有 computed 能拿到中间值，浏览器给的是矩阵
+  assert.equal(parseTranslateY("matrix(1, 0, 0, 1, 0, -123.5)"), -123.5);
+  assert.equal(
+    parseTranslateY("matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, -88, 0, 1)"),
+    -88
+  );
+  // 静止态与异常输入一律当没有位移，绝不能让 NaN 流进滚动位置
+  assert.equal(parseTranslateY("none"), 0);
+  assert.equal(parseTranslateY(""), 0);
+  assert.equal(parseTranslateY(null), 0);
+  assert.equal(parseTranslateY(undefined), 0);
+  assert.equal(parseTranslateY("matrix(1, 0, 0, 1)"), 0);
+  assert.equal(parseTranslateY("matrix(1, 0, 0, 1, 0, abc)"), 0);
+  assert.equal(parseTranslateY("rotate(20deg)"), 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -231,26 +250,52 @@ test("the anchor slide is the one the viewport is closest to", () => {
 
 test("queue trimming carries the in-flight offset into the new coordinates", () => {
   // 正好贴在吸附点上：没有偏移要还原
-  assert.equal(measureOffsetWithinSlide({ slideTop: 0, viewportHeight: VIEWPORT }), 0);
-  // 切屏动画走到 40%：锚点已经被顶出去 360px，重贴时要原样还回来
   assert.equal(
-    measureOffsetWithinSlide({ slideTop: -360, viewportHeight: VIEWPORT }),
+    measureOffsetWithinSlide({
+      scrollTop: 1_800,
+      slideTop: 1_800,
+      viewportHeight: VIEWPORT,
+    }),
+    0
+  );
+  // 已经往下滑过锚点 360px，重贴时要原样还回来
+  assert.equal(
+    measureOffsetWithinSlide({
+      scrollTop: 2_160,
+      slideTop: 1_800,
+      viewportHeight: VIEWPORT,
+    }),
     360
   );
   assert.equal(
-    measureOffsetWithinSlide({ slideTop: 200, viewportHeight: VIEWPORT }),
+    measureOffsetWithinSlide({
+      scrollTop: 1_600,
+      slideTop: 1_800,
+      viewportHeight: VIEWPORT,
+    }),
     -200
   );
   // 几何异常时夹在一屏内，不会把滚动位置甩飞
   assert.equal(
-    measureOffsetWithinSlide({ slideTop: -50_000, viewportHeight: VIEWPORT }),
+    measureOffsetWithinSlide({
+      scrollTop: 50_000,
+      slideTop: 0,
+      viewportHeight: VIEWPORT,
+    }),
     VIEWPORT
   );
   assert.equal(
-    measureOffsetWithinSlide({ slideTop: 50_000, viewportHeight: VIEWPORT }),
+    measureOffsetWithinSlide({
+      scrollTop: 0,
+      slideTop: 50_000,
+      viewportHeight: VIEWPORT,
+    }),
     -VIEWPORT
   );
-  assert.equal(measureOffsetWithinSlide({ slideTop: -10, viewportHeight: 0 }), 0);
+  assert.equal(
+    measureOffsetWithinSlide({ scrollTop: 10, slideTop: 0, viewportHeight: 0 }),
+    0
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -365,6 +410,7 @@ test("the shorts page wires the pager to the same scroll container", () => {
   assert.match(shortsPageSource, /useShortsSwipePager\(\{/);
   assert.match(shortsPageSource, /enabled:\s*useTouchPager/);
   assert.match(shortsPageSource, /containerRef,/);
+  assert.match(shortsPageSource, /trackRef,/);
   assert.match(shortsPageSource, /usesDocumentScroll:\s*useDocumentScroll/);
   assert.match(
     shortsPageSource,
@@ -372,6 +418,30 @@ test("the shorts page wires the pager to the same scroll container", () => {
   );
   // activeIndex 仍然只由 IntersectionObserver 决定，播放/预载链路不变
   assert.doesNotMatch(shortsPageSource, /pager[\s\S]{0,40}setActiveIndex/i);
+});
+
+test("every slide lives inside the transform track", () => {
+  // 位移写在轨道上而不是逐条 slide 上：一次合成层，切屏动画走合成器线程
+  assert.match(
+    shortsPageSource,
+    /<div className="shorts-feed__track" ref=\{trackRef\}>/
+  );
+  const feedBlock =
+    /<div\s+className=\{`shorts-feed[\s\S]*?<div className="shorts-feed__track"[\s\S]*?items\.map\(/.exec(
+      shortsPageSource
+    );
+  assert.ok(feedBlock, "slides should be rendered inside the track");
+});
+
+test("the track carries no layer hint while the feed is at rest", () => {
+  // 常驻 transform / will-change 会在每个 <video> 祖先上留合成层，
+  // 本页在 iOS 合成路径上踩过坑，静止态必须是干净的普通块
+  const trackRule = /^\.shorts-feed__track \{[\s\S]*?\}/m.exec(shortsCss);
+  assert.ok(trackRule, ".shorts-feed__track rule should exist");
+  assert.match(trackRule[0], /transform:\s*none/);
+  assert.match(trackRule[0], /will-change:\s*auto/);
+  assert.match(trackRule[0], /position:\s*static/);
+  assert.doesNotMatch(trackRule[0], /translate3d/);
 });
 
 test("the progress bar keeps the whole finger to itself", () => {
@@ -385,8 +455,15 @@ test("the progress bar keeps the whole finger to itself", () => {
 
 test("queue trimming re-anchors without discarding the in-flight offset", () => {
   assert.match(shortsPageSource, /offsetWithinAnchor: measureOffsetWithinActiveSlide\(/);
+  // 量和还原必须用同一个参照系（轨道），否则动画进行中的 translateY 会被
+  // 重复计入一次，重贴时画面跳一整屏
   assert.match(
     shortsPageSource,
-    /root\.scrollTop = Math\.max\(0, slide\.offsetTop \+ offsetWithinAnchor\)/
+    /readShortsSlideTopWithinTrack\(slide, track\) \+ pending\.offsetWithinAnchor/
+  );
+  assert.match(shortsPageSource, /slideTop: readShortsSlideTopWithinTrack\(slide, track\)/);
+  assert.doesNotMatch(
+    shortsPageSource,
+    /slideTop:[\s\S]{0,80}getBoundingClientRect\(\)\.top - base/
   );
 });

--- a/tests/shortsSwipePager.test.ts
+++ b/tests/shortsSwipePager.test.ts
@@ -18,7 +18,10 @@ import {
   resolveShortsPagerSettleDuration,
   resolveShortsPagerTargetIndex,
 } from "../src/shorts/useShortsSwipePager";
-import { shouldUseShortsTouchPager } from "../src/shorts/platform";
+import {
+  shouldTakeOverShortsScrolling,
+  shouldUseShortsSwipePager,
+} from "../src/shorts/platform";
 
 const VIEWPORT = 900;
 
@@ -385,33 +388,53 @@ function withWindow<T>(
   }
 }
 
-test("the touch pager takes over wherever touch is the primary input", () => {
-  // iPhone 文档滚动模式也一视同仁：它当初被排除是为了保住"Safari 工具栏
-  // 随刷动收起"，而真机截图证明有 scroll-snap 在时工具栏根本收不起来。
+test("the gesture controller is mounted on every device, mouse included", () => {
+  // 控制器用 pointer 事件，同一套代码同时吃手指和鼠标——桌面拖拽是白送的。
+  // 参考实现 zyronon/douyin 全仓只绑 pointer 事件，没有"移动端一套桌面一套"。
   withWindow({ search: "", coarsePointer: true }, () => {
-    assert.equal(shouldUseShortsTouchPager(), true);
+    assert.equal(shouldUseShortsSwipePager(), true);
   });
-  // 桌面 / 触控本仍然走原生 scroll-snap + 滚轮 + 方向键
   withWindow({ search: "", coarsePointer: false }, () => {
-    assert.equal(shouldUseShortsTouchPager(), false);
+    assert.equal(shouldUseShortsSwipePager(), true);
   });
-  // 不支持 matchMedia 的环境不能抛错，按不启用处理
+  // 不支持 matchMedia 的环境不能抛错
   withWindow({ search: "" }, () => {
-    assert.equal(shouldUseShortsTouchPager(), false);
+    assert.equal(shouldUseShortsSwipePager(), true);
+  });
+  // 唯一的关闭方式是显式回退开关
+  withWindow({ search: "?shortsPager=0", coarsePointer: true }, () => {
+    assert.equal(shouldUseShortsSwipePager(), false);
   });
 });
 
-test("the touch pager has an explicit escape hatch in both directions", () => {
-  withWindow({ search: "?shortsPager=0", coarsePointer: true }, () => {
-    assert.equal(shouldUseShortsTouchPager(), false);
+test("only touch devices hand native scrolling over to the pager", () => {
+  // 触屏：手指位移必须完全由我们写，不能和浏览器的滚动预测抢同一根手指。
+  // iPhone 文档滚动模式也一视同仁——它当初被排除是为了保住"Safari 工具栏
+  // 随刷动收起"，而真机截图证明有 scroll-snap 在时工具栏根本收不起来。
+  withWindow({ search: "", coarsePointer: true }, () => {
+    assert.equal(shouldTakeOverShortsScrolling(), true);
   });
-  // 桌面上强制开启，便于在开发机上验证手势逻辑
+  // 桌面保留原生吸附：滚轮和方向键本来就好用，没理由替浏览器重写一遍。
+  // 鼠标拖拽是叠加上去的，只写 transform，与吸附不冲突。
+  withWindow({ search: "", coarsePointer: false }, () => {
+    assert.equal(shouldTakeOverShortsScrolling(), false);
+  });
+  withWindow({ search: "" }, () => {
+    assert.equal(shouldTakeOverShortsScrolling(), false);
+  });
+});
+
+test("the pager has an explicit escape hatch in both directions", () => {
+  withWindow({ search: "?shortsPager=0", coarsePointer: true }, () => {
+    assert.equal(shouldTakeOverShortsScrolling(), false);
+  });
+  // 桌面上强制走触屏那套，便于同机对照
   withWindow({ search: "?shortsPager=1", coarsePointer: false }, () => {
-    assert.equal(shouldUseShortsTouchPager(), true);
+    assert.equal(shouldTakeOverShortsScrolling(), true);
   });
   // 无关取值不改变默认判定
   withWindow({ search: "?shortsPager=yes", coarsePointer: false }, () => {
-    assert.equal(shouldUseShortsTouchPager(), false);
+    assert.equal(shouldTakeOverShortsScrolling(), false);
   });
 });
 
@@ -454,13 +477,13 @@ test("desktop keeps the native snapping path untouched", () => {
 
 test("the shorts page wires the pager to the same scroll container", () => {
   assert.match(shortsPageSource, /useShortsSwipePager\(\{/);
-  assert.match(shortsPageSource, /enabled:\s*useTouchPager/);
+  assert.match(shortsPageSource, /enabled:\s*usePagerGestures/);
   assert.match(shortsPageSource, /containerRef,/);
   assert.match(shortsPageSource, /trackRef,/);
   assert.match(shortsPageSource, /usesDocumentScroll:\s*useDocumentScroll/);
   assert.match(
     shortsPageSource,
-    /className=\{`shorts-feed\$\{useTouchPager \? " is-touch-paged" : ""\}`\}/
+    /className=\{`shorts-feed\$\{takeOverScrolling \? " is-touch-paged" : ""\}`\}/
   );
   // activeIndex 仍然只由 IntersectionObserver 决定，播放/预载链路不变
   assert.doesNotMatch(shortsPageSource, /pager[\s\S]{0,40}setActiveIndex/i);

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -109,6 +109,8 @@ function createHarness(options?: { slideCount?: number }) {
   const root = {
     scrollTop: 0,
     clientHeight: SLIDE_HEIGHT,
+    // 桌面保留原生吸附，手势期间由 pager 临时摘掉
+    style: { scrollSnapType: "" },
     setPointerCapture: () => undefined,
     releasePointerCapture: () => undefined,
     scrollHeight: slideCount * SLIDE_HEIGHT,
@@ -242,6 +244,10 @@ function createHarness(options?: { slideCount?: number }) {
     },
     get styleFlushes() {
       return styleFlushes;
+    },
+    /** 原生吸附此刻是否被摘掉了。 */
+    get snapSuspended() {
+      return root.style.scrollSnapType === "none";
     },
     /** 落点动画是否在等 transitionend。 */
     get awaitingTransition() {
@@ -1029,4 +1035,87 @@ test("a mouse click that never moves stays a click", () => {
     assert.equal(h.clickGuardActive(), false);
     assert.equal(h.root.scrollTop, 0);
   });
+});
+
+// ---------------------------------------------------------------------------
+// 原生吸附：桌面留着给滚轮用，手势期间必须摘掉
+// ---------------------------------------------------------------------------
+
+test("native snapping is lifted while the gesture drives, and handed back after", () => {
+  withHarness((h) => {
+    // 静止时吸附归样式表管（滚轮和方向键要靠它）
+    assert.equal(h.snapSuspended, false);
+
+    h.pointerDown(200, 700, { pointerType: "mouse" });
+    h.tick(16);
+    // 方向还没定，先别动人家的吸附
+    h.pointerMove(200, 694);
+    assert.equal(h.snapSuspended, false);
+
+    // 判定为纵向、开始接管的那一刻摘掉。不摘的话吸附点会跟着轨道的
+    // transform 一起移动，mandatory 立刻反向拉 scrollTop 补偿，
+    // 净效果正好抵消掉跟手位移——桌面上就是"怎么拖都不动"。
+    h.tick(16);
+    h.pointerMove(200, 680);
+    assert.equal(h.snapSuspended, true);
+
+    h.tick(16);
+    h.pointerMove(200, 600);
+    assert.equal(h.translate, -80);
+    assert.equal(h.snapSuspended, true);
+
+    h.pointerUp(200, 600);
+    // 动画还在跑，吸附点仍然在动，还不能还
+    assert.equal(h.snapSuspended, true);
+
+    h.endTransition();
+    // 落定、transform 清干净之后才还回去，此时我们正停在吸附点上
+    assert.equal(h.snapSuspended, false);
+    assert.equal(h.transformStyle, "");
+  });
+});
+
+test("an interrupted gesture never leaves snapping switched off", () => {
+  withHarness((h) => {
+    // 多指中断
+    h.pointerDown(200, 800);
+    h.tick(16);
+    h.pointerMove(200, 780);
+    h.tick(16);
+    h.pointerMove(200, 500);
+    assert.equal(h.snapSuspended, true);
+    h.secondFingerDownAt([{ clientX: 200, clientY: 500 }]);
+    h.endTransition();
+    assert.equal(h.snapSuspended, false);
+  });
+});
+
+test("横向 seek 与纯点击都不该动到原生吸附", () => {
+  withHarness((h) => {
+    // 判定为横向：手势不归我们管，吸附原样留着
+    h.pointerDown(200, 700);
+    h.tick(16);
+    h.pointerMove(320, 706);
+    h.pointerUp(320, 706);
+    assert.equal(h.snapSuspended, false);
+
+    // 纯点击同理
+    h.pointerDown(200, 700);
+    h.tick(60);
+    h.pointerUp(200, 700);
+    assert.equal(h.snapSuspended, false);
+  });
+});
+
+test("tearing down mid-gesture hands snapping back", () => {
+  const harness = createHarness();
+  harness.pointerDown(200, 800);
+  harness.tick(16);
+  harness.pointerMove(200, 780);
+  harness.tick(16);
+  harness.pointerMove(200, 600);
+  assert.equal(harness.snapSuspended, true);
+  harness.destroy();
+  // 页面走了还把 scroll-snap-type: none 留在 DOM 上，滚轮就永远不吸附了
+  assert.equal(harness.snapSuspended, false);
 });

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -109,8 +109,6 @@ function createHarness(options?: { slideCount?: number }) {
   const root = {
     scrollTop: 0,
     clientHeight: SLIDE_HEIGHT,
-    // 桌面保留原生吸附，手势期间由 pager 临时摘掉
-    style: { scrollSnapType: "" },
     setPointerCapture: () => undefined,
     releasePointerCapture: () => undefined,
     scrollHeight: slideCount * SLIDE_HEIGHT,
@@ -245,10 +243,6 @@ function createHarness(options?: { slideCount?: number }) {
     get styleFlushes() {
       return styleFlushes;
     },
-    /** 原生吸附此刻是否被摘掉了。 */
-    get snapSuspended() {
-      return root.style.scrollSnapType === "none";
-    },
     /** 落点动画是否在等 transitionend。 */
     get awaitingTransition() {
       return (trackListeners.get("transitionend")?.size ?? 0) > 0;
@@ -351,6 +345,18 @@ function createHarness(options?: { slideCount?: number }) {
           clientY: p.clientY,
           target: null,
         });
+      });
+    },
+    /** 一次 wheel 事件。deltaY 正 = 向下滚 = 看下一条。 */
+    wheel(
+      deltaY: number,
+      options?: { deltaMode?: number; ctrlKey?: boolean; target?: unknown }
+    ) {
+      fire("wheel", {
+        deltaY,
+        deltaMode: options?.deltaMode ?? 0,
+        ctrlKey: options?.ctrlKey ?? false,
+        target: options?.target ?? null,
       });
     },
     /**
@@ -1038,84 +1044,124 @@ test("a mouse click that never moves stays a click", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 原生吸附：桌面留着给滚轮用，手势期间必须摘掉
+// 滚轮：一次手势 = 一条视频，和手指同一条落点动画
 // ---------------------------------------------------------------------------
 
-test("native snapping is lifted while the gesture drives, and handed back after", () => {
+test("one wheel notch advances exactly one video", () => {
   withHarness((h) => {
-    // 静止时吸附归样式表管（滚轮和方向键要靠它）
-    assert.equal(h.snapSuspended, false);
-
-    h.pointerDown(200, 700, { pointerType: "mouse" });
-    h.tick(16);
-    // 方向还没定，先别动人家的吸附
-    h.pointerMove(200, 694);
-    assert.equal(h.snapSuspended, false);
-
-    // 判定为纵向、开始接管的那一刻摘掉。不摘的话吸附点会跟着轨道的
-    // transform 一起移动，mandatory 立刻反向拉 scrollTop 补偿，
-    // 净效果正好抵消掉跟手位移——桌面上就是"怎么拖都不动"。
-    h.tick(16);
-    h.pointerMove(200, 680);
-    assert.equal(h.snapSuspended, true);
-
-    h.tick(16);
-    h.pointerMove(200, 600);
-    assert.equal(h.translate, -80);
-    assert.equal(h.snapSuspended, true);
-
-    h.pointerUp(200, 600);
-    // 动画还在跑，吸附点仍然在动，还不能还
-    assert.equal(h.snapSuspended, true);
-
+    h.wheel(100);
+    // 走的是和拖拽完全相同的 FLIP 落点：位置当场提交，再补一段动画
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.settleDurationMs, SHORTS_PAGER_COMMIT_SETTLE_MS);
     h.endTransition();
-    // 落定、transform 清干净之后才还回去，此时我们正停在吸附点上
-    assert.equal(h.snapSuspended, false);
     assert.equal(h.transformStyle, "");
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
   });
 });
 
-test("an interrupted gesture never leaves snapping switched off", () => {
+test("scrolling up with the wheel goes back one video", () => {
   withHarness((h) => {
-    // 多指中断
+    h.root.scrollTop = SLIDE_HEIGHT * 2;
+    h.wheel(-100);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("a trackpad flick is one video, not fifteen", () => {
+  withHarness((h) => {
+    // 触控板一次轻扫：几十个小 delta，间隔十几毫秒，尾巴拖很久
+    h.wheel(8);
+    h.wheel(14);
+    h.wheel(22); // 累计 44，越过阈值 → 切一屏
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+
+    // 之后的惯性尾巴全部被同一次手势吞掉
+    for (let i = 0; i < 40; i += 1) {
+      h.tick(12);
+      h.wheel(30);
+    }
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT, "惯性尾巴不该继续翻页");
+  });
+});
+
+test("a fresh wheel gesture after a pause advances again", () => {
+  withHarness((h) => {
+    h.wheel(100);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    h.endTransition();
+    // 间隔拉开 = 新的一次手势
+    h.tick(200);
+    h.wheel(100);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+  });
+});
+
+test("a nudge too small to be deliberate does nothing", () => {
+  withHarness((h) => {
+    h.wheel(10);
+    h.tick(10);
+    h.wheel(12);
+    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.awaitingTransition, false);
+  });
+});
+
+test("the wheel is line- and page-aware, not just pixel-aware", () => {
+  withHarness((h) => {
+    // Firefox 按行给 delta：3 行 ≈ 48px，够一格
+    h.wheel(3, { deltaMode: 1 });
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+  withHarness((h) => {
+    h.wheel(1, { deltaMode: 2 });
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("the wheel stops at the end of the queue", () => {
+  withHarness(
+    (h) => {
+      h.root.scrollTop = SLIDE_HEIGHT * 2;
+      h.wheel(100);
+      assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+      assert.equal(h.awaitingTransition, false);
+      // 队首同理
+      h.root.scrollTop = 0;
+      h.tick(500);
+      h.wheel(-100);
+      assert.equal(h.root.scrollTop, 0);
+    },
+    { slideCount: 3 }
+  );
+});
+
+test("pinch zoom and the progress bar keep their own wheel", () => {
+  withHarness((h) => {
+    // Ctrl+滚轮是浏览器缩放，不能抢
+    h.wheel(300, { ctrlKey: true });
+    assert.equal(h.root.scrollTop, 0);
+    // 进度条上的滚轮同样不归我们管
+    const progress = {
+      closest: (selector: string) =>
+        selector === "[data-shorts-no-swipe]" ? progress : null,
+    };
+    h.tick(500);
+    h.wheel(300, { target: progress });
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+test("the wheel is ignored while a finger is still down", () => {
+  withHarness((h) => {
     h.pointerDown(200, 800);
     h.tick(16);
     h.pointerMove(200, 780);
     h.tick(16);
-    h.pointerMove(200, 500);
-    assert.equal(h.snapSuspended, true);
-    h.secondFingerDownAt([{ clientX: 200, clientY: 500 }]);
-    h.endTransition();
-    assert.equal(h.snapSuspended, false);
+    h.pointerMove(200, 700);
+    const dragged = h.translate;
+    h.wheel(300);
+    // 手指还在拖，滚轮不能横插一脚改变落点
+    assert.equal(h.translate, dragged);
+    assert.equal(h.root.scrollTop, 0);
   });
-});
-
-test("横向 seek 与纯点击都不该动到原生吸附", () => {
-  withHarness((h) => {
-    // 判定为横向：手势不归我们管，吸附原样留着
-    h.pointerDown(200, 700);
-    h.tick(16);
-    h.pointerMove(320, 706);
-    h.pointerUp(320, 706);
-    assert.equal(h.snapSuspended, false);
-
-    // 纯点击同理
-    h.pointerDown(200, 700);
-    h.tick(60);
-    h.pointerUp(200, 700);
-    assert.equal(h.snapSuspended, false);
-  });
-});
-
-test("tearing down mid-gesture hands snapping back", () => {
-  const harness = createHarness();
-  harness.pointerDown(200, 800);
-  harness.tick(16);
-  harness.pointerMove(200, 780);
-  harness.tick(16);
-  harness.pointerMove(200, 600);
-  assert.equal(harness.snapSuspended, true);
-  harness.destroy();
-  // 页面走了还把 scroll-snap-type: none 留在 DOM 上，滚轮就永远不吸附了
-  assert.equal(harness.snapSuspended, false);
 });

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  SHORTS_PAGER_MAX_SETTLE_MS,
+  SHORTS_PAGER_COMMIT_SETTLE_MS,
+  SHORTS_PAGER_MAX_BOUNCE_MS,
   SHORTS_PAGER_SETTLE_FALLBACK_MS,
   createShortsSwipePager,
   parseTranslateY,
@@ -417,17 +418,27 @@ test("dragging never exposes a third video, however far the finger goes", () => 
     h.touchMove(200, 780);
     h.tick(16);
     h.touchMove(200, -5_000);
-    assert.equal(h.translate, -SLIDE_HEIGHT);
+    // 相邻一屏之外只剩带阻尼的越界余量，第三条永远露不出来
+    const overshoot = -SLIDE_HEIGHT - h.translate;
+    assert.ok(overshoot > 0, "末端应当能推动一点，不是硬冻结");
+    assert.ok(overshoot <= SLIDE_HEIGHT * 0.12 + 0.001, `overshoot ${overshoot}`);
   });
 });
 
-test("the first video does not scroll above the top of the feed", () => {
+test("the first video gives a damped pull instead of freezing solid", () => {
   withHarness((h) => {
     h.touchStart(200, 100);
     h.tick(16);
     h.touchMove(200, 120);
     h.tick(16);
     h.touchMove(200, 5_000);
+    // 手指拉了 4880px，画面只跟出去一屏的 12%——能动，但明确"到头了"
+    assert.equal(h.translate, SLIDE_HEIGHT * 0.12);
+
+    // 松手后弹回原位
+    h.touchEnd(200, 5_000);
+    h.endTransition();
+    assert.equal(h.root.scrollTop, 0);
     assert.equal(h.translate, 0);
   });
 });
@@ -587,17 +598,34 @@ test("a transitionend from a child or another property is ignored", () => {
   });
 });
 
-test("settling never runs longer than the tuned ceiling", () => {
+test("a switch always animates for the same fixed duration", () => {
   withHarness((h) => {
+    // 慢慢拖过 1/3 屏再松手：切屏成立，时长是常数而不是按速度浮动
     h.touchStart(200, 800);
     h.tick(16);
     h.touchMove(200, 780);
     h.tick(3_000);
     h.touchMove(200, 400);
     h.touchEnd(200, 400);
-    assert.ok(h.settleDurationMs <= SHORTS_PAGER_MAX_SETTLE_MS);
-    assert.ok(h.settleDurationMs > 0);
+    assert.equal(h.settleDurationMs, SHORTS_PAGER_COMMIT_SETTLE_MS);
     assert.match(h.transitionSpec, /cubic-bezier/);
+  });
+});
+
+test("bouncing back is quicker than switching", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    h.tick(16);
+    h.touchMove(200, 680);
+    h.tick(600);
+    h.touchMove(200, 620);
+    h.touchEnd(200, 620);
+    // 没构成切屏 → 回弹，必须比切屏干脆
+    assert.ok(h.settleDurationMs > 0);
+    assert.ok(h.settleDurationMs <= SHORTS_PAGER_MAX_BOUNCE_MS);
+    assert.ok(h.settleDurationMs < SHORTS_PAGER_COMMIT_SETTLE_MS);
+    h.endTransition();
+    assert.equal(h.root.scrollTop, 0);
   });
 });
 

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -17,6 +17,8 @@ import {
 // 写回 scrollTop 并清掉 transform。
 
 const SLIDE_HEIGHT = 900;
+const PRIMARY_POINTER = 1;
+const SECOND_POINTER = 2;
 
 type TouchPoint = { clientX: number; clientY: number };
 
@@ -107,6 +109,8 @@ function createHarness(options?: { slideCount?: number }) {
   const root = {
     scrollTop: 0,
     clientHeight: SLIDE_HEIGHT,
+    setPointerCapture: () => undefined,
+    releasePointerCapture: () => undefined,
     scrollHeight: slideCount * SLIDE_HEIGHT,
     getBoundingClientRect: () => ({ top: 0 }),
     querySelectorAll: () => slides,
@@ -194,14 +198,14 @@ function createHarness(options?: { slideCount?: number }) {
     handler({
       cancelable: true,
       preventDefault: () => {
-        if (type === "touchmove") prevented.touchmove += 1;
-        if (type === "touchend") prevented.touchend += 1;
+        if (type === "pointermove") prevented.touchmove += 1;
+        if (type === "pointerup") prevented.touchend += 1;
       },
       ...event,
     });
   }
 
-  function point(x: number, y: number): TouchPoint {
+  function point(x: number, y: number) {
     return { clientX: x, clientY: y };
   }
 
@@ -307,23 +311,56 @@ function createHarness(options?: { slideCount?: number }) {
       });
       return swallowed;
     },
-    touchStart(x: number, y: number, target?: unknown) {
-      fire("touchstart", { touches: [point(x, y)], target: target ?? null });
+    /** 主指针按下。pointerType 默认 touch，测鼠标时显式传 mouse。 */
+    pointerDown(
+      x: number,
+      y: number,
+      options?: { target?: unknown; pointerType?: string; button?: number; id?: number }
+    ) {
+      fire("pointerdown", {
+        pointerId: options?.id ?? PRIMARY_POINTER,
+        pointerType: options?.pointerType ?? "touch",
+        button: options?.button ?? 0,
+        ...point(x, y),
+        target: options?.target ?? null,
+      });
     },
-    touchStartMulti(points: TouchPoint[]) {
-      fire("touchstart", { touches: points, target: null });
+    pointerMove(x: number, y: number, id = PRIMARY_POINTER) {
+      fire("pointermove", { pointerId: id, ...point(x, y) });
     },
-    touchMove(x: number, y: number) {
-      fire("touchmove", { touches: [point(x, y)] });
+    pointerUp(x: number, y: number, id = PRIMARY_POINTER) {
+      fire("pointerup", { pointerId: id, ...point(x, y) });
     },
-    touchMoveMulti(points: TouchPoint[]) {
-      fire("touchmove", { touches: points });
+    pointerCancel(id = PRIMARY_POINTER) {
+      fire("pointercancel", { pointerId: id });
     },
-    touchEnd(x: number, y: number) {
-      fire("touchend", { changedTouches: [point(x, y)], touches: [] });
+    /** 两根手指同时落下。 */
+    pointerDownMulti(points: TouchPoint[]) {
+      points.forEach((p, i) => {
+        fire("pointerdown", {
+          pointerId: PRIMARY_POINTER + i,
+          pointerType: "touch",
+          button: 0,
+          clientX: p.clientX,
+          clientY: p.clientY,
+          target: null,
+        });
+      });
     },
-    touchCancel() {
-      fire("touchcancel", { touches: [] });
+    /**
+     * 拖动途中第二根手指落下。多指判定现在发生在 pointerdown 上（而不是
+     * 像 touch 事件那样靠 touches.length），语义更直接。
+     */
+    secondFingerDownAt(points: TouchPoint[]) {
+      const second = points[points.length - 1];
+      fire("pointerdown", {
+        pointerId: SECOND_POINTER,
+        pointerType: "touch",
+        button: 0,
+        clientX: second.clientX,
+        clientY: second.clientY,
+        target: null,
+      });
     },
     resize() {
       const handler = windowListeners.get("resize");
@@ -356,12 +393,12 @@ function withHarness(
 
 /** 一次干净的快速上滑（切下一条）。 */
 function flickToNext(h: Harness, fromY = 700) {
-  h.touchStart(200, fromY);
+  h.pointerDown(200, fromY);
   h.tick(16);
-  h.touchMove(200, fromY - 30);
+  h.pointerMove(200, fromY - 30);
   h.tick(16);
-  h.touchMove(200, fromY - 60);
-  h.touchEnd(200, fromY - 60);
+  h.pointerMove(200, fromY - 60);
+  h.pointerUp(200, fromY - 60);
 }
 
 // ---------------------------------------------------------------------------
@@ -370,16 +407,16 @@ function flickToNext(h: Harness, fromY = 700) {
 
 test("the feed follows the finger one to one once the direction is settled", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
+    h.pointerDown(200, 700);
     // 未过方向判定阈值前不动，长按倍速 / 点击仍有机会成立
     h.tick(16);
-    h.touchMove(200, 692);
+    h.pointerMove(200, 692);
     assert.equal(h.translate, 0);
     assert.equal(h.prevented.touchmove, 0);
 
     // 判定成立的那一帧把阈值位移归零，画面不会突然跳 12px
     h.tick(16);
-    h.touchMove(200, 680);
+    h.pointerMove(200, 680);
     assert.equal(h.translate, 0);
     assert.equal(h.prevented.touchmove, 1);
     // 接管后才提升合成层，静止时不留
@@ -387,10 +424,10 @@ test("the feed follows the finger one to one once the direction is settled", () 
 
     // 之后逐像素跟手
     h.tick(16);
-    h.touchMove(200, 600);
+    h.pointerMove(200, 600);
     assert.equal(h.translate, -80);
     h.tick(16);
-    h.touchMove(200, 640);
+    h.pointerMove(200, 640);
     assert.equal(h.translate, -40);
 
     // 全程 scrollTop 不动：IntersectionObserver 之外的几何都还在原位
@@ -400,11 +437,11 @@ test("the feed follows the finger one to one once the direction is settled", () 
 
 test("the drag runs on the compositor, never through scrollTop", () => {
   withHarness((h) => {
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(16);
-    h.touchMove(200, 600);
+    h.pointerMove(200, 600);
     assert.equal(h.transformStyle, "translate3d(0, -180px, 0)");
     assert.equal(h.transitionSpec, "none");
     assert.equal(h.root.scrollTop, 0);
@@ -413,11 +450,11 @@ test("the drag runs on the compositor, never through scrollTop", () => {
 
 test("dragging never exposes a third video, however far the finger goes", () => {
   withHarness((h) => {
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(16);
-    h.touchMove(200, -5_000);
+    h.pointerMove(200, -5_000);
     // 相邻一屏之外只剩带阻尼的越界余量，第三条永远露不出来
     const overshoot = -SLIDE_HEIGHT - h.translate;
     assert.ok(overshoot > 0, "末端应当能推动一点，不是硬冻结");
@@ -427,16 +464,16 @@ test("dragging never exposes a third video, however far the finger goes", () => 
 
 test("the first video gives a damped pull instead of freezing solid", () => {
   withHarness((h) => {
-    h.touchStart(200, 100);
+    h.pointerDown(200, 100);
     h.tick(16);
-    h.touchMove(200, 120);
+    h.pointerMove(200, 120);
     h.tick(16);
-    h.touchMove(200, 5_000);
+    h.pointerMove(200, 5_000);
     // 手指拉了 4880px，画面只跟出去一屏的 12%——能动，但明确"到头了"
     assert.equal(h.translate, SLIDE_HEIGHT * 0.12);
 
     // 松手后弹回原位
-    h.touchEnd(200, 5_000);
+    h.pointerUp(200, 5_000);
     h.endTransition();
     assert.equal(h.root.scrollTop, 0);
     assert.equal(h.translate, 0);
@@ -493,13 +530,13 @@ test("the FLIP start value is committed before the transition is armed", () => {
 
 test("a slow short drag bounces back to the current video", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
+    h.pointerDown(200, 700);
     h.tick(16);
-    h.touchMove(200, 680);
+    h.pointerMove(200, 680);
     h.tick(400);
-    h.touchMove(200, 660);
+    h.pointerMove(200, 660);
     assert.equal(h.translate, -20);
-    h.touchEnd(200, 660);
+    h.pointerUp(200, 660);
     h.endTransition();
     assert.equal(h.root.scrollTop, 0);
     assert.equal(h.translate, 0);
@@ -509,12 +546,12 @@ test("a slow short drag bounces back to the current video", () => {
 test("a slow but long drag still switches, exactly like Douyin", () => {
   withHarness((h) => {
     const past = SLIDE_HEIGHT / 3 + 40;
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(2_000);
-    h.touchMove(200, 800 - past);
-    h.touchEnd(200, 800 - past);
+    h.pointerMove(200, 800 - past);
+    h.pointerUp(200, 800 - past);
     h.endTransition();
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
   });
@@ -523,12 +560,12 @@ test("a slow but long drag still switches, exactly like Douyin", () => {
 test("swiping back down returns to the previous video", () => {
   withHarness((h) => {
     h.root.scrollTop = SLIDE_HEIGHT * 2;
-    h.touchStart(200, 200);
+    h.pointerDown(200, 200);
     h.tick(16);
-    h.touchMove(200, 230);
+    h.pointerMove(200, 230);
     h.tick(16);
-    h.touchMove(200, 300);
-    h.touchEnd(200, 300);
+    h.pointerMove(200, 300);
+    h.pointerUp(200, 300);
     h.endTransition();
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
   });
@@ -538,12 +575,12 @@ test("the last video has nowhere to go and simply bounces back", () => {
   withHarness(
     (h) => {
       h.root.scrollTop = SLIDE_HEIGHT * 2;
-      h.touchStart(200, 800);
+      h.pointerDown(200, 800);
       h.tick(16);
-      h.touchMove(200, 780);
+      h.pointerMove(200, 780);
       h.tick(16);
-      h.touchMove(200, 400);
-      h.touchEnd(200, 400);
+      h.pointerMove(200, 400);
+      h.pointerUp(200, 400);
       h.endTransition();
       assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
       assert.equal(h.translate, 0);
@@ -601,12 +638,12 @@ test("a transitionend from a child or another property is ignored", () => {
 test("a switch always animates for the same fixed duration", () => {
   withHarness((h) => {
     // 慢慢拖过 1/3 屏再松手：切屏成立，时长是常数而不是按速度浮动
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(3_000);
-    h.touchMove(200, 400);
-    h.touchEnd(200, 400);
+    h.pointerMove(200, 400);
+    h.pointerUp(200, 400);
     assert.equal(h.settleDurationMs, SHORTS_PAGER_COMMIT_SETTLE_MS);
     assert.match(h.transitionSpec, /cubic-bezier/);
   });
@@ -614,12 +651,12 @@ test("a switch always animates for the same fixed duration", () => {
 
 test("bouncing back is quicker than switching", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
+    h.pointerDown(200, 700);
     h.tick(16);
-    h.touchMove(200, 680);
+    h.pointerMove(200, 680);
     h.tick(600);
-    h.touchMove(200, 620);
-    h.touchEnd(200, 620);
+    h.pointerMove(200, 620);
+    h.pointerUp(200, 620);
     // 没构成切屏 → 回弹，必须比切屏干脆
     assert.ok(h.settleDurationMs > 0);
     assert.ok(h.settleDurationMs <= SHORTS_PAGER_MAX_BOUNCE_MS);
@@ -635,16 +672,16 @@ test("bouncing back is quicker than switching", () => {
 
 test("horizontal seeking on the video keeps the feed completely still", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
+    h.pointerDown(200, 700);
     h.tick(16);
-    h.touchMove(260, 706);
+    h.pointerMove(260, 706);
     h.tick(16);
-    h.touchMove(400, 712);
+    h.pointerMove(400, 712);
     assert.equal(h.translate, 0);
     assert.equal(h.root.scrollTop, 0);
     // 没有接管就不能挡掉默认行为，也不能吞掉这次点击
     assert.equal(h.prevented.touchmove, 0);
-    h.touchEnd(400, 712);
+    h.pointerUp(400, 712);
     assert.equal(h.prevented.touchend, 0);
     assert.equal(h.awaitingTransition, false);
     // 轨道上不能留下任何合成层提示
@@ -654,9 +691,9 @@ test("horizontal seeking on the video keeps the feed completely still", () => {
 
 test("a plain tap stays a tap", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
+    h.pointerDown(200, 700);
     h.tick(80);
-    h.touchEnd(200, 700);
+    h.pointerUp(200, 700);
     assert.equal(h.prevented.touchend, 0);
     assert.equal(h.root.scrollTop, 0);
     assert.equal(h.awaitingTransition, false);
@@ -669,25 +706,25 @@ test("touches that start on the progress bar never page the feed", () => {
       closest: (selector: string) =>
         selector === "[data-shorts-no-swipe]" ? progress : null,
     };
-    h.touchStart(200, 700, progress);
+    h.pointerDown(200, 700, { target: progress });
     h.tick(16);
-    h.touchMove(200, 400);
+    h.pointerMove(200, 400);
     assert.equal(h.translate, 0);
-    h.touchEnd(200, 400);
+    h.pointerUp(200, 400);
     assert.equal(h.prevented.touchend, 0);
   });
 });
 
 test("a second finger hands the gesture back and snaps to the nearest video", () => {
   withHarness((h) => {
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(16);
-    h.touchMove(200, 200);
+    h.pointerMove(200, 200);
     assert.equal(h.translate, -580);
 
-    h.touchMoveMulti([
+    h.secondFingerDownAt([
       { clientX: 200, clientY: 200 },
       { clientX: 260, clientY: 400 },
     ]);
@@ -696,19 +733,19 @@ test("a second finger hands the gesture back and snaps to the nearest video", ()
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
 
     // 交出去之后的移动完全不再影响位移
-    h.touchMove(200, 100);
+    h.pointerMove(200, 100);
     assert.equal(h.translate, 0);
   });
 });
 
 test("a multi-touch start is ignored outright", () => {
   withHarness((h) => {
-    h.touchStartMulti([
+    h.pointerDownMulti([
       { clientX: 100, clientY: 700 },
       { clientX: 300, clientY: 700 },
     ]);
     h.tick(16);
-    h.touchMove(100, 300);
+    h.pointerMove(100, 300);
     assert.equal(h.translate, 0);
     assert.equal(h.root.scrollTop, 0);
   });
@@ -716,13 +753,13 @@ test("a multi-touch start is ignored outright", () => {
 
 test("a cancelled touch settles instead of freezing between videos", () => {
   withHarness((h) => {
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(16);
-    h.touchMove(200, 500);
+    h.pointerMove(200, 500);
     assert.equal(h.translate, -280);
-    h.touchCancel();
+    h.pointerCancel();
     h.endTransition();
     assert.equal(h.root.scrollTop, 0);
     assert.equal(h.translate, 0);
@@ -739,7 +776,7 @@ test("grabbing a flying slide freezes it at the frame it is actually on", () => 
     // 补偿量从 870 动画归零；此刻画面走到一半，还剩 400
     h.setLiveTranslate(400);
 
-    h.touchStart(200, 500);
+    h.pointerDown(200, 500);
     // 内联值被改写成当前这一帧的位置，不会瞬移到终点
     assert.equal(h.translate, 400);
     assert.equal(h.transitionSpec, "none");
@@ -748,10 +785,10 @@ test("grabbing a flying slide freezes it at the frame it is actually on", () => 
     // 接着再甩一把。等效位置 900-400=500 已经更靠近第 1 屏，
     // 所以这一下是从第 1 屏再前进一屏——连甩两次走两屏，不会卡住
     h.tick(16);
-    h.touchMove(200, 470);
+    h.pointerMove(200, 470);
     h.tick(16);
-    h.touchMove(200, 440);
-    h.touchEnd(200, 440);
+    h.pointerMove(200, 440);
+    h.pointerUp(200, 440);
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
     h.endTransition();
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
@@ -764,9 +801,9 @@ test("tapping to stop a flying slide still lands on a video", () => {
     flickToNext(h, 800);
     h.setLiveTranslate(400);
 
-    h.touchStart(200, 500);
+    h.pointerDown(200, 500);
     h.tick(40);
-    h.touchEnd(200, 500);
+    h.pointerUp(200, 500);
     // 这一下只是"停住"，不该被当成单击去暂停视频
     assert.equal(h.prevented.touchend, 2);
     h.endTransition();
@@ -799,17 +836,17 @@ test("a queue trim mid-flight lands on the same video, in new coordinates", () =
 test("a queue trim mid-drag keeps the finger tracking continuous", () => {
   withHarness((h) => {
     h.root.scrollTop = SLIDE_HEIGHT * 3;
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(16);
-    h.touchMove(200, 700);
+    h.pointerMove(200, 700);
     assert.equal(h.translate, -80);
 
     h.trimLeading(2);
     h.tick(16);
     // 位移纯由手指决定，裁剪换坐标系不会把跟手带偏
-    h.touchMove(200, 680);
+    h.pointerMove(200, 680);
     assert.equal(h.translate, -100);
   });
 });
@@ -844,11 +881,11 @@ test("a resize mid-flight drops the stale target and realigns", () => {
 test("a resize during a drag leaves the finger in control", () => {
   withHarness((h) => {
     h.setAnchorIndex(0);
-    h.touchStart(200, 800);
+    h.pointerDown(200, 800);
     h.tick(16);
-    h.touchMove(200, 780);
+    h.pointerMove(200, 780);
     h.tick(16);
-    h.touchMove(200, 600);
+    h.pointerMove(200, 600);
     assert.equal(h.translate, -180);
     h.resize();
     assert.equal(h.translate, -180);
@@ -876,7 +913,7 @@ test("a deliberate tap right after a swipe still reaches the video", () => {
     flickToNext(h);
     assert.equal(h.clickGuardActive(), true);
     // 用户重新按下：守卫立即失效，这一下轻点的 click 能原样穿过去
-    h.touchStart(200, 500);
+    h.pointerDown(200, 500);
     assert.equal(h.clickGuardActive(), false);
     assert.equal(h.fireClick(), false);
   });
@@ -887,9 +924,9 @@ test("once the feed has settled a tap is just a tap again", () => {
     flickToNext(h);
     h.endTransition();
     h.advance(400);
-    h.touchStart(200, 500);
+    h.pointerDown(200, 500);
     h.tick(60);
-    h.touchEnd(200, 500);
+    h.pointerUp(200, 500);
     // 只有那次竖滑挡过默认行为，这一下轻点原样放行
     assert.equal(h.prevented.touchend, 1);
     assert.equal(h.clickGuardActive(), false);
@@ -907,10 +944,10 @@ test("the click guard expires on its own if no click ever arrives", () => {
 
 test("horizontal seeking leaves the click guard alone", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
+    h.pointerDown(200, 700);
     h.tick(16);
-    h.touchMove(280, 706);
-    h.touchEnd(280, 706);
+    h.pointerMove(280, 706);
+    h.pointerUp(280, 706);
     assert.equal(h.clickGuardActive(), false);
   });
 });
@@ -932,11 +969,11 @@ test("tearing down mid-flight leaves a settled position and a clean track", () =
 
 test("tearing down mid-drag writes the finger offset back to scrollTop", () => {
   const harness = createHarness();
-  harness.touchStart(200, 800);
+  harness.pointerDown(200, 800);
   harness.tick(16);
-  harness.touchMove(200, 780);
+  harness.pointerMove(200, 780);
   harness.tick(16);
-  harness.touchMove(200, 600);
+  harness.pointerMove(200, 600);
   assert.equal(harness.translate, -180);
   // 手指还按着就被卸载：跟手位移必须落回 scrollTop，不能凭空丢掉
   harness.destroy();
@@ -950,4 +987,46 @@ test("tearing down the page releases every listener", () => {
   harness.destroy();
   assert.equal(harness.hasListeners(), false);
   assert.equal(harness.awaitingTransition, false);
+});
+
+// ---------------------------------------------------------------------------
+// 鼠标：桌面拖拽走的是同一条状态机
+// ---------------------------------------------------------------------------
+
+test("a mouse drag pages the feed exactly like a finger does", () => {
+  withHarness((h) => {
+    h.pointerDown(200, 700, { pointerType: "mouse" });
+    h.tick(16);
+    h.pointerMove(200, 670);
+    h.tick(16);
+    h.pointerMove(200, 640);
+    // 跟手位移写在轨道上，和触摸一模一样
+    assert.equal(h.translate, -30);
+    h.pointerUp(200, 640);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    h.endTransition();
+    assert.equal(h.transformStyle, "");
+  });
+});
+
+test("only the left mouse button drags", () => {
+  withHarness((h) => {
+    // 右键 / 中键按下不该起手，否则右键菜单和中键粘贴会被当成滑动
+    h.pointerDown(200, 700, { pointerType: "mouse", button: 2 });
+    h.tick(16);
+    h.pointerMove(200, 400);
+    assert.equal(h.translate, 0);
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+test("a mouse click that never moves stays a click", () => {
+  withHarness((h) => {
+    h.pointerDown(200, 700, { pointerType: "mouse" });
+    h.tick(60);
+    h.pointerUp(200, 700);
+    assert.equal(h.prevented.touchend, 0);
+    assert.equal(h.clickGuardActive(), false);
+    assert.equal(h.root.scrollTop, 0);
+  });
 });

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -1,0 +1,673 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SHORTS_PAGER_MAX_SETTLE_MS,
+  createShortsSwipePager,
+} from "../src/shorts/useShortsSwipePager";
+
+// 事件序列级别的回归测试：判定公式已经在 shortsSwipePager.test.ts 里单独覆盖，
+// 这里验证的是把它们串起来的状态机——跟手位移、方向让路、多指中断、点击是否
+// 被吞、动画被队列裁剪平移之后还能不能正确落点。
+
+const SLIDE_HEIGHT = 900;
+
+type TouchPoint = { clientX: number; clientY: number };
+
+type Harness = ReturnType<typeof createHarness>;
+
+function createHarness(options?: { slideCount?: number }) {
+  const slideCount = options?.slideCount ?? 6;
+  let clock = 1_000;
+  let nextFrameId = 1;
+  let nextTimerId = 1;
+  const frames = new Map<number, (now: number) => void>();
+  const timers = new Map<number, { at: number; run: () => void }>();
+  const rootListeners = new Map<string, (event: unknown) => void>();
+  const windowListeners = new Map<string, (event: unknown) => void>();
+
+  const root = {
+    scrollTop: 0,
+    clientHeight: SLIDE_HEIGHT,
+    scrollHeight: slideCount * SLIDE_HEIGHT,
+    getBoundingClientRect: () => ({ top: 0 }),
+    querySelectorAll: () => slides,
+    addEventListener: (type: string, handler: (event: unknown) => void) => {
+      rootListeners.set(type, handler);
+    },
+    removeEventListener: (type: string) => {
+      rootListeners.delete(type);
+    },
+  };
+
+  const slides = Array.from({ length: slideCount }, (_, index) => ({
+    dataset: { index: String(index) },
+    getBoundingClientRect: () => ({
+      top: index * SLIDE_HEIGHT - root.scrollTop,
+    }),
+  }));
+
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalDocument = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "document"
+  );
+  const originalPerformance = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "performance"
+  );
+
+  const fakeWindow = {
+    innerHeight: SLIDE_HEIGHT,
+    scrollY: 0,
+    scrollTo: () => undefined,
+    requestAnimationFrame: (callback: (now: number) => void) => {
+      const id = nextFrameId++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancelAnimationFrame: (id: number) => {
+      frames.delete(id);
+    },
+    setTimeout: (run: () => void, delay: number) => {
+      const id = nextTimerId++;
+      timers.set(id, { at: clock + delay, run });
+      return id;
+    },
+    clearTimeout: (id: number) => {
+      timers.delete(id);
+    },
+    addEventListener: (type: string, handler: (event: unknown) => void) => {
+      windowListeners.set(type, handler);
+    },
+    removeEventListener: (type: string) => {
+      windowListeners.delete(type);
+    },
+  };
+
+  define("window", fakeWindow);
+  define("document", { documentElement: { scrollHeight: root.scrollHeight } });
+  define("performance", { now: () => clock });
+
+  function define(name: string, value: unknown) {
+    Object.defineProperty(globalThis, name, {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  function restore(name: string, descriptor: PropertyDescriptor | undefined) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else delete (globalThis as Record<string, unknown>)[name];
+  }
+
+  let anchorIndex = 0;
+  const destroyPager = createShortsSwipePager({
+    root: root as unknown as HTMLElement,
+    usesDocumentScroll: false,
+    getAnchorSlide: () =>
+      (slides[anchorIndex] ?? null) as unknown as HTMLElement | null,
+  });
+
+  const prevented = { touchmove: 0, touchend: 0 };
+
+  function fire(type: string, event: Record<string, unknown>) {
+    const handler = rootListeners.get(type);
+    assert.ok(handler, `${type} listener should be registered`);
+    handler({
+      cancelable: true,
+      preventDefault: () => {
+        if (type === "touchmove") prevented.touchmove += 1;
+        if (type === "touchend") prevented.touchend += 1;
+      },
+      ...event,
+    });
+  }
+
+  function point(x: number, y: number): TouchPoint {
+    return { clientX: x, clientY: y };
+  }
+
+  return {
+    root,
+    slides,
+    prevented,
+    get clock() {
+      return clock;
+    },
+    get pendingFrames() {
+      return frames.size;
+    },
+    setAnchorIndex(index: number) {
+      anchorIndex = index;
+    },
+    tick(ms: number) {
+      clock += ms;
+    },
+    /** 推进时钟并跑掉这一轮排队的帧与到期定时器。 */
+    advance(ms: number) {
+      clock += ms;
+      const due = [...frames.entries()];
+      frames.clear();
+      for (const [, callback] of due) callback(clock);
+      for (const [id, timer] of [...timers.entries()]) {
+        if (timer.at <= clock) {
+          timers.delete(id);
+          timer.run();
+        }
+      }
+    },
+    /** 一直跑到落点动画结束。 */
+    runSettle(maxFrames = 200) {
+      let guard = 0;
+      while (frames.size > 0 && guard < maxFrames) {
+        this.advance(16);
+        guard += 1;
+      }
+      assert.ok(guard < maxFrames, "settle animation should terminate");
+    },
+    touchStart(x: number, y: number, target?: unknown) {
+      fire("touchstart", { touches: [point(x, y)], target: target ?? null });
+    },
+    touchStartMulti(points: TouchPoint[]) {
+      fire("touchstart", { touches: points, target: null });
+    },
+    touchMove(x: number, y: number) {
+      fire("touchmove", { touches: [point(x, y)] });
+    },
+    touchMoveMulti(points: TouchPoint[]) {
+      fire("touchmove", { touches: points });
+    },
+    touchEnd(x: number, y: number) {
+      fire("touchend", { changedTouches: [point(x, y)], touches: [] });
+    },
+    touchCancel() {
+      fire("touchcancel", { touches: [] });
+    },
+    clickGuardActive() {
+      return rootListeners.has("click");
+    },
+    /** 返回这次 click 有没有被吞掉（吞掉 = 不会传到 slide 的单击处理上）。 */
+    fireClick() {
+      const handler = rootListeners.get("click");
+      if (!handler) return false;
+      let swallowed = false;
+      handler({
+        stopPropagation: () => {
+          swallowed = true;
+        },
+        preventDefault: () => undefined,
+      });
+      return swallowed;
+    },
+    resize() {
+      const handler = windowListeners.get("resize");
+      assert.ok(handler, "resize listener should be registered");
+      handler({});
+    },
+    hasListeners() {
+      return rootListeners.size > 0 || windowListeners.size > 0;
+    },
+    destroy() {
+      destroyPager?.();
+      restore("window", originalWindow);
+      restore("document", originalDocument);
+      restore("performance", originalPerformance);
+    },
+  };
+}
+
+function withHarness(
+  run: (harness: Harness) => void,
+  options?: { slideCount?: number }
+) {
+  const harness = createHarness(options);
+  try {
+    run(harness);
+  } finally {
+    harness.destroy();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 跟手
+// ---------------------------------------------------------------------------
+
+test("the feed follows the finger one to one once the direction is settled", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    // 未过方向判定阈值前不动，长按倍速 / 点击仍有机会成立
+    h.tick(16);
+    h.touchMove(200, 692);
+    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.prevented.touchmove, 0);
+
+    // 判定成立的那一帧把阈值位移归零，画面不会突然跳 12px
+    h.tick(16);
+    h.touchMove(200, 680);
+    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.prevented.touchmove, 1);
+
+    // 之后逐像素跟手
+    h.tick(16);
+    h.touchMove(200, 600);
+    assert.equal(h.root.scrollTop, 80);
+    h.tick(16);
+    h.touchMove(200, 640);
+    assert.equal(h.root.scrollTop, 40);
+  });
+});
+
+test("dragging never exposes a third video, however far the finger goes", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, -5_000);
+    // 最多停在下一屏，不会滑过它
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("the first video does not scroll above the top of the feed", () => {
+  withHarness((h) => {
+    h.touchStart(200, 100);
+    h.tick(16);
+    h.touchMove(200, 120);
+    h.tick(16);
+    h.touchMove(200, 5_000);
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 松手判定
+// ---------------------------------------------------------------------------
+
+test("a quick flick switches to the next video and settles onto it", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    h.tick(16);
+    h.touchMove(200, 670);
+    h.tick(16);
+    h.touchMove(200, 640);
+    h.tick(16);
+    h.touchEnd(200, 640);
+    // 竖滑吞掉浏览器补发的合成 click，否则会被当成单击而暂停视频
+    assert.equal(h.prevented.touchend, 1);
+    h.runSettle();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("a slow short drag bounces back to the current video", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    h.tick(16);
+    h.touchMove(200, 680);
+    h.tick(400);
+    h.touchMove(200, 660);
+    assert.ok(h.root.scrollTop > 0);
+    h.touchEnd(200, 660);
+    h.runSettle();
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+test("a slow but long drag still switches, exactly like Douyin", () => {
+  withHarness((h) => {
+    const past = SLIDE_HEIGHT / 3 + 40;
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(2_000);
+    h.touchMove(200, 800 - past);
+    h.touchEnd(200, 800 - past);
+    h.runSettle();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("swiping back down returns to the previous video", () => {
+  withHarness((h) => {
+    h.root.scrollTop = SLIDE_HEIGHT * 2;
+    h.touchStart(200, 200);
+    h.tick(16);
+    h.touchMove(200, 230);
+    h.tick(16);
+    h.touchMove(200, 300);
+    h.touchEnd(200, 300);
+    h.runSettle();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("the last video has nowhere to go and simply bounces back", () => {
+  withHarness(
+    (h) => {
+      h.root.scrollTop = SLIDE_HEIGHT * 2;
+      h.touchStart(200, 800);
+      h.tick(16);
+      h.touchMove(200, 780);
+      h.tick(16);
+      h.touchMove(200, 400);
+      h.touchEnd(200, 400);
+      h.runSettle();
+      assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+    },
+    { slideCount: 3 }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 手势兼容
+// ---------------------------------------------------------------------------
+
+test("horizontal seeking on the video keeps the feed completely still", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    h.tick(16);
+    h.touchMove(260, 706);
+    h.tick(16);
+    h.touchMove(400, 712);
+    assert.equal(h.root.scrollTop, 0);
+    // 没有接管就不能挡掉默认行为，也不能吞掉这次点击
+    assert.equal(h.prevented.touchmove, 0);
+    h.touchEnd(400, 712);
+    assert.equal(h.prevented.touchend, 0);
+    assert.equal(h.pendingFrames, 0);
+  });
+});
+
+test("a plain tap stays a tap", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    h.tick(80);
+    h.touchEnd(200, 700);
+    assert.equal(h.prevented.touchend, 0);
+    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.pendingFrames, 0);
+  });
+});
+
+test("touches that start on the progress bar never page the feed", () => {
+  withHarness((h) => {
+    const progress = { closest: (selector: string) =>
+      selector === "[data-shorts-no-swipe]" ? progress : null };
+    h.touchStart(200, 700, progress);
+    h.tick(16);
+    h.touchMove(200, 400);
+    assert.equal(h.root.scrollTop, 0);
+    h.touchEnd(200, 400);
+    assert.equal(h.prevented.touchend, 0);
+  });
+});
+
+test("a second finger hands the gesture back and snaps to the nearest video", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 200);
+    // 800→780 是方向判定那一段，被归零；之后的 580px 才是画面位移
+    assert.equal(h.root.scrollTop, 580);
+
+    h.touchMoveMulti([
+      { clientX: 200, clientY: 200 },
+      { clientX: 260, clientY: 400 },
+    ]);
+    h.runSettle();
+    // 600 更靠近下一屏（900）而不是当前屏（0）
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+
+    // 交出去之后的移动完全不再影响滚动
+    h.touchMove(200, 100);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("a multi-touch start is ignored outright", () => {
+  withHarness((h) => {
+    h.touchStartMulti([
+      { clientX: 100, clientY: 700 },
+      { clientX: 300, clientY: 700 },
+    ]);
+    h.tick(16);
+    h.touchMove(100, 300);
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+test("a cancelled touch settles instead of freezing between videos", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 500);
+    assert.equal(h.root.scrollTop, 280);
+    h.touchCancel();
+    h.runSettle();
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 连续滑动 / 打断
+// ---------------------------------------------------------------------------
+
+test("grabbing a flying slide takes over from where it actually is", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 700);
+    h.touchEnd(200, 700);
+    // 只跑一帧，动画停在半路
+    h.advance(16);
+    const midFlight = h.root.scrollTop;
+    assert.ok(midFlight > 0 && midFlight < SLIDE_HEIGHT);
+
+    // 按住：动画立即停下，不再有排队的帧
+    h.touchStart(200, 500);
+    assert.equal(h.pendingFrames, 0);
+    assert.equal(h.root.scrollTop, midFlight);
+
+    // 接着再甩一把，仍然只前进一屏
+    h.tick(16);
+    h.touchMove(200, 470);
+    h.tick(16);
+    h.touchMove(200, 440);
+    h.touchEnd(200, 440);
+    h.runSettle();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+test("tapping to stop a flying slide still lands on a video", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 700);
+    h.touchEnd(200, 700);
+    h.advance(16);
+    const midFlight = h.root.scrollTop;
+    assert.ok(midFlight > 0 && midFlight < SLIDE_HEIGHT);
+
+    h.touchStart(200, 500);
+    h.tick(40);
+    h.touchEnd(200, 500);
+    // 这一下只是"停住"，不该被当成单击去暂停视频
+    assert.equal(h.prevented.touchend, 2);
+    h.runSettle();
+    assert.ok(
+      h.root.scrollTop === 0 || h.root.scrollTop === SLIDE_HEIGHT,
+      "should land on a slide boundary"
+    );
+  });
+});
+
+test("settling never runs longer than the tuned ceiling", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(3_000);
+    h.touchMove(200, 400);
+    h.touchEnd(200, 400);
+    const startedAt = h.clock;
+    h.runSettle();
+    assert.ok(h.clock - startedAt <= SHORTS_PAGER_MAX_SETTLE_MS + 32);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 与队列裁剪 / 视口变化共存
+// ---------------------------------------------------------------------------
+
+test("a queue trim mid-flight shifts the animation instead of derailing it", () => {
+  withHarness((h) => {
+    h.root.scrollTop = SLIDE_HEIGHT * 3;
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 700);
+    h.touchEnd(200, 700);
+    h.advance(16);
+
+    // 裁掉队首 2 条：坐标系整体上移，画面位置不变
+    const shift = SLIDE_HEIGHT * 2;
+    h.root.scrollTop -= shift;
+    h.runSettle();
+    // 落点跟着一起平移，仍然停在原来那条视频的下一条上
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 4 - shift);
+  });
+});
+
+test("a queue trim mid-drag keeps the finger tracking continuous", () => {
+  withHarness((h) => {
+    h.root.scrollTop = SLIDE_HEIGHT * 3;
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 700);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 3 + 80);
+
+    const shift = SLIDE_HEIGHT * 2;
+    h.root.scrollTop -= shift;
+    h.tick(16);
+    // 手指再往上 20px：位置应当是"平移后的位置"再加 20，而不是跳回旧坐标
+    h.touchMove(200, 680);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 3 + 100 - shift);
+  });
+});
+
+test("a viewport resize realigns the active video", () => {
+  withHarness((h) => {
+    h.setAnchorIndex(2);
+    h.root.scrollTop = SLIDE_HEIGHT * 2 + 37;
+    h.resize();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+
+    // 后续的补偿帧和定时器不会把位置再挪走
+    h.advance(16);
+    h.advance(300);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+  });
+});
+
+test("a resize during a drag leaves the finger in control", () => {
+  withHarness((h) => {
+    h.setAnchorIndex(0);
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 600);
+    assert.equal(h.root.scrollTop, 180);
+    h.resize();
+    assert.equal(h.root.scrollTop, 180);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 合成 click 兜底
+// ---------------------------------------------------------------------------
+
+function flickToNext(h: Harness) {
+  h.touchStart(200, 700);
+  h.tick(16);
+  h.touchMove(200, 670);
+  h.tick(16);
+  h.touchMove(200, 640);
+  h.touchEnd(200, 640);
+}
+
+test("the click a vertical swipe leaves behind never pauses the video", () => {
+  withHarness((h) => {
+    assert.equal(h.clickGuardActive(), false);
+    flickToNext(h);
+    assert.equal(h.clickGuardActive(), true);
+    assert.equal(h.fireClick(), true);
+    // 只吞一次，之后立刻恢复
+    assert.equal(h.clickGuardActive(), false);
+  });
+});
+
+test("a deliberate tap right after a swipe still reaches the video", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    assert.equal(h.clickGuardActive(), true);
+    // 用户重新按下：守卫立即失效，这一下轻点的 click 能原样穿过去
+    h.touchStart(200, 500);
+    assert.equal(h.clickGuardActive(), false);
+    assert.equal(h.fireClick(), false);
+  });
+});
+
+test("once the feed has settled a tap is just a tap again", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    h.runSettle();
+    h.touchStart(200, 500);
+    h.tick(60);
+    h.touchEnd(200, 500);
+    // 只有那次竖滑挡过默认行为，这一下轻点原样放行
+    assert.equal(h.prevented.touchend, 1);
+    assert.equal(h.clickGuardActive(), false);
+  });
+});
+
+test("the click guard expires on its own if no click ever arrives", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    assert.equal(h.clickGuardActive(), true);
+    h.advance(400);
+    assert.equal(h.clickGuardActive(), false);
+  });
+});
+
+test("horizontal seeking leaves the click guard alone", () => {
+  withHarness((h) => {
+    h.touchStart(200, 700);
+    h.tick(16);
+    h.touchMove(280, 706);
+    h.touchEnd(280, 706);
+    assert.equal(h.clickGuardActive(), false);
+  });
+});
+
+test("tearing down the page releases every listener", () => {
+  const harness = createHarness();
+  assert.ok(harness.hasListeners());
+  harness.destroy();
+  assert.equal(harness.hasListeners(), false);
+});

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -347,6 +347,12 @@ function createHarness(options?: { slideCount?: number }) {
         });
       });
     },
+    /** 容器发出一次 scroll 事件（外力挪动了滚动位置）。 */
+    scroll() {
+      const handler = rootListeners.get("scroll");
+      assert.ok(handler, "scroll listener should be registered");
+      handler({});
+    },
     /** 一次 wheel 事件。deltaY 正 = 向下滚 = 看下一条。 */
     wheel(
       deltaY: number,
@@ -1135,19 +1141,76 @@ test("the wheel stops at the end of the queue", () => {
   );
 });
 
-test("pinch zoom and the progress bar keep their own wheel", () => {
+test("pinch zoom keeps its own wheel, everything else is taken over", () => {
   withHarness((h) => {
     // Ctrl+滚轮是浏览器缩放，不能抢
     h.wheel(300, { ctrlKey: true });
     assert.equal(h.root.scrollTop, 0);
-    // 进度条上的滚轮同样不归我们管
+
+    // 进度条上的滚轮**必须**被接管。data-shorts-no-swipe 是给拖拽用的
+    // （进度条要吃掉整根手指），滚轮不该认它——漏掉一处 preventDefault，
+    // 原生滚动就从那里溜出去，而吸附已经关了，画面会停在两条视频中间。
     const progress = {
       closest: (selector: string) =>
         selector === "[data-shorts-no-swipe]" ? progress : null,
     };
     h.tick(500);
     h.wheel(300, { target: progress });
-    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 兜底不变量：静止时绝不停在两条视频之间
+// ---------------------------------------------------------------------------
+
+test("an unexplained scroll drift corrects itself once things go quiet", () => {
+  withHarness((h) => {
+    // 模拟浏览器滚动锚定 / 漏掉的原生滚动：位置被外力挪到了半路
+    h.root.scrollTop = SLIDE_HEIGHT + 137;
+    h.scroll();
+    // 立刻不动手，先等滚动真正停下来
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT + 137);
+    h.advance(200);
+    // 就近吸附回去
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    h.endTransition();
+    assert.equal(h.transformStyle, "");
+  });
+});
+
+test("a couple of pixels of rounding is not worth a correction", () => {
+  withHarness((h) => {
+    h.root.scrollTop = SLIDE_HEIGHT + 1;
+    h.scroll();
+    h.advance(200);
+    // 亚像素取整不该触发一次动画
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT + 1);
+    assert.equal(h.awaitingTransition, false);
+  });
+});
+
+test("the guard never fights an animation or a finger", () => {
+  withHarness((h) => {
+    // 落点动画进行中：scrollTop 本来就已经在目标上，守卫不能插手
+    h.wheel(100);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    h.scroll();
+    h.advance(200);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+
+    // 手指拖动中：位移记在 transform 上，scrollTop 不动，同样不能插手
+    h.endTransition();
+    h.tick(500);
+    h.pointerDown(200, 800);
+    h.tick(16);
+    h.pointerMove(200, 780);
+    h.tick(16);
+    h.pointerMove(200, 600);
+    const dragged = h.translate;
+    h.scroll();
+    h.advance(200);
+    assert.equal(h.translate, dragged);
   });
 });
 

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -2,12 +2,18 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   SHORTS_PAGER_MAX_SETTLE_MS,
+  SHORTS_PAGER_SETTLE_FALLBACK_MS,
   createShortsSwipePager,
+  parseTranslateY,
 } from "../src/shorts/useShortsSwipePager";
 
 // 事件序列级别的回归测试：判定公式已经在 shortsSwipePager.test.ts 里单独覆盖，
-// 这里验证的是把它们串起来的状态机——跟手位移、方向让路、多指中断、点击是否
-// 被吞、动画被队列裁剪平移之后还能不能正确落点。
+// 这里验证把它们串起来的状态机——跟手位移、方向让路、多指中断、点击是否被吞，
+// 以及 transform → scrollTop 的落点提交在各种打断下还对不对。
+//
+// 坐标模型（与实现一致）：手势 / 动画进行中 scrollTop 不动，位移全部记在轨道
+// 的 translateY 上；等效滚动位置恒为 scrollTop - translate。落点提交时把位移
+// 写回 scrollTop 并清掉 transform。
 
 const SLIDE_HEIGHT = 900;
 
@@ -24,6 +30,78 @@ function createHarness(options?: { slideCount?: number }) {
   const timers = new Map<number, { at: number; run: () => void }>();
   const rootListeners = new Map<string, (event: unknown) => void>();
   const windowListeners = new Map<string, (event: unknown) => void>();
+  const trackListeners = new Map<string, Set<(event: unknown) => void>>();
+
+  /**
+   * 动画进行中，内联 transform 记的是终点值，屏幕上是中间值。
+   * override 非 null 时代表"transition 正在跑"，几何按它算。
+   */
+  let liveTranslateOverride: number | null = null;
+
+  const trackStyle = {
+    _transform: "",
+    _transition: "",
+    _willChange: "",
+    get transform() {
+      return this._transform;
+    },
+    set transform(value: string) {
+      this._transform = value;
+      transformWrites.push(value);
+    },
+    get transition() {
+      return this._transition;
+    },
+    set transition(value: string) {
+      this._transition = value;
+      // transition 关掉时屏幕上立刻等于内联值，不再有中间态。
+      if (value === "" || value === "none") liveTranslateOverride = null;
+    },
+    get willChange() {
+      return this._willChange;
+    },
+    set willChange(value: string) {
+      this._willChange = value;
+    },
+  };
+
+  const inlineTranslate = () => parseTranslateY(trackStyle.transform);
+  const visualTranslate = () => liveTranslateOverride ?? inlineTranslate();
+
+  /** 每次写入 transform 的历史，用来验证 FLIP 的补偿值确实落到了样式上。 */
+  const transformWrites: string[] = [];
+
+  let styleFlushes = 0;
+
+  const track = {
+    style: trackStyle,
+    getBoundingClientRect: () => {
+      // 实现只在 FLIP 里读轨道自身的 rect，用来强制一次样式提交
+      styleFlushes += 1;
+      return { top: -root.scrollTop + visualTranslate() };
+    },
+    addEventListener: (type: string, handler: (event: unknown) => void) => {
+      if (!trackListeners.has(type)) trackListeners.set(type, new Set());
+      trackListeners.get(type)!.add(handler);
+    },
+    removeEventListener: (type: string, handler: (event: unknown) => void) => {
+      trackListeners.get(type)?.delete(handler);
+    },
+  };
+
+  const slides: Array<{
+    dataset: { index: string };
+    getBoundingClientRect: () => { top: number };
+  }> = [];
+  for (let index = 0; index < slideCount; index += 1) {
+    const slide = {
+      dataset: { index: String(index) },
+      getBoundingClientRect: () => ({
+        top: slides.indexOf(slide) * SLIDE_HEIGHT - root.scrollTop + visualTranslate(),
+      }),
+    };
+    slides.push(slide);
+  }
 
   const root = {
     scrollTop: 0,
@@ -39,27 +117,37 @@ function createHarness(options?: { slideCount?: number }) {
     },
   };
 
-  const slides = Array.from({ length: slideCount }, (_, index) => ({
-    dataset: { index: String(index) },
-    getBoundingClientRect: () => ({
-      top: index * SLIDE_HEIGHT - root.scrollTop,
-    }),
-  }));
-
   const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
-  const originalDocument = Object.getOwnPropertyDescriptor(
-    globalThis,
-    "document"
-  );
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
   const originalPerformance = Object.getOwnPropertyDescriptor(
     globalThis,
     "performance"
   );
 
+  function define(name: string, value: unknown) {
+    Object.defineProperty(globalThis, name, {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  function restore(name: string, descriptor: PropertyDescriptor | undefined) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else delete (globalThis as Record<string, unknown>)[name];
+  }
+
   const fakeWindow = {
     innerHeight: SLIDE_HEIGHT,
     scrollY: 0,
     scrollTo: () => undefined,
+    // 浏览器给的是矩阵形式，实现必须认得
+    getComputedStyle: () => ({
+      transform:
+        liveTranslateOverride !== null
+          ? `matrix(1, 0, 0, 1, 0, ${liveTranslateOverride})`
+          : trackStyle.transform || "none",
+    }),
     requestAnimationFrame: (callback: (now: number) => void) => {
       const id = nextFrameId++;
       frames.set(id, callback);
@@ -88,22 +176,10 @@ function createHarness(options?: { slideCount?: number }) {
   define("document", { documentElement: { scrollHeight: root.scrollHeight } });
   define("performance", { now: () => clock });
 
-  function define(name: string, value: unknown) {
-    Object.defineProperty(globalThis, name, {
-      value,
-      configurable: true,
-      writable: true,
-    });
-  }
-
-  function restore(name: string, descriptor: PropertyDescriptor | undefined) {
-    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
-    else delete (globalThis as Record<string, unknown>)[name];
-  }
-
   let anchorIndex = 0;
   const destroyPager = createShortsSwipePager({
     root: root as unknown as HTMLElement,
+    track: track as unknown as HTMLElement,
     usesDocumentScroll: false,
     getAnchorSlide: () =>
       (slides[anchorIndex] ?? null) as unknown as HTMLElement | null,
@@ -130,6 +206,7 @@ function createHarness(options?: { slideCount?: number }) {
 
   return {
     root,
+    track,
     slides,
     prevented,
     get clock() {
@@ -138,13 +215,70 @@ function createHarness(options?: { slideCount?: number }) {
     get pendingFrames() {
       return frames.size;
     },
+    /** 内联 transform 上的位移（动画进行中是终点值）。 */
+    get translate() {
+      return inlineTranslate();
+    },
+    /** 屏幕上此刻的位移。 */
+    get visualTranslate() {
+      return visualTranslate();
+    },
+    get transitionSpec() {
+      return trackStyle.transition;
+    },
+    get willChange() {
+      return trackStyle.willChange;
+    },
+    get transformStyle() {
+      return trackStyle.transform;
+    },
+    get transformWrites() {
+      return [...transformWrites];
+    },
+    get styleFlushes() {
+      return styleFlushes;
+    },
+    /** 落点动画是否在等 transitionend。 */
+    get awaitingTransition() {
+      return (trackListeners.get("transitionend")?.size ?? 0) > 0;
+    },
+    /** 从 `transform 300ms ...` 里取出时长。 */
+    get settleDurationMs() {
+      const match = /transform (\d+)ms/.exec(trackStyle.transition);
+      return match ? Number(match[1]) : 0;
+    },
     setAnchorIndex(index: number) {
       anchorIndex = index;
+    },
+    /** 模拟动画跑到中途：屏幕上的位移停在 px。 */
+    setLiveTranslate(px: number) {
+      liveTranslateOverride = px;
+    },
+    /** 模拟 transition 正常跑完。 */
+    endTransition(propertyName = "transform") {
+      liveTranslateOverride = null;
+      const handlers = [...(trackListeners.get("transitionend") ?? [])];
+      for (const handler of handlers) handler({ target: track, propertyName });
+    },
+    /** 模拟一个从子元素冒泡上来、或别的属性的 transitionend。 */
+    fireForeignTransitionEnd(options: { fromChild?: boolean; property?: string }) {
+      const handlers = [...(trackListeners.get("transitionend") ?? [])];
+      for (const handler of handlers) {
+        handler({
+          target: options.fromChild ? slides[0] : track,
+          propertyName: options.property ?? "transform",
+        });
+      }
+    },
+    /** 模拟长会话队列裁剪：砍掉队首 n 条，并按实现的方式重贴 scrollTop。 */
+    trimLeading(count: number) {
+      slides.splice(0, count);
+      root.scrollHeight -= count * SLIDE_HEIGHT;
+      root.scrollTop -= count * SLIDE_HEIGHT;
     },
     tick(ms: number) {
       clock += ms;
     },
-    /** 推进时钟并跑掉这一轮排队的帧与到期定时器。 */
     advance(ms: number) {
       clock += ms;
       const due = [...frames.entries()];
@@ -157,14 +291,20 @@ function createHarness(options?: { slideCount?: number }) {
         }
       }
     },
-    /** 一直跑到落点动画结束。 */
-    runSettle(maxFrames = 200) {
-      let guard = 0;
-      while (frames.size > 0 && guard < maxFrames) {
-        this.advance(16);
-        guard += 1;
-      }
-      assert.ok(guard < maxFrames, "settle animation should terminate");
+    clickGuardActive() {
+      return rootListeners.has("click");
+    },
+    fireClick() {
+      const handler = rootListeners.get("click");
+      if (!handler) return false;
+      let swallowed = false;
+      handler({
+        stopPropagation: () => {
+          swallowed = true;
+        },
+        preventDefault: () => undefined,
+      });
+      return swallowed;
     },
     touchStart(x: number, y: number, target?: unknown) {
       fire("touchstart", { touches: [point(x, y)], target: target ?? null });
@@ -183,22 +323,6 @@ function createHarness(options?: { slideCount?: number }) {
     },
     touchCancel() {
       fire("touchcancel", { touches: [] });
-    },
-    clickGuardActive() {
-      return rootListeners.has("click");
-    },
-    /** 返回这次 click 有没有被吞掉（吞掉 = 不会传到 slide 的单击处理上）。 */
-    fireClick() {
-      const handler = rootListeners.get("click");
-      if (!handler) return false;
-      let swallowed = false;
-      handler({
-        stopPropagation: () => {
-          swallowed = true;
-        },
-        preventDefault: () => undefined,
-      });
-      return swallowed;
     },
     resize() {
       const handler = windowListeners.get("resize");
@@ -229,8 +353,18 @@ function withHarness(
   }
 }
 
+/** 一次干净的快速上滑（切下一条）。 */
+function flickToNext(h: Harness, fromY = 700) {
+  h.touchStart(200, fromY);
+  h.tick(16);
+  h.touchMove(200, fromY - 30);
+  h.tick(16);
+  h.touchMove(200, fromY - 60);
+  h.touchEnd(200, fromY - 60);
+}
+
 // ---------------------------------------------------------------------------
-// 跟手
+// 跟手：位移记在轨道上，scrollTop 全程不动
 // ---------------------------------------------------------------------------
 
 test("the feed follows the finger one to one once the direction is settled", () => {
@@ -239,22 +373,40 @@ test("the feed follows the finger one to one once the direction is settled", () 
     // 未过方向判定阈值前不动，长按倍速 / 点击仍有机会成立
     h.tick(16);
     h.touchMove(200, 692);
-    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
     assert.equal(h.prevented.touchmove, 0);
 
     // 判定成立的那一帧把阈值位移归零，画面不会突然跳 12px
     h.tick(16);
     h.touchMove(200, 680);
-    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
     assert.equal(h.prevented.touchmove, 1);
+    // 接管后才提升合成层，静止时不留
+    assert.equal(h.willChange, "transform");
 
     // 之后逐像素跟手
     h.tick(16);
     h.touchMove(200, 600);
-    assert.equal(h.root.scrollTop, 80);
+    assert.equal(h.translate, -80);
     h.tick(16);
     h.touchMove(200, 640);
-    assert.equal(h.root.scrollTop, 40);
+    assert.equal(h.translate, -40);
+
+    // 全程 scrollTop 不动：IntersectionObserver 之外的几何都还在原位
+    assert.equal(h.root.scrollTop, 0);
+  });
+});
+
+test("the drag runs on the compositor, never through scrollTop", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(16);
+    h.touchMove(200, 600);
+    assert.equal(h.transformStyle, "translate3d(0, -180px, 0)");
+    assert.equal(h.transitionSpec, "none");
+    assert.equal(h.root.scrollTop, 0);
   });
 });
 
@@ -265,8 +417,7 @@ test("dragging never exposes a third video, however far the finger goes", () => 
     h.touchMove(200, 780);
     h.tick(16);
     h.touchMove(200, -5_000);
-    // 最多停在下一屏，不会滑过它
-    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.translate, -SLIDE_HEIGHT);
   });
 });
 
@@ -277,27 +428,55 @@ test("the first video does not scroll above the top of the feed", () => {
     h.touchMove(200, 120);
     h.tick(16);
     h.touchMove(200, 5_000);
-    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// 松手判定
+// 松手判定与落点提交
 // ---------------------------------------------------------------------------
 
-test("a quick flick switches to the next video and settles onto it", () => {
+test("a quick flick commits the position immediately, then animates into it", () => {
   withHarness((h) => {
-    h.touchStart(200, 700);
-    h.tick(16);
-    h.touchMove(200, 670);
-    h.tick(16);
-    h.touchMove(200, 640);
-    h.tick(16);
-    h.touchEnd(200, 640);
+    flickToNext(h);
     // 竖滑吞掉浏览器补发的合成 click，否则会被当成单击而暂停视频
     assert.equal(h.prevented.touchend, 1);
-    h.runSettle();
+
+    // 关键：位置在松手当场就落到 scrollTop 上了，IntersectionObserver
+    // 立刻能判出新的活跃屏，下一条视频不必等动画走完才起播
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+
+    // 画面靠轨道上的反向补偿保持连续，再动画归零
+    const writes = h.transformWrites;
+    // 松手时手指已经把画面拉走 30px，补偿量 = 30 + 900
+    assert.ok(
+      writes.includes("translate3d(0, 870px, 0)"),
+      `FLIP compensation missing: ${writes.join(" | ")}`
+    );
+    assert.equal(writes[writes.length - 1], "translate3d(0, 0px, 0)");
+    assert.ok(h.awaitingTransition);
+    assert.equal(h.willChange, "transform");
+    assert.match(h.transitionSpec, /^transform \d+ms cubic-bezier/);
+
+    h.endTransition();
+    // 收尾只是摘掉合成层提示，位置早就定了
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.transformStyle, "");
+    assert.equal(h.willChange, "");
+    assert.equal(h.awaitingTransition, false);
+  });
+});
+
+test("the FLIP start value is committed before the transition is armed", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    const writes = h.transformWrites;
+    const start = writes.indexOf("translate3d(0, 870px, 0)");
+    const end = writes.lastIndexOf("translate3d(0, 0px, 0)");
+    // 起点必须先以无过渡的方式写下并强制提交，否则浏览器会把两次写入
+    // 合并，直接跳到终点而根本不产生动画
+    assert.ok(start >= 0 && end > start, writes.join(" | "));
+    assert.ok(h.styleFlushes > 0, "start value must be flushed");
   });
 });
 
@@ -308,10 +487,11 @@ test("a slow short drag bounces back to the current video", () => {
     h.touchMove(200, 680);
     h.tick(400);
     h.touchMove(200, 660);
-    assert.ok(h.root.scrollTop > 0);
+    assert.equal(h.translate, -20);
     h.touchEnd(200, 660);
-    h.runSettle();
+    h.endTransition();
     assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
   });
 });
 
@@ -324,7 +504,7 @@ test("a slow but long drag still switches, exactly like Douyin", () => {
     h.tick(2_000);
     h.touchMove(200, 800 - past);
     h.touchEnd(200, 800 - past);
-    h.runSettle();
+    h.endTransition();
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
   });
 });
@@ -338,7 +518,7 @@ test("swiping back down returns to the previous video", () => {
     h.tick(16);
     h.touchMove(200, 300);
     h.touchEnd(200, 300);
-    h.runSettle();
+    h.endTransition();
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
   });
 });
@@ -353,11 +533,72 @@ test("the last video has nowhere to go and simply bounces back", () => {
       h.tick(16);
       h.touchMove(200, 400);
       h.touchEnd(200, 400);
-      h.runSettle();
+      h.endTransition();
       assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+      assert.equal(h.translate, 0);
     },
     { slideCount: 3 }
   );
+});
+
+test("a lost transitionend cannot strand the feed between two videos", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    const duration = h.settleDurationMs;
+    assert.ok(duration > 0);
+    // 标签页切走 / 合成器丢事件：transitionend 永远不来。位置本来就已经
+    // 落定，这里只验证兜底定时器把合成层提示也收干净了
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    h.advance(duration + SHORTS_PAGER_SETTLE_FALLBACK_MS);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.transformStyle, "");
+    assert.equal(h.willChange, "");
+    assert.equal(h.awaitingTransition, false);
+  });
+});
+
+test("the fallback timer firing after a real transitionend changes nothing", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    const duration = h.settleDurationMs;
+    h.endTransition();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    // 兜底定时器随后到期，不能把画面又推走一屏
+    h.advance(duration + SHORTS_PAGER_SETTLE_FALLBACK_MS);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.transformStyle, "");
+  });
+});
+
+test("a transitionend from a child or another property is ignored", () => {
+  withHarness((h) => {
+    flickToNext(h);
+    // 子元素冒泡上来的、或别的属性的 transitionend 不能把动画提前掐掉——
+    // 那会让画面在半路瞬移到落点
+    h.fireForeignTransitionEnd({ fromChild: true });
+    assert.ok(h.awaitingTransition, "child bubble must not end the motion");
+    assert.equal(h.willChange, "transform");
+    h.fireForeignTransitionEnd({ property: "opacity" });
+    assert.ok(h.awaitingTransition, "other properties must not end the motion");
+
+    h.endTransition();
+    assert.equal(h.awaitingTransition, false);
+    assert.equal(h.willChange, "");
+  });
+});
+
+test("settling never runs longer than the tuned ceiling", () => {
+  withHarness((h) => {
+    h.touchStart(200, 800);
+    h.tick(16);
+    h.touchMove(200, 780);
+    h.tick(3_000);
+    h.touchMove(200, 400);
+    h.touchEnd(200, 400);
+    assert.ok(h.settleDurationMs <= SHORTS_PAGER_MAX_SETTLE_MS);
+    assert.ok(h.settleDurationMs > 0);
+    assert.match(h.transitionSpec, /cubic-bezier/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -371,12 +612,15 @@ test("horizontal seeking on the video keeps the feed completely still", () => {
     h.touchMove(260, 706);
     h.tick(16);
     h.touchMove(400, 712);
+    assert.equal(h.translate, 0);
     assert.equal(h.root.scrollTop, 0);
     // 没有接管就不能挡掉默认行为，也不能吞掉这次点击
     assert.equal(h.prevented.touchmove, 0);
     h.touchEnd(400, 712);
     assert.equal(h.prevented.touchend, 0);
-    assert.equal(h.pendingFrames, 0);
+    assert.equal(h.awaitingTransition, false);
+    // 轨道上不能留下任何合成层提示
+    assert.equal(h.willChange, "");
   });
 });
 
@@ -387,18 +631,20 @@ test("a plain tap stays a tap", () => {
     h.touchEnd(200, 700);
     assert.equal(h.prevented.touchend, 0);
     assert.equal(h.root.scrollTop, 0);
-    assert.equal(h.pendingFrames, 0);
+    assert.equal(h.awaitingTransition, false);
   });
 });
 
 test("touches that start on the progress bar never page the feed", () => {
   withHarness((h) => {
-    const progress = { closest: (selector: string) =>
-      selector === "[data-shorts-no-swipe]" ? progress : null };
+    const progress = {
+      closest: (selector: string) =>
+        selector === "[data-shorts-no-swipe]" ? progress : null,
+    };
     h.touchStart(200, 700, progress);
     h.tick(16);
     h.touchMove(200, 400);
-    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
     h.touchEnd(200, 400);
     assert.equal(h.prevented.touchend, 0);
   });
@@ -411,20 +657,19 @@ test("a second finger hands the gesture back and snaps to the nearest video", ()
     h.touchMove(200, 780);
     h.tick(16);
     h.touchMove(200, 200);
-    // 800→780 是方向判定那一段，被归零；之后的 580px 才是画面位移
-    assert.equal(h.root.scrollTop, 580);
+    assert.equal(h.translate, -580);
 
     h.touchMoveMulti([
       { clientX: 200, clientY: 200 },
       { clientX: 260, clientY: 400 },
     ]);
-    h.runSettle();
-    // 600 更靠近下一屏（900）而不是当前屏（0）
+    h.endTransition();
+    // 等效位置 580 更靠近下一屏（900）而不是当前屏（0）
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
 
-    // 交出去之后的移动完全不再影响滚动
+    // 交出去之后的移动完全不再影响位移
     h.touchMove(200, 100);
-    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.translate, 0);
   });
 });
 
@@ -436,6 +681,7 @@ test("a multi-touch start is ignored outright", () => {
     ]);
     h.tick(16);
     h.touchMove(100, 300);
+    assert.equal(h.translate, 0);
     assert.equal(h.root.scrollTop, 0);
   });
 });
@@ -447,10 +693,11 @@ test("a cancelled touch settles instead of freezing between videos", () => {
     h.touchMove(200, 780);
     h.tick(16);
     h.touchMove(200, 500);
-    assert.equal(h.root.scrollTop, 280);
+    assert.equal(h.translate, -280);
     h.touchCancel();
-    h.runSettle();
+    h.endTransition();
     assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
   });
 });
 
@@ -458,72 +705,46 @@ test("a cancelled touch settles instead of freezing between videos", () => {
 // 连续滑动 / 打断
 // ---------------------------------------------------------------------------
 
-test("grabbing a flying slide takes over from where it actually is", () => {
+test("grabbing a flying slide freezes it at the frame it is actually on", () => {
   withHarness((h) => {
-    h.touchStart(200, 800);
-    h.tick(16);
-    h.touchMove(200, 780);
-    h.tick(16);
-    h.touchMove(200, 700);
-    h.touchEnd(200, 700);
-    // 只跑一帧，动画停在半路
-    h.advance(16);
-    const midFlight = h.root.scrollTop;
-    assert.ok(midFlight > 0 && midFlight < SLIDE_HEIGHT);
+    flickToNext(h, 800);
+    // 补偿量从 870 动画归零；此刻画面走到一半，还剩 400
+    h.setLiveTranslate(400);
 
-    // 按住：动画立即停下，不再有排队的帧
     h.touchStart(200, 500);
-    assert.equal(h.pendingFrames, 0);
-    assert.equal(h.root.scrollTop, midFlight);
+    // 内联值被改写成当前这一帧的位置，不会瞬移到终点
+    assert.equal(h.translate, 400);
+    assert.equal(h.transitionSpec, "none");
+    assert.equal(h.awaitingTransition, false);
 
-    // 接着再甩一把，仍然只前进一屏
+    // 接着再甩一把。等效位置 900-400=500 已经更靠近第 1 屏，
+    // 所以这一下是从第 1 屏再前进一屏——连甩两次走两屏，不会卡住
     h.tick(16);
     h.touchMove(200, 470);
     h.tick(16);
     h.touchMove(200, 440);
     h.touchEnd(200, 440);
-    h.runSettle();
-    assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+    h.endTransition();
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+    assert.equal(h.transformStyle, "");
   });
 });
 
 test("tapping to stop a flying slide still lands on a video", () => {
   withHarness((h) => {
-    h.touchStart(200, 800);
-    h.tick(16);
-    h.touchMove(200, 780);
-    h.tick(16);
-    h.touchMove(200, 700);
-    h.touchEnd(200, 700);
-    h.advance(16);
-    const midFlight = h.root.scrollTop;
-    assert.ok(midFlight > 0 && midFlight < SLIDE_HEIGHT);
+    flickToNext(h, 800);
+    h.setLiveTranslate(400);
 
     h.touchStart(200, 500);
     h.tick(40);
     h.touchEnd(200, 500);
     // 这一下只是"停住"，不该被当成单击去暂停视频
     assert.equal(h.prevented.touchend, 2);
-    h.runSettle();
-    assert.ok(
-      h.root.scrollTop === 0 || h.root.scrollTop === SLIDE_HEIGHT,
-      "should land on a slide boundary"
-    );
-  });
-});
-
-test("settling never runs longer than the tuned ceiling", () => {
-  withHarness((h) => {
-    h.touchStart(200, 800);
-    h.tick(16);
-    h.touchMove(200, 780);
-    h.tick(3_000);
-    h.touchMove(200, 400);
-    h.touchEnd(200, 400);
-    const startedAt = h.clock;
-    h.runSettle();
-    assert.ok(h.clock - startedAt <= SHORTS_PAGER_MAX_SETTLE_MS + 32);
+    h.endTransition();
+    // 等效位置 500 更靠近第 1 屏，就近吸附过去，不会卡在两屏之间
     assert.equal(h.root.scrollTop, SLIDE_HEIGHT);
+    assert.equal(h.transformStyle, "");
   });
 });
 
@@ -531,23 +752,19 @@ test("settling never runs longer than the tuned ceiling", () => {
 // 与队列裁剪 / 视口变化共存
 // ---------------------------------------------------------------------------
 
-test("a queue trim mid-flight shifts the animation instead of derailing it", () => {
+test("a queue trim mid-flight lands on the same video, in new coordinates", () => {
   withHarness((h) => {
     h.root.scrollTop = SLIDE_HEIGHT * 3;
-    h.touchStart(200, 800);
-    h.tick(16);
-    h.touchMove(200, 780);
-    h.tick(16);
-    h.touchMove(200, 700);
-    h.touchEnd(200, 700);
-    h.advance(16);
+    flickToNext(h, 800);
+    assert.ok(h.awaitingTransition);
 
     // 裁掉队首 2 条：坐标系整体上移，画面位置不变
-    const shift = SLIDE_HEIGHT * 2;
-    h.root.scrollTop -= shift;
-    h.runSettle();
-    // 落点跟着一起平移，仍然停在原来那条视频的下一条上
-    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 4 - shift);
+    h.trimLeading(2);
+    h.endTransition();
+
+    // 目标仍是原来那条视频，只是它现在的偏移少了 2 屏
+    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 2);
+    assert.equal(h.translate, 0);
   });
 });
 
@@ -559,14 +776,13 @@ test("a queue trim mid-drag keeps the finger tracking continuous", () => {
     h.touchMove(200, 780);
     h.tick(16);
     h.touchMove(200, 700);
-    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 3 + 80);
+    assert.equal(h.translate, -80);
 
-    const shift = SLIDE_HEIGHT * 2;
-    h.root.scrollTop -= shift;
+    h.trimLeading(2);
     h.tick(16);
-    // 手指再往上 20px：位置应当是"平移后的位置"再加 20，而不是跳回旧坐标
+    // 位移纯由手指决定，裁剪换坐标系不会把跟手带偏
     h.touchMove(200, 680);
-    assert.equal(h.root.scrollTop, SLIDE_HEIGHT * 3 + 100 - shift);
+    assert.equal(h.translate, -100);
   });
 });
 
@@ -584,6 +800,19 @@ test("a viewport resize realigns the active video", () => {
   });
 });
 
+test("a resize mid-flight drops the stale target and realigns", () => {
+  withHarness((h) => {
+    h.setAnchorIndex(0);
+    flickToNext(h, 800);
+    h.setLiveTranslate(-400);
+    h.resize();
+    // 尺寸变了，按旧尺寸算的终点作废；当前屏被拉回吸附点
+    assert.equal(h.root.scrollTop, 0);
+    assert.equal(h.translate, 0);
+    assert.equal(h.awaitingTransition, false);
+  });
+});
+
 test("a resize during a drag leaves the finger in control", () => {
   withHarness((h) => {
     h.setAnchorIndex(0);
@@ -592,24 +821,16 @@ test("a resize during a drag leaves the finger in control", () => {
     h.touchMove(200, 780);
     h.tick(16);
     h.touchMove(200, 600);
-    assert.equal(h.root.scrollTop, 180);
+    assert.equal(h.translate, -180);
     h.resize();
-    assert.equal(h.root.scrollTop, 180);
+    assert.equal(h.translate, -180);
+    assert.equal(h.root.scrollTop, 0);
   });
 });
 
 // ---------------------------------------------------------------------------
 // 合成 click 兜底
 // ---------------------------------------------------------------------------
-
-function flickToNext(h: Harness) {
-  h.touchStart(200, 700);
-  h.tick(16);
-  h.touchMove(200, 670);
-  h.tick(16);
-  h.touchMove(200, 640);
-  h.touchEnd(200, 640);
-}
 
 test("the click a vertical swipe leaves behind never pauses the video", () => {
   withHarness((h) => {
@@ -636,7 +857,8 @@ test("a deliberate tap right after a swipe still reaches the video", () => {
 test("once the feed has settled a tap is just a tap again", () => {
   withHarness((h) => {
     flickToNext(h);
-    h.runSettle();
+    h.endTransition();
+    h.advance(400);
     h.touchStart(200, 500);
     h.tick(60);
     h.touchEnd(200, 500);
@@ -665,9 +887,39 @@ test("horizontal seeking leaves the click guard alone", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// 卸载
+// ---------------------------------------------------------------------------
+
+test("tearing down mid-flight leaves a settled position and a clean track", () => {
+  const harness = createHarness();
+  flickToNext(harness, 800);
+  harness.setLiveTranslate(400);
+  harness.destroy();
+  // 位置在松手时就提交了，卸载只需要把 transform 收干净，不能留在 DOM 上
+  assert.equal(harness.root.scrollTop, SLIDE_HEIGHT);
+  assert.equal(harness.transformStyle, "");
+  assert.equal(harness.willChange, "");
+});
+
+test("tearing down mid-drag writes the finger offset back to scrollTop", () => {
+  const harness = createHarness();
+  harness.touchStart(200, 800);
+  harness.tick(16);
+  harness.touchMove(200, 780);
+  harness.tick(16);
+  harness.touchMove(200, 600);
+  assert.equal(harness.translate, -180);
+  // 手指还按着就被卸载：跟手位移必须落回 scrollTop，不能凭空丢掉
+  harness.destroy();
+  assert.equal(harness.root.scrollTop, 180);
+  assert.equal(harness.transformStyle, "");
+});
+
 test("tearing down the page releases every listener", () => {
   const harness = createHarness();
   assert.ok(harness.hasListeners());
   harness.destroy();
   assert.equal(harness.hasListeners(), false);
+  assert.equal(harness.awaitingTransition, false);
 });

--- a/tests/shortsSwipePagerFlow.test.ts
+++ b/tests/shortsSwipePagerFlow.test.ts
@@ -23,9 +23,15 @@ const SECOND_POINTER = 2;
 type TouchPoint = { clientX: number; clientY: number };
 
 type Harness = ReturnType<typeof createHarness>;
+type HarnessOptions = {
+  slideCount?: number;
+  usesDocumentScroll?: boolean;
+};
 
-function createHarness(options?: { slideCount?: number }) {
+function createHarness(options?: HarnessOptions) {
   const slideCount = options?.slideCount ?? 6;
+  const usesDocumentScroll = options?.usesDocumentScroll ?? false;
+  let documentScrollTop = 0;
   let clock = 1_000;
   let nextFrameId = 1;
   let nextTimerId = 1;
@@ -81,7 +87,7 @@ function createHarness(options?: { slideCount?: number }) {
     getBoundingClientRect: () => {
       // 实现只在 FLIP 里读轨道自身的 rect，用来强制一次样式提交
       styleFlushes += 1;
-      return { top: -root.scrollTop + visualTranslate() };
+      return { top: -readScrollTop() + visualTranslate() };
     },
     addEventListener: (type: string, handler: (event: unknown) => void) => {
       if (!trackListeners.has(type)) trackListeners.set(type, new Set());
@@ -100,7 +106,10 @@ function createHarness(options?: { slideCount?: number }) {
     const slide = {
       dataset: { index: String(index) },
       getBoundingClientRect: () => ({
-        top: slides.indexOf(slide) * SLIDE_HEIGHT - root.scrollTop + visualTranslate(),
+        top:
+          slides.indexOf(slide) * SLIDE_HEIGHT -
+          readScrollTop() +
+          visualTranslate(),
       }),
     };
     slides.push(slide);
@@ -121,6 +130,9 @@ function createHarness(options?: { slideCount?: number }) {
       rootListeners.delete(type);
     },
   };
+
+  const readScrollTop = () =>
+    usesDocumentScroll ? documentScrollTop : root.scrollTop;
 
   const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
   const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
@@ -144,8 +156,12 @@ function createHarness(options?: { slideCount?: number }) {
 
   const fakeWindow = {
     innerHeight: SLIDE_HEIGHT,
-    scrollY: 0,
-    scrollTo: () => undefined,
+    get scrollY() {
+      return documentScrollTop;
+    },
+    scrollTo: (_left: number, top: number) => {
+      documentScrollTop = top;
+    },
     // 浏览器给的是矩阵形式，实现必须认得
     getComputedStyle: () => ({
       transform:
@@ -185,7 +201,7 @@ function createHarness(options?: { slideCount?: number }) {
   const destroyPager = createShortsSwipePager({
     root: root as unknown as HTMLElement,
     track: track as unknown as HTMLElement,
-    usesDocumentScroll: false,
+    usesDocumentScroll,
     getAnchorSlide: () =>
       (slides[anchorIndex] ?? null) as unknown as HTMLElement | null,
   });
@@ -349,9 +365,17 @@ function createHarness(options?: { slideCount?: number }) {
     },
     /** 容器发出一次 scroll 事件（外力挪动了滚动位置）。 */
     scroll() {
-      const handler = rootListeners.get("scroll");
+      const listeners = usesDocumentScroll ? windowListeners : rootListeners;
+      const handler = listeners.get("scroll");
       assert.ok(handler, "scroll listener should be registered");
       handler({});
+    },
+    get scrollTop() {
+      return readScrollTop();
+    },
+    setExternalScrollTop(value: number) {
+      if (usesDocumentScroll) documentScrollTop = value;
+      else root.scrollTop = value;
     },
     /** 一次 wheel 事件。deltaY 正 = 向下滚 = 看下一条。 */
     wheel(
@@ -399,7 +423,7 @@ function createHarness(options?: { slideCount?: number }) {
 
 function withHarness(
   run: (harness: Harness) => void,
-  options?: { slideCount?: number }
+  options?: HarnessOptions
 ) {
   const harness = createHarness(options);
   try {
@@ -1163,6 +1187,23 @@ test("pinch zoom keeps its own wheel, everything else is taken over", () => {
 // ---------------------------------------------------------------------------
 // 兜底不变量：静止时绝不停在两条视频之间
 // ---------------------------------------------------------------------------
+
+test("document scroll drift is observed and corrected on the viewport", () => {
+  const harness = createHarness({ usesDocumentScroll: true });
+  try {
+    harness.setExternalScrollTop(SLIDE_HEIGHT + 137);
+    harness.scroll();
+    assert.equal(harness.scrollTop, SLIDE_HEIGHT + 137);
+
+    harness.advance(200);
+    assert.equal(harness.scrollTop, SLIDE_HEIGHT);
+    harness.endTransition();
+  } finally {
+    harness.destroy();
+  }
+  // 清理也必须使用同一个宿主，否则每次重进短视频页都会泄漏一个监听器。
+  assert.equal(harness.hasListeners(), false);
+});
 
 test("an unexplained scroll drift corrects itself once things go quiet", () => {
   withHarness((h) => {


### PR DESCRIPTION
Closes #81

参考 [zyronon/douyin](https://github.com/zyronon/douyin) 重做短视频页的滑动体验。核心结论是：**凡是留给浏览器的输入通道，"原生吸附手感不可控"这个问题就原样留在那里**。所以手指、鼠标拖拽、滚轮三种输入现在走同一套判定和同一条落点动画。

## 三层问题，三层修

### 一、判定：滑多远才算切屏

原来靠 `scroll-snap-type: y mandatory`，判定权在浏览器：各家实现不一致，慢速大幅滑动常被判回弹，快速轻扫又可能不吸附。改成 douyin `utils/slide.ts` 的三段式——

| 手势 | 结果 |
|---|---|
| 位移 < 20px | 回弹（防误触） |
| 位移 > 1/3 屏 | 必切，再慢也切 |
| 中间地带 | 150ms 内抬手、或抬手速度够快 → 切；否则回弹 |

速度那条通路是我们补的：只看整段按压时长的话，"先按住暂停、再甩走"必定被误判成回弹。

### 二、运动：动画跑在哪条线程上

douyin 用 `translate3d` + CSS `transition`，走**合成器线程**。这一条尤其关键——切屏那几百毫秒恰好是主线程最忙的时候（React 重渲染、iOS 共享 `<video>` 换插槽、`play()` 起播、下一条预载），主线程动画一掉帧就顿。

位移记在新增的轨道元素 `.shorts-feed__track` 上，落点用 FLIP：松手当下先把 `scrollTop` 写到目标 slide，再用反向 `translate` 补偿这次跳变，然后动画归零。好处是位置提交**不依赖 `transitionend`**（那个事件在标签页切走时会丢），队列裁剪的坐标平移也天然连续。

轨道静止时没有 `transform` 也没有 `will-change`，不在每个 `<video>` 祖先上留常驻合成层——本页在 iOS 合成路径上踩过坑。

### 三、预载：为什么滑到会先看见一张静态封面

两层独立根因，都不是解码慢：

1. **预载授权每次切屏清零**，要靠当前条真的起播并囤够 4–12 秒缓冲才挣得回来。而正常刷视频比这条链路走完还快 → 下一条在被滑到那一刻根本没发过任何网络请求。改成两级：紧邻的下一条**无条件预载**，授权只决定再往后囤几条。
2. **字节下下来 ≠ 有画面**。按 HTML 渲染模型，`<video>` 在真正播放前一直画 poster，缓冲多满都一样。清掉这个标志只有 `play()` 和 seek 两条路——预载条不能 `play()`，所以写一次 `currentTime` 逼它解码首帧。douyin 的 `BaseVideo.vue` 就是这么做的。

iOS 走的是共享元素分支，有它自己独立的一道门，两处都补了。备用元素还改成跟着**浏览方向**放，往回连看不再每条都冷启动。

## 顺带修掉的既有问题

- **右侧滚动条**：抑制规则只写在 `.shorts-feed` 上，而 iPhone 路径早把滚动主体搬到了 `html`，抑制没跟着搬
- **切屏时 UI "事后叠上来"**：标题栏和操作栏非活跃时 `opacity: 0`，切屏后延迟 0.15s 再花 0.5s 淡入。删掉入场动效，它们现在贴在各自视频上一起滑
- **正在滑入的下一屏是暗的**：非活跃海报被压到 50% 不透明 + 缩小 4%，要等覆盖视口 60% 才开始变亮。画面层现在共用同一套视觉契约
- **队列裁剪硬跳**：切屏动画进行到一半被裁剪打断时会硬拽回吸附点，现在保留分数偏移（这条对桌面原生滚动同样生效）
- **落点时长机制从未生效**：原来按抬手速度反解时长，但 FLIP 之后剩余距离恒为约一屏，真实手速反解出的值必然超上限，整套退化成常数 380ms——甩得越快反而越慢。切屏改固定 300ms（douyin 同值），回弹按距离取 180–260ms
- **到头/到尾硬冻结**：改成带阻尼的越界 + 回弹
- **拖动期间 `activeIndex` 抖动**：IO 看的是视觉位置，跟手时一次滑动能翻 2–4 次，每次都是一整套暂停/起播/授权清零。跟手期间冻结判定，与 douyin 只在 `touchEnd` 推进 index 一致

## 一条兜底不变量

关掉原生吸附之后，没有任何机制会把意外的滚动偏移纠回来，而能造成偏移的路径数不清（浏览器滚动锚定、漏掉的 `preventDefault`、扩展、页内查找）。与其逐个堵，不如让 **"静止时画面绝不停在两条视频之间"** 这条不变量自己成立：滚动停下 120ms 后量一次，偏离超过 2px 就就近吸回去。

## 平台与开关

所有设备、所有输入一视同仁。曾经分过两次特例，两次都被真机证伪并已收回（iPhone "保工具栏"、桌面"保滚轮"）。

`?shortsPager=0` 整个关掉，回到纯原生滚动——真机回退开关。

## 测试

682 个测试通过（新增判定公式、滚轮手势聚合、`deltaMode` 换算、边缘阻尼、首帧预热、预载深度、FLIP 落点提交、打断与多指、合成 click 守卫等分支的覆盖）。`tsc` / `npm audit` / `build` 全绿。

**未验证**：iOS 上根滚动条的 CSS 抑制是否生效（WebKit 对根元素 `::-webkit-scrollbar` 的支持随版本而异）；iOS 方向反转的那一次仍是冷启动——两个持久 media element 覆盖不了 prev/active/next 三个位置，要彻底解决需要加第三个。

---

Rebuilds the shorts scrolling experience against [zyronon/douyin](https://github.com/zyronon/douyin). The guiding conclusion: any input channel left to the browser keeps the uncontrollable native-snap feel, so touch, mouse drag and wheel now share one decision path and one settle animation.

Three layers were wrong. **Decision** — how far is far enough — was delegated to `scroll-snap-type: mandatory`; it now follows douyin's three-part rule (<20px bounces, >1/3 screen always commits, the middle band looks at flick speed). **Motion** ran on the main thread via rAF over `scrollTop`, competing with exactly the work a slide change triggers; it now uses `translate3d` plus a CSS transition on a dedicated track, committing the position up front (FLIP) so nothing depends on `transitionend` firing. **Preloading** had two independent causes for the static cover users saw: a preload grant that reset on every swipe and could never be re-earned at normal browsing speed, and the fact that a `<video>` paints its poster until playback actually starts regardless of how much is buffered.

Also fixed along the way: the right-hand scrollbar (suppression never followed the scroll host when it moved to the document), entrance animations that made the overlay appear after the swipe instead of riding in with the video, a queue trim that yanked the scroll position mid-animation, a settle-duration formula that could never fire, hard-frozen ends, and `activeIndex` thrashing during a drag.

The load-bearing addition is an invariant rather than another point fix: the feed can no longer come to rest between two videos, so any future path that nudges the scroll position corrects itself.

682 tests pass; `tsc`, `npm audit` and `build` are green. Not verified: whether CSS scrollbar suppression takes effect on the iOS root scroller, and reversing direction on iOS still costs one cold start (two persistent media elements cannot cover prev/active/next).
