### PR TITLE
feat: 播放器倍速与双击快进 —— 控制栏一步可达，双击侧边按连击累计 | Playback-rate control and double-tap side seek

### DIFF
--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -8,10 +8,30 @@ import {
 import Artplayer, { type Option, type SettingOption } from "artplayer";
 import type Hls from "hls.js";
 import {
+  classifyTapZone,
+  computeDoubleTapSeekTime,
+  DOUBLE_TAP_CHAIN_WINDOW_MS,
+  formatDoubleTapSeekLabel,
+  reduceDoubleTap,
+  type DoubleTapAction,
+  type SeekChain,
+  type SeekChainSide,
+  type TapKind,
+  type TapZone,
+} from "@/lib/doubleTapSeek";
+import {
   calculateFullscreenSubtitleBottom,
   getFullscreenPlayerOrientation,
 } from "@/lib/fullscreenSubtitleLayout";
 import { diagnosePlaybackSource } from "@/lib/playbackError";
+import {
+  formatPlaybackRateLabel,
+  formatPlaybackRateOptionLabel,
+  matchPlaybackRateOption,
+  normalizePlaybackRate,
+  NORMAL_PLAYBACK_RATE,
+  PLAYBACK_RATE_OPTIONS,
+} from "@/lib/playbackRate";
 import {
   escapeHtml,
   formatSubtitleLabel,
@@ -115,7 +135,7 @@ const LONG_PRESS_MS = 400;
 /** 长按时使用的播放倍速。 */
 const FAST_RATE = 2;
 /** 默认倍速。 */
-const NORMAL_RATE = 1;
+const NORMAL_RATE = NORMAL_PLAYBACK_RATE;
 /** ArtPlayer 内部播放失败自动重连次数。 */
 const ARTPLAYER_RECONNECT_TIME_MAX = 3;
 /** 播放状态下控制栏无操作后自动隐藏的时间。 */
@@ -128,6 +148,14 @@ const KEYBOARD_SEEK_IDLE_COMMIT_MS = 1_500;
 Artplayer.FAST_FORWARD_VALUE = FAST_RATE;
 Artplayer.RECONNECT_TIME_MAX = ARTPLAYER_RECONNECT_TIME_MAX;
 Artplayer.CONTROL_HIDE_TIME = ARTPLAYER_CONTROL_HIDE_TIME_MS;
+// 控制栏倍速按钮、设置面板“播放速度”和桌面端右键菜单共用同一份档位。
+Artplayer.PLAYBACK_RATE = PLAYBACK_RATE_OPTIONS;
+// ArtPlayer 的双击动作写死在它的点击派发里：先 emit dblclick，再按自己的
+// UA 判断执行“移动端切换播放 / 桌面端切换全屏”，回调里无法取消。它的移动端
+// 判断口径又和本文件按指针类型判断的不一致（例如带触摸屏的桌面浏览器），
+// 所以这里关掉两个内置开关，双击语义统一由 bindPlayerDoubleClickActions 实现。
+Artplayer.MOBILE_DBCLICK_PLAY = false;
+Artplayer.DBCLICK_FULLSCREEN = false;
 
 const DEFAULT_SETTINGS: PlayerSettings = {
   volume: 1,
@@ -147,6 +175,10 @@ const COMPACT_SETTING_LAYOUT = {
   itemHeight: 30,
 };
 const ORIENTATION_CONTROL_NAME = "orientationToggle";
+const PLAYBACK_RATE_CONTROL_NAME = "playbackRateToggle";
+const PLAYBACK_RATE_VALUE_CLASS = "art-selector-value";
+const PLAYBACK_RATE_ITEM_CLASS = "art-selector-item";
+const PLAYBACK_RATE_LIST_CLASS = "art-selector-list";
 const TRIPLE_SCREEN_CONTROL_NAME = "tripleScreen";
 const TRIPLE_SCREEN_RELAY_QUERY = "tripleScreenRelay";
 const MANUAL_ORIENTATION_CLASS = "art-manual-orientation";
@@ -156,6 +188,10 @@ const FAST_RATE_HINT_CLASS = "video-player__art-rate-hint";
 const PLAYER_GESTURE_HUD_CLASS = "video-player__art-gesture-hud";
 const PLAYER_GESTURE_HUD_ICON_CLASS = "video-player__art-gesture-hud-icon";
 const PLAYER_GESTURE_HUD_VALUE_CLASS = "video-player__art-gesture-hud-value";
+const SEEK_RIPPLE_CLASS = "video-player__art-seek-ripple";
+const SEEK_RIPPLE_LEAVING_CLASS = "video-player__art-seek-ripple--leaving";
+/** 与 CSS 里淡出动画的时长一致，动画结束后才移除节点。 */
+const SEEK_RIPPLE_LEAVE_MS = 220;
 const FULLSCREEN_SUBTITLE_BOTTOM_CSS_VAR =
   "--video-player-subtitle-bottom";
 const FULLSCREEN_SUBTITLE_ORIENTATION_DATASET =
@@ -188,6 +224,7 @@ const GESTURE_ACTIVATION_PX = 12;
 const GESTURE_DIRECTION_LOCK_RATIO = 1.2;
 const GESTURE_VERTICAL_SCALE = 1.15;
 const playerGestureHudTimers = new WeakMap<HTMLElement, number>();
+const seekRippleTimers = new WeakMap<HTMLElement, number>();
 const tripleScreenBindings = new WeakMap<
   Artplayer,
   { toggle: () => void; destroy: () => void }
@@ -594,6 +631,8 @@ function mountArtPlayer({
     handleFastChange,
     onGestureHud
   );
+  const unbindDoubleClickActions = bindPlayerDoubleClickActions(art);
+  const unbindPlaybackRateControl = bindPlaybackRateControl(art);
   const unbindProgressPreview = bindProgressPreview(
     art,
     video,
@@ -645,6 +684,8 @@ function mountArtPlayer({
     if (art.fullscreenWeb) art.fullscreenWeb = false;
     unbindFastRate();
     unbindMobileGestures();
+    unbindDoubleClickActions();
+    unbindPlaybackRateControl();
     unbindProgressPreview();
     unbindKeyboardHotkeys();
     unbindMobileFullscreenControlAutoHide();
@@ -1325,6 +1366,103 @@ function showPlayerGestureHud(
   playerGestureHudTimers.set(player, timer);
 }
 
+/**
+ * 双击快进 / 快退的反馈：在被点的那一侧铺一层半圆遮罩，并从指尖位置扩散
+ * 一圈水波纹，中间显示方向箭头和累计秒数。遮罩的生命周期就是连击窗口，
+ * 每次点击刷新水波纹和文案，窗口结束提交 seek 时一起淡出。
+ *
+ * 用整块半圆而不是居中的小胶囊：胶囊靠 left 百分比定位，窄屏上可用宽度只
+ * 剩另一半，文案会被压成两行；这里的文案在半圆内部居中，不受这个限制。
+ */
+function showPlayerSeekRipple(
+  art: Artplayer,
+  side: SeekChainSide,
+  label: string,
+  event: Event
+) {
+  const player = art.template.$player;
+  clearSeekRippleTimer(player);
+
+  let ripple = player.querySelector<HTMLElement>(`.${SEEK_RIPPLE_CLASS}`);
+  if (!ripple) {
+    ripple = document.createElement("div");
+    ripple.setAttribute("aria-hidden", "true");
+    player.appendChild(ripple);
+  }
+  // 整体重新赋值：既切换左右，也清掉可能正在播放的淡出状态。
+  ripple.className = `${SEEK_RIPPLE_CLASS} ${SEEK_RIPPLE_CLASS}--${side}`;
+  ripple.replaceChildren();
+
+  const wave = document.createElement("span");
+  wave.className = `${SEEK_RIPPLE_CLASS}-wave`;
+  const origin = seekRippleOrigin(ripple, event);
+  wave.style.left = `${origin.x}%`;
+  wave.style.top = `${origin.y}%`;
+
+  const icon = document.createElement("span");
+  icon.className = `${SEEK_RIPPLE_CLASS}-icon`;
+  icon.innerHTML = seekRippleIcon();
+
+  const value = document.createElement("span");
+  value.className = `${SEEK_RIPPLE_CLASS}-value`;
+  value.textContent = label;
+
+  // 重新创建子节点即可重放水波纹和箭头动画，不必手动重置 animation。
+  ripple.append(wave, icon, value);
+}
+
+/** 连击结束：淡出后移除。 */
+function hidePlayerSeekRipple(art: Artplayer) {
+  const player = art.template.$player;
+  const ripple = player.querySelector<HTMLElement>(`.${SEEK_RIPPLE_CLASS}`);
+  if (!ripple) return;
+
+  clearSeekRippleTimer(player);
+  ripple.classList.add(SEEK_RIPPLE_LEAVING_CLASS);
+  const timer = window.setTimeout(() => {
+    seekRippleTimers.delete(player);
+    ripple.remove();
+  }, SEEK_RIPPLE_LEAVE_MS);
+  seekRippleTimers.set(player, timer);
+}
+
+/** 播放器卸载：不放动画，直接清掉。 */
+function clearPlayerSeekRipple(art: Artplayer) {
+  const player = art.template.$player;
+  clearSeekRippleTimer(player);
+  player.querySelector<HTMLElement>(`.${SEEK_RIPPLE_CLASS}`)?.remove();
+}
+
+function clearSeekRippleTimer(player: HTMLElement) {
+  const timer = seekRippleTimers.get(player);
+  if (timer === undefined) return;
+  window.clearTimeout(timer);
+  seekRippleTimers.delete(player);
+}
+
+/** 水波纹从指尖扩散：把点击位置换算成遮罩内部的百分比。 */
+function seekRippleOrigin(ripple: HTMLElement, event: Event) {
+  const rect = ripple.getBoundingClientRect();
+  if (!(event instanceof MouseEvent) || rect.width <= 0 || rect.height <= 0) {
+    return { x: 50, y: 50 };
+  }
+  return {
+    x: clamp(((event.clientX - rect.left) / rect.width) * 100, 0, 100),
+    y: clamp(((event.clientY - rect.top) / rect.height) * 100, 0, 100),
+  };
+}
+
+/** 三个箭头按 CSS 里的延迟依次点亮，左侧靠水平翻转复用同一段路径。 */
+function seekRippleIcon() {
+  return `
+    <svg viewBox="0 0 34 24" fill="none">
+      <path d="m5 7.4 4.6 4.6L5 16.6" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="m14.2 7.4 4.6 4.6-4.6 4.6" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="m23.4 7.4 4.6 4.6-4.6 4.6" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  `;
+}
+
 function clearPlayerGestureHud(art: Artplayer) {
   const player = art.template.$player;
   const currentTimer = playerGestureHudTimers.get(player);
@@ -1372,7 +1510,7 @@ function createPlayerControls(
   enableOrientationControl: boolean,
   enableTripleScreenControl: boolean
 ): PlayerControl[] {
-  const controls: PlayerControl[] = [];
+  const controls: PlayerControl[] = [createPlaybackRateControl()];
   if (enableTripleScreenControl) {
     controls.push(createTripleScreenControl());
   }
@@ -1380,6 +1518,146 @@ function createPlayerControls(
     controls.push(createOrientationControl());
   }
   return controls;
+}
+
+/**
+ * 控制栏上的倍速入口。ArtPlayer 自带的倍速藏在设置面板二级菜单里，桌面端
+ * 的右键菜单在移动端根本不初始化，所以这里补一个一步可达的按钮，选项沿用
+ * ArtPlayer 控制栏 selector 的原生结构与样式。
+ */
+function createPlaybackRateControl(): PlayerControl {
+  return {
+    name: PLAYBACK_RATE_CONTROL_NAME,
+    position: "right",
+    index: 26,
+    // 不用 ArtPlayer 的 hint 提示：它渲染在控件正上方，正好压住展开的最后一档。
+    html: formatPlaybackRateLabel(NORMAL_RATE),
+    selector: PLAYBACK_RATE_OPTIONS.map((rate) => ({
+      value: rate,
+      default: rate === NORMAL_RATE,
+      html: formatPlaybackRateOptionLabel(rate),
+    })),
+    onSelect(this: Artplayer, selector) {
+      const rate = normalizePlaybackRate(selector.value);
+      this.playbackRate = rate;
+      // 播放失败重连和切换清晰度都会走 video.load()，那时浏览器把
+      // playbackRate 重置成 defaultPlaybackRate；一起写入才能保住用户选择。
+      this.video.defaultPlaybackRate = rate;
+      setPlaybackRateSelectorOpen(this, false);
+      return formatPlaybackRateLabel(rate);
+    },
+    mounted(this: Artplayer, element) {
+      element.setAttribute("role", "button");
+      element.setAttribute("tabindex", "0");
+      element.setAttribute("aria-haspopup", "listbox");
+      element.setAttribute("aria-label", "播放速度");
+      element.setAttribute("title", "播放速度");
+      element.dataset.rateOpen = "false";
+      this.events.proxy(element, "keydown", (event) => {
+        const keyEvent = event as KeyboardEvent;
+        if (keyEvent.key !== "Enter" && keyEvent.key !== " ") return;
+        keyEvent.preventDefault();
+        setPlaybackRateSelectorOpen(
+          this,
+          element.dataset.rateOpen !== "true",
+          element
+        );
+      });
+      updatePlaybackRateControl(this, element);
+    },
+    click(this: Artplayer, _component, event) {
+      // 选项自身的点击交给 onSelect，这里只负责展开 / 收起。
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(`.${PLAYBACK_RATE_LIST_CLASS}`)
+      ) {
+        return;
+      }
+      const element = getPlaybackRateControl(this);
+      setPlaybackRateSelectorOpen(this, element?.dataset.rateOpen !== "true");
+    },
+  };
+}
+
+function getPlaybackRateControl(art: Artplayer, mountedElement?: HTMLElement) {
+  // 控件 mounted 时 art.controls 还没赋值到实例上，这时只能用回调里的节点。
+  const controls = (art as Artplayer & {
+    controls?: Record<string, HTMLElement | undefined>;
+  }).controls;
+  return mountedElement ?? controls?.[PLAYBACK_RATE_CONTROL_NAME];
+}
+
+/**
+ * ArtPlayer 控制栏的 selector 只有 :hover 才展开，触摸设备上不可靠，
+ * 所以额外用 data-rate-open 表达展开状态，由 CSS 在两种指针下分别生效。
+ */
+function setPlaybackRateSelectorOpen(
+  art: Artplayer,
+  open: boolean,
+  mountedElement?: HTMLElement
+) {
+  const element = getPlaybackRateControl(art, mountedElement);
+  if (!element) return;
+  element.dataset.rateOpen = open ? "true" : "false";
+  element.setAttribute("aria-expanded", open ? "true" : "false");
+}
+
+/** 把控制栏按钮文案与列表选中态同步到真实倍速。 */
+function updatePlaybackRateControl(art: Artplayer, mountedElement?: HTMLElement) {
+  const element = getPlaybackRateControl(art, mountedElement);
+  if (!element) return;
+
+  const rate = normalizePlaybackRate(art.video?.playbackRate);
+  const value = element.querySelector<HTMLElement>(
+    `.${PLAYBACK_RATE_VALUE_CLASS}`
+  );
+  if (value) value.textContent = formatPlaybackRateLabel(rate);
+
+  const current = matchPlaybackRateOption(rate);
+  element
+    .querySelectorAll<HTMLElement>(`.${PLAYBACK_RATE_ITEM_CLASS}`)
+    .forEach((item) => {
+      const itemRate = normalizePlaybackRate(item.dataset.value);
+      item.classList.toggle("art-current", current !== null && itemRate === current);
+    });
+}
+
+function bindPlaybackRateControl(art: Artplayer) {
+  function handleRateChange() {
+    // 长按 2 倍速是临时状态，松手就恢复；期间不改按钮文案，
+    // 免得用户以为自己选中了 2 倍速。
+    if (art.template.$player.classList.contains(FAST_RATE_CLASS)) return;
+    updatePlaybackRateControl(art);
+  }
+
+  function closeSelector() {
+    setPlaybackRateSelectorOpen(art, false);
+  }
+
+  function handleControlChange(show: boolean) {
+    // 控制栏在桌面端每次 mousemove 都会重新置为显示，只在隐藏时收起列表。
+    if (!show) closeSelector();
+  }
+
+  art.on("video:ratechange", handleRateChange);
+  art.on("video:loadedmetadata", handleRateChange);
+  // 点到播放器外面、控制栏隐藏、进出全屏、打开设置面板时都要收起展开的列表。
+  art.on("blur", closeSelector);
+  art.on("control", handleControlChange);
+  art.on("fullscreen", closeSelector);
+  art.on("fullscreenWeb", closeSelector);
+  art.on("setting", closeSelector);
+
+  return () => {
+    art.off("video:ratechange", handleRateChange);
+    art.off("video:loadedmetadata", handleRateChange);
+    art.off("blur", closeSelector);
+    art.off("control", handleControlChange);
+    art.off("fullscreen", closeSelector);
+    art.off("fullscreenWeb", closeSelector);
+    art.off("setting", closeSelector);
+  };
 }
 
 function createTripleScreenControl(): PlayerControl {
@@ -2150,6 +2428,140 @@ function bindLongPressFast(
     video.removeEventListener("mouseleave", handlePressEnd);
     video.removeEventListener("pause", handlePressEnd);
     video.removeEventListener("ended", handlePressEnd);
+  };
+}
+
+/**
+ * 播放器的双击动作。触摸设备上双击左右侧边按 10 秒快退 / 快进（移动端
+ * YouTube 的连击机制），双击中间仍是播放 / 暂停；鼠标设备保持双击全屏。
+ *
+ * 真实 seek 与键盘左右键一致：连击期间只累计目标时间并预览进度条，
+ * 窗口结束后提交一次，避免一串点击把 HLS 缓冲反复冲掉。
+ */
+function bindPlayerDoubleClickActions(art: Artplayer) {
+  const seekEnabled = shouldEnableMobileGestures();
+  let chain: SeekChain | null = null;
+  let seekTarget: number | null = null;
+  let chainTimer: number | null = null;
+
+  function clearChainTimer() {
+    if (chainTimer === null) return;
+    window.clearTimeout(chainTimer);
+    chainTimer = null;
+  }
+
+  function scheduleChainCommit() {
+    clearChainTimer();
+    chainTimer = window.setTimeout(() => {
+      chainTimer = null;
+      commitChainSeek();
+    }, DOUBLE_TAP_CHAIN_WINDOW_MS);
+  }
+
+  function renderSeekTarget() {
+    const duration = art.duration;
+    if (seekTarget === null || !Number.isFinite(duration) || duration <= 0) {
+      return;
+    }
+    art.emit("setBar", "played", clamp(seekTarget, 0, duration) / duration);
+  }
+
+  function commitChainSeek() {
+    clearChainTimer();
+    chain = null;
+    hidePlayerSeekRipple(art);
+    if (seekTarget === null) return;
+
+    const duration = art.duration;
+    const hasDuration = Number.isFinite(duration) && duration > 0;
+    const target = hasDuration ? clamp(seekTarget, 0, duration) : seekTarget;
+    seekTarget = null;
+    art.seek = target;
+    if (hasDuration) art.emit("setBar", "played", target / duration);
+  }
+
+  function accumulateSeek(
+    action: Extract<DoubleTapAction, { type: "seek" }>,
+    event: Event
+  ) {
+    const duration = art.duration;
+    if (!Number.isFinite(duration) || duration <= 0) return;
+
+    seekTarget = computeDoubleTapSeekTime({
+      baseTime: seekTarget ?? art.currentTime,
+      stepSeconds: action.stepSeconds,
+      duration,
+    });
+    renderSeekTarget();
+    showPlayerSeekRipple(
+      art,
+      action.side,
+      formatDoubleTapSeekLabel(action.totalSeconds),
+      event
+    );
+    scheduleChainCommit();
+  }
+
+  function tapZoneFromEvent(event: Event): TapZone {
+    const rect = art.template.$player.getBoundingClientRect();
+    const clientX =
+      event instanceof MouseEvent ? event.clientX : rect.left + rect.width / 2;
+    return classifyTapZone(clientX - rect.left, rect.width);
+  }
+
+  function handleTap(kind: TapKind, event: Event) {
+    if (!seekEnabled) {
+      // 鼠标设备沿用 ArtPlayer 原本的双击全屏。
+      if (kind === "dblclick") art.fullscreen = !art.fullscreen;
+      return;
+    }
+    if (art.isLock) return;
+
+    const result = reduceDoubleTap(chain, {
+      kind,
+      zone: tapZoneFromEvent(event),
+      at: Date.now(),
+    });
+    chain = result.chain;
+
+    if (result.action.type === "seek") {
+      accumulateSeek(result.action, event);
+      return;
+    }
+    if (result.action.type === "end") {
+      commitChainSeek();
+      if (result.action.toggle) art.toggle();
+    }
+  }
+
+  const handleClick = (event: Event) => handleTap("click", event);
+  const handleDoubleClick = (event: Event) => handleTap("dblclick", event);
+
+  function handleTimeUpdate() {
+    // 播放中的 timeupdate 会把进度条写回真实媒体时间，连击未提交时要盖回目标。
+    if (seekTarget !== null) renderSeekTarget();
+  }
+
+  art.on("click", handleClick);
+  art.on("dblclick", handleDoubleClick);
+  art.on("video:timeupdate", handleTimeUpdate);
+  art.on("video:pause", commitChainSeek);
+  art.on("video:ended", commitChainSeek);
+  art.on("blur", commitChainSeek);
+  window.addEventListener("blur", commitChainSeek);
+
+  return () => {
+    clearChainTimer();
+    chain = null;
+    seekTarget = null;
+    clearPlayerSeekRipple(art);
+    art.off("click", handleClick);
+    art.off("dblclick", handleDoubleClick);
+    art.off("video:timeupdate", handleTimeUpdate);
+    art.off("video:pause", commitChainSeek);
+    art.off("video:ended", commitChainSeek);
+    art.off("blur", commitChainSeek);
+    window.removeEventListener("blur", commitChainSeek);
   };
 }
 

--- a/src/lib/doubleTapSeek.ts
+++ b/src/lib/doubleTapSeek.ts
@@ -1,0 +1,136 @@
+/**
+ * 移动端“双击侧边快进/快退”的分区与连击状态机。
+ *
+ * 参考移动端 YouTube 的机制而不只是它的秒数：真正决定手感的是连击窗口——
+ * 第一次双击点亮某一侧之后，窗口内的后续点击继续在同一侧累加，而不是每次
+ * 都要重新双击。ArtPlayer 的点击派发按 300ms 判定双击，一串连点拿到的事件
+ * 是 click / dblclick 交替出现的，所以窗口开启后两种事件都算一次累加。
+ *
+ * 真实 seek 不在每次点击时提交：和键盘左右键一样，先累计目标时间并预览
+ * 进度条，连击窗口结束后只提交一次，避免一串点击把 HLS 缓冲反复冲掉。
+ */
+
+/** 侧边热区各占播放器宽度的比例，中间留给双击播放/暂停。 */
+export const SIDE_TAP_ZONE_RATIO = 0.35;
+/** 单次双击快进/快退的秒数。 */
+export const DOUBLE_TAP_SEEK_SECONDS = 10;
+/** 连击窗口：最后一次点击后多久结束累计并提交真实 seek。 */
+export const DOUBLE_TAP_CHAIN_WINDOW_MS = 700;
+
+export type TapZone = "left" | "center" | "right";
+export type TapKind = "click" | "dblclick";
+export type SeekChainSide = "left" | "right";
+
+export type SeekChain = {
+  /** 累计净步数：向右为正、向左为负 */
+  steps: number;
+  /** 最近一次点击落在哪一侧，决定提示浮层出现的位置 */
+  side: SeekChainSide;
+  /** 最近一次点击的时间戳，用于判断连击窗口是否过期 */
+  lastTapAt: number;
+};
+
+export type DoubleTapEvent = {
+  kind: TapKind;
+  zone: TapZone;
+  at: number;
+};
+
+export type DoubleTapAction =
+  /** 普通单击等不参与快进的点击，交回 ArtPlayer 的默认行为 */
+  | { type: "ignore" }
+  /** 累加一次快进/快退：stepSeconds 是本次增量，totalSeconds 是连击净值 */
+  | { type: "seek"; side: SeekChainSide; stepSeconds: number; totalSeconds: number }
+  /** 结束连击并提交；toggle 表示这次点击同时要切换播放/暂停 */
+  | { type: "end"; toggle: boolean };
+
+/** 按点击横坐标划分左 / 中 / 右热区。 */
+export function classifyTapZone(
+  localX: number,
+  width: number,
+  sideRatio = SIDE_TAP_ZONE_RATIO
+): TapZone {
+  if (!Number.isFinite(width) || width <= 0) return "center";
+  if (!Number.isFinite(localX)) return "center";
+  const side = width * sideRatio;
+  if (localX < side) return "left";
+  if (localX > width - side) return "right";
+  return "center";
+}
+
+/** 连击窗口是否仍然有效。 */
+export function isSeekChainActive(
+  chain: SeekChain | null,
+  at: number,
+  windowMs = DOUBLE_TAP_CHAIN_WINDOW_MS
+): chain is SeekChain {
+  if (!chain) return false;
+  return at - chain.lastTapAt <= windowMs;
+}
+
+/**
+ * 连击状态机。窗口未开启时只有双击侧边才会启动，避免误碰单击就跳时间；
+ * 窗口开启后，同侧点击继续累加，另一侧点击则把净值往回减（等价于 YouTube
+ * 上换边重新计数，但因为这里还没提交，回退更符合直觉）。
+ */
+export function reduceDoubleTap(
+  chain: SeekChain | null,
+  event: DoubleTapEvent
+): { chain: SeekChain | null; action: DoubleTapAction } {
+  const active = isSeekChainActive(chain, event.at) ? chain : null;
+
+  if (event.zone === "center") {
+    // 连击中点中间：提交已累计的快进并结束；双击中间保持切换播放/暂停。
+    if (!active && event.kind === "click") {
+      return { chain: null, action: { type: "ignore" } };
+    }
+    return { chain: null, action: { type: "end", toggle: event.kind === "dblclick" } };
+  }
+
+  const direction = event.zone === "left" ? -1 : 1;
+  if (!active) {
+    if (event.kind === "click") return { chain: null, action: { type: "ignore" } };
+    const started: SeekChain = {
+      steps: direction,
+      side: event.zone,
+      lastTapAt: event.at,
+    };
+    return { chain: started, action: seekAction(started, direction) };
+  }
+
+  const next: SeekChain = {
+    steps: active.steps + direction,
+    side: event.zone,
+    lastTapAt: event.at,
+  };
+  return { chain: next, action: seekAction(next, direction) };
+}
+
+/** 目标时间：从上一次的累计目标（没有就用当前播放位置）继续加减并夹住边界。 */
+export function computeDoubleTapSeekTime(input: {
+  baseTime: number;
+  stepSeconds: number;
+  duration: number;
+}): number {
+  const { baseTime, stepSeconds, duration } = input;
+  const target = baseTime + stepSeconds;
+  if (target < 0) return 0;
+  if (target > duration) return duration;
+  return target;
+}
+
+/** 浮层文案：连击净值抵消回 0 时明确告诉用户回到了原处。 */
+export function formatDoubleTapSeekLabel(totalSeconds: number) {
+  if (totalSeconds === 0) return "回到原位";
+  const action = totalSeconds > 0 ? "快进" : "快退";
+  return `${action} ${Math.abs(totalSeconds)} 秒`;
+}
+
+function seekAction(chain: SeekChain, direction: number): DoubleTapAction {
+  return {
+    type: "seek",
+    side: chain.side,
+    stepSeconds: direction * DOUBLE_TAP_SEEK_SECONDS,
+    totalSeconds: chain.steps * DOUBLE_TAP_SEEK_SECONDS,
+  };
+}

--- a/src/lib/playbackRate.ts
+++ b/src/lib/playbackRate.ts
@@ -1,0 +1,52 @@
+/**
+ * 详情页播放器的倍速档位与文案。
+ *
+ * ArtPlayer 自带的倍速入口只有两个：桌面端右键菜单，以及设置面板里的
+ * “播放速度”二级菜单；右键菜单在移动端根本不会初始化。控制栏上新增的倍速
+ * 按钮必须和这两处共用同一份档位，否则同一个播放器会出现两套倍速。
+ */
+
+/** 与 Artplayer.PLAYBACK_RATE 一致的倍速档位。 */
+export const PLAYBACK_RATE_OPTIONS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+/** 正常倍速。 */
+export const NORMAL_PLAYBACK_RATE = 1;
+
+/**
+ * 读回来的 playbackRate 可能是 0 / NaN / 负数（媒体元素重载、长按倍速被
+ * 打断等），一律回落到正常倍速再参与比较和展示。
+ */
+export function normalizePlaybackRate(rate: unknown): number {
+  const value = Number(rate);
+  if (!Number.isFinite(value) || value <= 0) return NORMAL_PLAYBACK_RATE;
+  return value;
+}
+
+export function isNormalPlaybackRate(rate: unknown) {
+  return normalizePlaybackRate(rate) === NORMAL_PLAYBACK_RATE;
+}
+
+/** 控制栏按钮上的文案：正常倍速显示“倍速”，其它显示实际倍数。 */
+export function formatPlaybackRateLabel(rate: unknown) {
+  return isNormalPlaybackRate(rate) ? "倍速" : `${formatRateNumber(rate)}x`;
+}
+
+/** 下拉列表里的文案：与设置面板一致，正常倍速显示“正常”。 */
+export function formatPlaybackRateOptionLabel(rate: unknown) {
+  return isNormalPlaybackRate(rate) ? "正常" : `${formatRateNumber(rate)}x`;
+}
+
+/**
+ * 把当前倍速对齐到列表里的档位；长按倍速等临时值不在档位里时返回 null，
+ * 让调用方把所有选项的选中态清掉，而不是硬标一个不对的档位。
+ */
+export function matchPlaybackRateOption(rate: unknown): number | null {
+  const value = normalizePlaybackRate(rate);
+  return PLAYBACK_RATE_OPTIONS.includes(value) ? value : null;
+}
+
+function formatRateNumber(rate: unknown) {
+  // 0.75 不能像 ArtPlayer 右键菜单那样按 toFixed(1) 显示成 0.8，
+  // 那个数字和真实倍速对不上。
+  return Number(normalizePlaybackRate(rate).toFixed(2)).toString();
+}

--- a/src/styles/video-detail.css
+++ b/src/styles/video-detail.css
@@ -383,6 +383,59 @@
   }
 }
 
+/* ---------- 控制栏倍速按钮 ---------- */
+
+.art-video-player .art-control-playbackRateToggle {
+  padding: 0 2px;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
+}
+
+.art-video-player .art-control-playbackRateToggle .art-selector-value {
+  min-width: 44px;
+  padding: 0 6px;
+  text-align: center;
+}
+
+.art-video-player .art-control-playbackRateToggle .art-selector-list {
+  right: 0;
+  min-width: 78px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/*
+ * ArtPlayer 控制栏的下拉列表只靠 :hover 展开，触摸设备上没有可靠的 hover，
+ * 所以展开状态由按钮点击写在 data-rate-open 上，两种指针分别生效。
+ */
+.art-video-player
+  .art-control-playbackRateToggle[data-rate-open="true"]
+  .art-selector-list {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .art-video-player .art-control-playbackRateToggle:hover .art-selector-list {
+    opacity: 0;
+    transform: translateY(10px);
+    pointer-events: none;
+  }
+
+  .art-video-player
+    .art-control-playbackRateToggle[data-rate-open="true"]
+    .art-selector-list {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .art-video-player .art-control-playbackRateToggle .art-selector-item {
+    padding: 12px 18px;
+  }
+}
+
 .video-player__status {
   position: absolute;
   inset: 0;
@@ -500,6 +553,8 @@
   font-weight: var(--weight-semibold);
   line-height: 1;
   text-align: center;
+  /* 绝对定位按 left 收缩，窄屏上不加这行文案会被压成两行。 */
+  white-space: nowrap;
   transform: translate(-50%, -50%);
   pointer-events: none;
   animation: video-player-art-hud-in 120ms ease-out both;
@@ -527,6 +582,169 @@
   min-width: 36px;
   text-align: left;
   letter-spacing: 0;
+}
+
+/* ---------- 双击快进 / 快退的水波纹 ---------- */
+
+/*
+ * 被点的那一侧铺一层半圆遮罩，内边缘做成椭圆，和移动端 YouTube 一致。
+ * 层级压在控制栏（60）和播放遮罩（50）下面，只盖住画面。
+ */
+.video-player__art-seek-ripple {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 52%;
+  overflow: hidden;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+  pointer-events: none;
+  animation: video-player-seek-ripple-in 140ms ease-out both;
+}
+
+.video-player__art-seek-ripple--left {
+  left: 0;
+  border-radius: 0 46% 46% 0 / 0 50% 50% 0;
+}
+
+.video-player__art-seek-ripple--right {
+  right: 0;
+  border-radius: 46% 0 0 46% / 50% 0 0 50%;
+}
+
+.video-player__art-seek-ripple--leaving {
+  animation: video-player-seek-ripple-out 220ms ease-out both;
+}
+
+/*
+ * 水波纹从指尖扩散。用足够大的圆做缩放而不是把小圆放大几十倍，
+ * 边缘再用径向渐变化开，避免位图拉伸后的锯齿。
+ */
+.video-player__art-seek-ripple-wave {
+  position: absolute;
+  width: 100%;
+  aspect-ratio: 1;
+  margin: -50% 0 0 -50%;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.34) 0%,
+    rgba(255, 255, 255, 0.16) 58%,
+    rgba(255, 255, 255, 0) 72%
+  );
+  will-change: transform, opacity;
+  animation: video-player-seek-wave 560ms ease-out both;
+}
+
+.video-player__art-seek-ripple-icon {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: 48px;
+  height: 22px;
+}
+
+.video-player__art-seek-ripple--left .video-player__art-seek-ripple-icon {
+  transform: scaleX(-1);
+}
+
+.video-player__art-seek-ripple-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* 三个箭头依次点亮，方向感跟着快进 / 快退走。 */
+.video-player__art-seek-ripple-icon path {
+  animation: video-player-seek-chevron 900ms ease-in-out infinite;
+}
+
+.video-player__art-seek-ripple-icon path:nth-child(2) {
+  animation-delay: 150ms;
+}
+
+.video-player__art-seek-ripple-icon path:nth-child(3) {
+  animation-delay: 300ms;
+}
+
+.video-player__art-seek-ripple-value {
+  position: relative;
+  z-index: 1;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-bold);
+  line-height: 1;
+  white-space: nowrap;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.55);
+}
+
+/* 全屏时画面变大，箭头和秒数同步放大，保持和内嵌时一样的视觉比重。 */
+.art-video-player.art-fullscreen .video-player__art-seek-ripple-icon,
+.art-video-player.art-fullscreen-web .video-player__art-seek-ripple-icon,
+.art-video-player.art-manual-orientation .video-player__art-seek-ripple-icon {
+  width: 62px;
+  height: 28px;
+}
+
+.art-video-player.art-fullscreen .video-player__art-seek-ripple-value,
+.art-video-player.art-fullscreen-web .video-player__art-seek-ripple-value,
+.art-video-player.art-manual-orientation .video-player__art-seek-ripple-value {
+  font-size: var(--font-md);
+}
+
+@keyframes video-player-seek-ripple-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes video-player-seek-ripple-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes video-player-seek-wave {
+  from {
+    transform: scale(0.28);
+    opacity: 0.85;
+  }
+  to {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+@keyframes video-player-seek-chevron {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .video-player__art-seek-ripple-wave,
+  .video-player__art-seek-ripple-icon path {
+    animation: none;
+  }
+
+  .video-player__art-seek-ripple-wave {
+    opacity: 0;
+  }
 }
 
 .art-video-player.art-fullscreen .video-player__art-gesture-hud,

--- a/tests/doubleTapSeek.test.ts
+++ b/tests/doubleTapSeek.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyTapZone,
+  computeDoubleTapSeekTime,
+  DOUBLE_TAP_CHAIN_WINDOW_MS,
+  DOUBLE_TAP_SEEK_SECONDS,
+  formatDoubleTapSeekLabel,
+  isSeekChainActive,
+  reduceDoubleTap,
+  type SeekChain,
+} from "../src/lib/doubleTapSeek";
+
+const WIDTH = 1000;
+
+test("左右热区各占三分之一强，中间留给双击播放/暂停", () => {
+  assert.equal(classifyTapZone(0, WIDTH), "left");
+  assert.equal(classifyTapZone(349, WIDTH), "left");
+  // 边界值落在中间，不会误触发快进
+  assert.equal(classifyTapZone(350, WIDTH), "center");
+  assert.equal(classifyTapZone(500, WIDTH), "center");
+  assert.equal(classifyTapZone(650, WIDTH), "center");
+  assert.equal(classifyTapZone(651, WIDTH), "right");
+  assert.equal(classifyTapZone(1000, WIDTH), "right");
+});
+
+test("拿不到宽度或坐标时当作中间，不做快进", () => {
+  assert.equal(classifyTapZone(10, 0), "center");
+  assert.equal(classifyTapZone(10, Number.NaN), "center");
+  assert.equal(classifyTapZone(Number.NaN, WIDTH), "center");
+});
+
+test("连击窗口按最后一次点击时间计算", () => {
+  const chain: SeekChain = { steps: 1, side: "right", lastTapAt: 1_000 };
+  assert.equal(isSeekChainActive(null, 1_000), false);
+  assert.equal(isSeekChainActive(chain, 1_000 + DOUBLE_TAP_CHAIN_WINDOW_MS), true);
+  assert.equal(
+    isSeekChainActive(chain, 1_001 + DOUBLE_TAP_CHAIN_WINDOW_MS),
+    false
+  );
+});
+
+test("单击不启动连击，双击侧边才开始快进/快退", () => {
+  const ignored = reduceDoubleTap(null, { kind: "click", zone: "right", at: 0 });
+  assert.equal(ignored.action.type, "ignore");
+  assert.equal(ignored.chain, null);
+
+  const forward = reduceDoubleTap(null, { kind: "dblclick", zone: "right", at: 0 });
+  assert.deepEqual(forward.action, {
+    type: "seek",
+    side: "right",
+    stepSeconds: DOUBLE_TAP_SEEK_SECONDS,
+    totalSeconds: DOUBLE_TAP_SEEK_SECONDS,
+  });
+  assert.deepEqual(forward.chain, { steps: 1, side: "right", lastTapAt: 0 });
+
+  const backward = reduceDoubleTap(null, { kind: "dblclick", zone: "left", at: 0 });
+  assert.deepEqual(backward.action, {
+    type: "seek",
+    side: "left",
+    stepSeconds: -DOUBLE_TAP_SEEK_SECONDS,
+    totalSeconds: -DOUBLE_TAP_SEEK_SECONDS,
+  });
+});
+
+test("窗口内的单击和双击都继续累计，不必每次重新双击", () => {
+  // ArtPlayer 的点击派发让一串连点交替派发 click / dblclick
+  let state = reduceDoubleTap(null, { kind: "dblclick", zone: "right", at: 0 });
+  state = reduceDoubleTap(state.chain, { kind: "click", zone: "right", at: 200 });
+  assert.equal(
+    (state.action as { totalSeconds: number }).totalSeconds,
+    DOUBLE_TAP_SEEK_SECONDS * 2
+  );
+
+  state = reduceDoubleTap(state.chain, { kind: "dblclick", zone: "right", at: 400 });
+  assert.equal(
+    (state.action as { totalSeconds: number }).totalSeconds,
+    DOUBLE_TAP_SEEK_SECONDS * 3
+  );
+  assert.deepEqual(state.chain, { steps: 3, side: "right", lastTapAt: 400 });
+});
+
+test("窗口过期后单击不再快进，双击重新从一档开始", () => {
+  const chain: SeekChain = { steps: 3, side: "right", lastTapAt: 0 };
+  const late = DOUBLE_TAP_CHAIN_WINDOW_MS + 1;
+
+  const ignored = reduceDoubleTap(chain, { kind: "click", zone: "right", at: late });
+  assert.equal(ignored.action.type, "ignore");
+  assert.equal(ignored.chain, null);
+
+  const restarted = reduceDoubleTap(chain, {
+    kind: "dblclick",
+    zone: "right",
+    at: late,
+  });
+  assert.deepEqual(restarted.chain, { steps: 1, side: "right", lastTapAt: late });
+});
+
+test("连击中换边把累计值往回减，提示也跟到另一侧", () => {
+  let state = reduceDoubleTap(null, { kind: "dblclick", zone: "right", at: 0 });
+  state = reduceDoubleTap(state.chain, { kind: "click", zone: "right", at: 100 });
+  state = reduceDoubleTap(state.chain, { kind: "click", zone: "left", at: 200 });
+
+  assert.deepEqual(state.action, {
+    type: "seek",
+    side: "left",
+    stepSeconds: -DOUBLE_TAP_SEEK_SECONDS,
+    totalSeconds: DOUBLE_TAP_SEEK_SECONDS,
+  });
+  assert.deepEqual(state.chain, { steps: 1, side: "left", lastTapAt: 200 });
+});
+
+test("点中间结束连击：单击只提交，双击还要切换播放/暂停", () => {
+  const chain: SeekChain = { steps: 2, side: "right", lastTapAt: 0 };
+
+  const committed = reduceDoubleTap(chain, { kind: "click", zone: "center", at: 100 });
+  assert.deepEqual(committed.action, { type: "end", toggle: false });
+  assert.equal(committed.chain, null);
+
+  const toggled = reduceDoubleTap(chain, { kind: "dblclick", zone: "center", at: 100 });
+  assert.deepEqual(toggled.action, { type: "end", toggle: true });
+
+  // 没有连击时，中间单击交回 ArtPlayer 默认行为（显示/隐藏控制栏）
+  const idle = reduceDoubleTap(null, { kind: "click", zone: "center", at: 0 });
+  assert.deepEqual(idle.action, { type: "ignore" });
+
+  // 没有连击时，中间双击仍是播放/暂停
+  const idleToggle = reduceDoubleTap(null, { kind: "dblclick", zone: "center", at: 0 });
+  assert.deepEqual(idleToggle.action, { type: "end", toggle: true });
+});
+
+test("目标时间在片头片尾夹住边界", () => {
+  assert.equal(
+    computeDoubleTapSeekTime({ baseTime: 30, stepSeconds: 10, duration: 100 }),
+    40
+  );
+  assert.equal(
+    computeDoubleTapSeekTime({ baseTime: 5, stepSeconds: -10, duration: 100 }),
+    0
+  );
+  assert.equal(
+    computeDoubleTapSeekTime({ baseTime: 95, stepSeconds: 10, duration: 100 }),
+    100
+  );
+});
+
+test("提示文案区分快进、快退和抵消回原位", () => {
+  assert.equal(formatDoubleTapSeekLabel(30), "快进 30 秒");
+  assert.equal(formatDoubleTapSeekLabel(-10), "快退 10 秒");
+  assert.equal(formatDoubleTapSeekLabel(0), "回到原位");
+});

--- a/tests/playbackRate.test.ts
+++ b/tests/playbackRate.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatPlaybackRateLabel,
+  formatPlaybackRateOptionLabel,
+  isNormalPlaybackRate,
+  matchPlaybackRateOption,
+  normalizePlaybackRate,
+  NORMAL_PLAYBACK_RATE,
+  PLAYBACK_RATE_OPTIONS,
+} from "../src/lib/playbackRate";
+
+test("倍速档位与 ArtPlayer 内置设置面板保持同一份", () => {
+  // 控制栏按钮、设置面板“播放速度”、桌面端右键菜单共用这份档位
+  assert.deepEqual(PLAYBACK_RATE_OPTIONS, [0.5, 0.75, 1, 1.25, 1.5, 2]);
+  assert.ok(PLAYBACK_RATE_OPTIONS.includes(NORMAL_PLAYBACK_RATE));
+});
+
+test("非法倍速一律回落到正常倍速", () => {
+  assert.equal(normalizePlaybackRate(1.5), 1.5);
+  assert.equal(normalizePlaybackRate("1.25"), 1.25);
+  assert.equal(normalizePlaybackRate(0), NORMAL_PLAYBACK_RATE);
+  assert.equal(normalizePlaybackRate(-2), NORMAL_PLAYBACK_RATE);
+  assert.equal(normalizePlaybackRate(Number.NaN), NORMAL_PLAYBACK_RATE);
+  assert.equal(normalizePlaybackRate(undefined), NORMAL_PLAYBACK_RATE);
+  assert.equal(normalizePlaybackRate("abc"), NORMAL_PLAYBACK_RATE);
+});
+
+test("正常倍速判定覆盖非法值", () => {
+  assert.equal(isNormalPlaybackRate(1), true);
+  assert.equal(isNormalPlaybackRate(0), true);
+  assert.equal(isNormalPlaybackRate(2), false);
+});
+
+test("控制栏按钮在正常倍速下显示“倍速”，其它显示实际倍数", () => {
+  assert.equal(formatPlaybackRateLabel(1), "倍速");
+  assert.equal(formatPlaybackRateLabel(Number.NaN), "倍速");
+  assert.equal(formatPlaybackRateLabel(1.5), "1.5x");
+  assert.equal(formatPlaybackRateLabel(2), "2x");
+  // 0.75 不能像 ArtPlayer 右键菜单那样被 toFixed(1) 显示成 0.8
+  assert.equal(formatPlaybackRateLabel(0.75), "0.75x");
+});
+
+test("下拉列表文案与设置面板一致", () => {
+  assert.equal(formatPlaybackRateOptionLabel(1), "正常");
+  assert.equal(formatPlaybackRateOptionLabel(0.5), "0.5x");
+  assert.equal(formatPlaybackRateOptionLabel(1.25), "1.25x");
+});
+
+test("不在档位里的临时倍速不标记选中项", () => {
+  assert.equal(matchPlaybackRateOption(1.5), 1.5);
+  assert.equal(matchPlaybackRateOption("2"), 2);
+  // 长按倍速等临时值若不在档位内，返回 null 让调用方清空选中态
+  assert.equal(matchPlaybackRateOption(3), null);
+  assert.equal(matchPlaybackRateOption(0), NORMAL_PLAYBACK_RATE);
+});

--- a/tests/videoPlayerControls.test.ts
+++ b/tests/videoPlayerControls.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const playerSource = readFileSync(
+  new URL("../src/components/VideoPlayer.tsx", import.meta.url),
+  "utf8"
+);
+const detailCss = readFileSync(
+  new URL("../src/styles/video-detail.css", import.meta.url),
+  "utf8"
+);
+
+test("控制栏常驻倍速按钮，档位与设置面板共用一份", () => {
+  assert.match(
+    playerSource,
+    /const controls: PlayerControl\[\] = \[createPlaybackRateControl\(\)\]/
+  );
+  assert.match(playerSource, /Artplayer\.PLAYBACK_RATE = PLAYBACK_RATE_OPTIONS/);
+  assert.match(
+    playerSource,
+    /createPlaybackRateControl\(\)[\s\S]*selector: PLAYBACK_RATE_OPTIONS\.map/
+  );
+});
+
+test("选中的倍速一起写入 defaultPlaybackRate，重连后不被重置", () => {
+  assert.match(
+    playerSource,
+    /onSelect\([\s\S]*this\.playbackRate = rate;[\s\S]*this\.video\.defaultPlaybackRate = rate;/
+  );
+});
+
+test("长按 2 倍速期间不改控制栏文案", () => {
+  assert.match(
+    playerSource,
+    /function handleRateChange\(\)\s*\{[\s\S]*classList\.contains\(FAST_RATE_CLASS\)\) return;[\s\S]*updatePlaybackRateControl\(art\)/
+  );
+});
+
+test("倍速下拉在触摸端靠 data-rate-open 展开，并在失焦/隐藏时收起", () => {
+  assert.match(playerSource, /element\.dataset\.rateOpen = open \? "true" : "false"/);
+  assert.match(playerSource, /art\.on\("blur", closeSelector\)/);
+  assert.match(playerSource, /art\.off\("blur", closeSelector\)/);
+  assert.match(
+    playerSource,
+    /function handleControlChange\(show: boolean\)\s*\{[\s\S]*if \(!show\) closeSelector\(\)/
+  );
+  assert.match(
+    detailCss,
+    /\.art-control-playbackRateToggle\[data-rate-open="true"\][\s\S]*\.art-selector-list\s*\{[^}]*opacity:\s*1[^}]*pointer-events:\s*auto/s
+  );
+  assert.match(
+    detailCss,
+    /@media \(hover: none\) and \(pointer: coarse\)\s*\{[\s\S]*\.art-control-playbackRateToggle:hover \.art-selector-list\s*\{[^}]*opacity:\s*0/s
+  );
+});
+
+test("双击语义由播放器自己实现，关掉 ArtPlayer 内置的两个开关", () => {
+  assert.match(playerSource, /Artplayer\.MOBILE_DBCLICK_PLAY = false/);
+  assert.match(playerSource, /Artplayer\.DBCLICK_FULLSCREEN = false/);
+  // 鼠标设备仍保持双击全屏
+  assert.match(
+    playerSource,
+    /if \(!seekEnabled\) \{[\s\S]*if \(kind === "dblclick"\) art\.fullscreen = !art\.fullscreen;/
+  );
+});
+
+test("双击侧边快进按连击累计，窗口结束只提交一次 seek", () => {
+  assert.match(
+    playerSource,
+    /const unbindDoubleClickActions = bindPlayerDoubleClickActions\(art\)[\s\S]*unbindDoubleClickActions\(\)/s
+  );
+  assert.match(
+    playerSource,
+    /function commitChainSeek\(\)\s*\{[\s\S]*art\.seek = target;/
+  );
+  assert.match(
+    playerSource,
+    /function scheduleChainCommit\(\)\s*\{[\s\S]*DOUBLE_TAP_CHAIN_WINDOW_MS\)/
+  );
+  // 连击未提交时，timeupdate 不能把进度条写回真实播放位置
+  assert.match(
+    playerSource,
+    /function handleTimeUpdate\(\)\s*\{[\s\S]*if \(seekTarget !== null\) renderSeekTarget\(\)/
+  );
+  assert.match(playerSource, /art\.on\("dblclick", handleDoubleClick\)/);
+  assert.match(playerSource, /art\.off\("dblclick", handleDoubleClick\)/);
+  assert.match(playerSource, /art\.on\("click", handleClick\)/);
+  assert.match(playerSource, /art\.off\("click", handleClick\)/);
+});
+
+test("双击快进的反馈是被点一侧的半圆水波纹，随连击刷新、提交时淡出", () => {
+  assert.match(
+    playerSource,
+    /showPlayerSeekRipple\([\s\S]*?action\.side,[\s\S]*?formatDoubleTapSeekLabel\(action\.totalSeconds\),[\s\S]*?event[\s\S]*?\)/
+  );
+  assert.match(
+    playerSource,
+    /function commitChainSeek\(\)\s*\{[\s\S]*?hidePlayerSeekRipple\(art\)/
+  );
+  // 卸载时不放淡出动画，直接清掉
+  assert.match(playerSource, /clearPlayerSeekRipple\(art\);\s*\n\s*art\.off\("click"/);
+  assert.match(
+    detailCss,
+    /\.video-player__art-seek-ripple\s*\{[^}]*z-index:\s*40[^}]*width:\s*52%/s
+  );
+  assert.match(
+    detailCss,
+    /\.video-player__art-seek-ripple--left\s*\{[^}]*left:\s*0[^}]*border-radius/s
+  );
+  assert.match(
+    detailCss,
+    /\.video-player__art-seek-ripple--right\s*\{[^}]*right:\s*0[^}]*border-radius/s
+  );
+  // 水波纹从指尖扩散，左侧箭头靠水平翻转复用同一段路径
+  assert.match(playerSource, /const origin = seekRippleOrigin\(ripple, event\)/);
+  assert.match(
+    detailCss,
+    /\.video-player__art-seek-ripple--left \.video-player__art-seek-ripple-icon\s*\{[^}]*scaleX\(-1\)/s
+  );
+  assert.match(detailCss, /@keyframes video-player-seek-wave/);
+  // 动画敏感用户不播水波纹
+  assert.match(
+    detailCss,
+    /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.video-player__art-seek-ripple-wave[\s\S]*?animation:\s*none/s
+  );
+});
+
+test("窄屏上手势浮层文案不再被压成两行", () => {
+  // 绝对定位元素按 left 收缩：left: 75% 时可用宽度只剩另一半，中文会被折行
+  assert.match(
+    detailCss,
+    /\.video-player__art-gesture-hud\s*\{[^}]*white-space:\s*nowrap/s
+  );
+  assert.match(
+    detailCss,
+    /\.video-player__art-seek-ripple-value\s*\{[^}]*white-space:\s*nowrap/s
+  );
+});
+
+test("锁屏状态下不响应双击快进", () => {
+  assert.match(
+    playerSource,
+    /function handleTap\(kind: TapKind, event: Event\)\s*\{[\s\S]*if \(art\.isLock\) return;/
+  );
+});
+
+test("倍速按钮不用 ArtPlayer 的 hint 提示，避免压住展开的最后一档", () => {
+  const control = playerSource.slice(
+    playerSource.indexOf("function createPlaybackRateControl"),
+    playerSource.indexOf("function getPlaybackRateControl")
+  );
+  assert.doesNotMatch(control, /tooltip:/);
+  assert.match(control, /element\.setAttribute\("title", "播放速度"\)/);
+});


### PR DESCRIPTION
Closes #99

## 中文

### 改动内容

**控制栏倍速按钮**：ArtPlayer 的倍速只有两个入口 —— 桌面端右键菜单，和设置面板里的「播放速度」二级菜单，而右键菜单在移动端根本不会初始化（`if (!isMobile) this.init()`）。手机上换倍速只剩「齿轮 → 播放速度 → 选档位」，控制栏也看不出当前是几倍速。现在控制栏常驻一个倍速按钮：

- 复用 ArtPlayer 控制栏 selector 的原生结构与样式，档位来自 `Artplayer.PLAYBACK_RATE` —— 设置面板和右键菜单读的是同一份，一个播放器不会出现两套倍速。
- 按钮上显示当前倍速；长按 2 倍速是临时状态，期间不改文案，免得用户以为自己选中了 2 倍速。
- 选中的倍速同时写入 `defaultPlaybackRate`：播放失败重连会走 `video.load()`，否则浏览器会把倍速悄悄重置回 1。
- ArtPlayer 的控制栏 selector 只靠 `:hover` 展开，触摸端不可靠，所以展开状态另外用 `data-rate-open` 由点击驱动，两种指针分别生效。
- 这个按钮不用 ArtPlayer 的 hint 提示：它渲染在控件正上方，会压住展开列表的最后一档。

**移动端双击侧边快进 / 快退**：抄的是移动端 YouTube 的机制而不只是那 10 秒 —— 第一次双击开启 700ms 连击窗口，窗口内的后续点击继续在同一侧累加，不必每次重新双击；换边把累计值往回减；中间双击仍是播放 / 暂停。

- ArtPlayer 的双击动作写死在它的点击派发里（先 emit 再执行内置动作，回调里取消不掉），而且它按 UA 判断移动端，和本文件按指针类型判断的口径不一致 —— iPad、带触摸屏的桌面浏览器会「既快进又全屏」。所以关掉 `MOBILE_DBCLICK_PLAY` 和 `DBCLICK_FULLSCREEN`，双击语义统一在一处实现，鼠标设备的双击全屏行为保持不变。
- 一串连点从派发器出来是 `click` / `dblclick` 交替的，两种事件都算一次累加。
- 和键盘左右键一样：连击期间只累计目标时间并预览进度条，窗口结束提交一次真实 seek，一串点击不会把 HLS 缓冲反复冲掉。

**反馈样式**：被点的一侧铺半圆遮罩，水波纹从指尖位置扩散，中间是依次点亮的箭头和累计秒数，层级压在控制栏之下。它替换掉了原来居中的小胶囊 —— 那个胶囊绝对定位 + `left: 75%`，绝对定位元素只能收缩进「`left` 到包含块右边缘」的那 25% 宽度，390px 宽的播放器上「快进 10 秒」会被压成两行。现在文案在半圆内部居中，从结构上不再受这个规则约束；音量 / 亮度浮层补了 `white-space: nowrap` 兜底。

### 取舍

- **连击提交延迟约 700ms**：单次双击的画面跳转会晚于进度条和浮层。这是为了让一串点击只产生一次 seek，与键盘左右键的既有做法一致；要即时跳转的话把提交改成同步即可。
- **桌面端不做侧边快进**：双击全屏是桌面端的既有预期，桌面已经有 ←/→ 15 秒。
- **已知小瑕疵**：连击时 ArtPlayer 自身的「点击切换控制栏」会让控制栏闪一下。

### 测试

分区判定、连击状态机、倍速文案都抽成了 `src/lib/` 下的纯模块，按分支单测；另有一份源码/CSS 契约测试盯住接线（关掉的两个内置开关、`defaultPlaybackRate`、浮层不折行、水波纹左右定位与 reduced-motion）。

`tsc --noEmit` 干净，708 个前端测试全部通过，生产构建正常。另外在浏览器里按 390px 内嵌、竖屏、横屏三种尺寸实测了倍速按钮、下拉列表和水波纹的渲染。

---

## English

### What changed

**A playback-rate control in the control bar**: ArtPlayer exposes speed in two places only — the desktop context menu and a second-level panel behind the settings gear — and the context menu is never initialized on mobile (`if (!isMobile) this.init()`). On a phone, changing speed meant gear → Play Speed → pick, and the bar itself said nothing about the current rate. The bar now carries a rate button:

- It is built from ArtPlayer's own control-bar selector markup, and its rates come from `Artplayer.PLAYBACK_RATE`, which the settings panel and context menu read too — one player can never show two different sets.
- The button shows the current rate. Long-press 2x is a transient state, so the label is left alone while it is active.
- Selecting a rate also writes `defaultPlaybackRate`, because a reconnect calls `video.load()` and would otherwise reset playback to 1x behind the user's back.
- ArtPlayer opens a control selector on `:hover` alone, which touch devices cannot rely on, so the open state also lives in a `data-rate-open` attribute driven by taps, with each pointer type handled separately in CSS.
- The button skips ArtPlayer's hint tooltip: it renders directly above the control and covers the last option of the open list.

**Double-tap side seek on touch devices**: this copies mobile YouTube's mechanism rather than only its ten seconds — the first double tap opens a 700ms chain, further taps inside the window keep accumulating on that side, tapping the other side subtracts, and a double tap in the center still toggles play.

- ArtPlayer's double-click actions run right after the emit and cannot be cancelled from the callback, and it decides "mobile" from the user agent, which disagrees with the pointer-type check used elsewhere in this file — on iPad a double tap would seek and toggle fullscreen at once. `MOBILE_DBCLICK_PLAY` and `DBCLICK_FULLSCREEN` are therefore turned off and the double-click semantics live in one place; mouse devices keep double-click fullscreen.
- A rapid chain leaves the dispatcher as alternating `click` / `dblclick` events, so both count as a step.
- As with the keyboard arrows, a chain accumulates a target and previews it on the progress bar, then commits one real seek when the window closes, so a burst of taps cannot flush the HLS buffer repeatedly.

**The feedback**: a half-circle overlay on the tapped side, a ripple expanding from the fingertip, and staggered chevrons above the accumulated seconds, layered below the control bar. It replaces a centered pill positioned with `left: 75%`: an absolutely positioned box shrink-to-fits into the space between `left` and the containing block edge — a quarter of the width — so the label wrapped to two lines on a 390px-wide player. The label now centers inside the overlay, which removes the constraint instead of working around it, and `white-space: nowrap` guards the volume and brightness HUD against the same trap.

### Trade-offs

- **~700ms commit latency**: a single double tap moves the picture slightly after the progress bar and overlay react. This keeps a burst of taps down to one seek and matches what the keyboard arrows already do; committing synchronously is a one-line change if instant seeking is preferred.
- **No side seek on desktop**: double-click fullscreen is the established desktop expectation, and desktop already has ←/→ 15s.
- **Known nit**: during a chain, ArtPlayer's own click-toggles-controls behaviour flashes the control bar.

### Tests

Zone classification, the chain reducer and rate formatting are pure modules under `src/lib` with per-branch unit tests, plus a source/CSS contract test covering the wiring: the two disabled built-in switches, `defaultPlaybackRate`, the no-wrap fix, and the ripple's side placement and reduced-motion behaviour.

`tsc --noEmit` is clean, all 708 frontend tests pass, and the production build succeeds. The control, its dropdown and the ripple were also verified in a browser at 390px inline, portrait and landscape.
